### PR TITLE
chore: replace minio/mc with amazon/aws-cli in rustfs-init

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,20 +94,17 @@ services:
       - backend  # promotion-only; not Traefik-proxied for subscribers
 
   rustfs-init:
-    image: minio/mc:latest
+    image: amazon/aws-cli:latest
     depends_on:
       rustfs:
         condition: service_healthy
     restart: "no"
     environment:
-      - RUSTFS_ACCESS_KEY=${RUSTFS_ACCESS_KEY}
-      - RUSTFS_SECRET_KEY=${RUSTFS_SECRET_KEY}
+      - AWS_ACCESS_KEY_ID=${RUSTFS_ACCESS_KEY}
+      - AWS_SECRET_ACCESS_KEY=${RUSTFS_SECRET_KEY}
     entrypoint: >
-      /bin/sh -c "
-        mc alias set packyard http://rustfs:9000 $$RUSTFS_ACCESS_KEY $$RUSTFS_SECRET_KEY &&
-        mc mb --ignore-existing packyard/staging &&
-        echo 'Staging bucket ready'
-      "
+      sh -c "aws --endpoint-url http://rustfs:9000 s3 mb s3://staging --region us-east-1 || true &&
+             echo 'Staging bucket ready'"
     networks:
       - backend
 


### PR DESCRIPTION
Closes #4

## Changes

Replaces `minio/mc:latest` with `amazon/aws-cli:latest` in the `rustfs-init` one-shot service.

| Before | After |
|--------|-------|
| `minio/mc:latest` | `amazon/aws-cli:latest` |
| `mc alias set` + `mc mb --ignore-existing` | `aws s3 mb --endpoint-url --region us-east-1` |
| `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` passed directly to mc | Remapped to `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (standard SDK names) |

`|| true` preserves idempotency — exits 0 whether the bucket was created or already existed.

## Test plan

- [ ] `docker compose up -d` — `rustfs-init` exits 0 on a fresh stack
- [ ] `docker compose up -d` — `rustfs-init` exits 0 on a stack where the bucket already exists (idempotency)
- [ ] `stage-artifact.sh` can upload to the staging bucket after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)