### PR TITLE
feat: Add GitHub Actions CI pipeline with HTTP-only Traefik override

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,15 @@ updates:
       - dependencies
       - github-actions
 
-  # Docker base images — auth and rpm Dockerfiles
+  # Docker base images — root docker-compose.yml and service Dockerfiles
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - docker
+
   - package-ecosystem: docker
     directory: /auth
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ jobs:
   test-auth:
     name: Auth unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: auth/go.mod
           cache-dependency-path: auth/go.sum
@@ -24,9 +25,11 @@ jobs:
 
   build-images:
     name: Build Docker images
+    needs: test-auth
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Build auth image
         run: docker build ./auth

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,9 +8,10 @@ jobs:
   integration:
     name: Full stack + observability
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Create .env
         run: |
@@ -26,6 +27,13 @@ jobs:
             -f docker-compose.yml \
             -f docker-compose.override.ci.yml \
             up -d
+
+      - name: Wait for Traefik to be ready
+        run: |
+          echo "Waiting for Traefik..."
+          timeout 30 bash -c \
+            'until curl -s -o /dev/null -w "%{http_code}" http://localhost/gpg/meridian.asc | grep -qE "^(200|404)$"; do sleep 1; done'
+          echo "Traefik is ready."
 
       - name: Wait for auth to be healthy
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,9 @@ services:
   backup:
     image: keinos/sqlite3:latest
     restart: unless-stopped
+    depends_on:
+      auth:
+        condition: service_healthy
     volumes:
       - auth-db:/data/db:ro
       - auth-backup:/backup


### PR DESCRIPTION
## Summary

- Adds GitHub Actions CI and integration test workflows (`.github/workflows/`)
- Introduces HTTP-only Traefik override for CI environments (`docker-compose.override.ci.yml`, `traefik/traefik.ci.yml`, `traefik/dynamic-ci/`)
- Adds Dependabot configuration to keep action SHA pins up to date
- Pins Traefik image to `3.6.12`

## Test plan

- [ ] CI workflow triggers on push/PR to `main`
- [ ] Integration workflow runs compose stack with HTTP-only Traefik override and verifies services come up
- [ ] Dependabot PRs appear for outdated action SHA pins
- [ ] Traefik starts correctly with `traefik.ci.yml` config in a CI environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)