### PR TITLE
fix: Correct RPM component extraction in forwardAuth handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,104 @@ Promotion pipeline (GitHub Actions):
 
 For local development without a public domain, substitute a self-signed cert or use Traefik's local CA.
 
+## Local Development
+
+No public domain or TLS certificate required. The CI override swaps Traefik to plain HTTP and exposes the auth admin API directly on the host.
+
+### 1. Configure
+
+```bash
+git clone https://github.com/opennms/packyard.git
+cd packyard
+```
+
+Create a minimal `.env`:
+
+```bash
+cat > .env <<'EOF'
+ACME_EMAIL=dev@localhost
+RUSTFS_ACCESS_KEY=dev-access-key
+RUSTFS_SECRET_KEY=dev-secret-key-value
+EOF
+```
+
+### 2. Start the stack
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.ci.yml up -d
+```
+
+Wait for services to be ready:
+
+```bash
+# Traefik (routing)
+until curl -sf -o /dev/null http://localhost/gpg/meridian.asc; do sleep 1; done
+echo "Traefik ready"
+
+# Auth service
+until curl -sf http://localhost:8080/health > /dev/null; do sleep 2; done
+echo "Auth ready"
+```
+
+### 3. Create a subscription key
+
+The admin API is exposed directly at `localhost:8080` (not through Traefik):
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/keys \
+  -H 'Content-Type: application/json' \
+  -d '{"component": "core", "label": "dev-key"}' | jq .
+```
+
+```json
+{
+  "id": "abc123...",
+  "component": "core",
+  "label": "dev-key",
+  "active": true,
+  "created_at": "2025-01-01T00:00:00Z"
+}
+```
+
+### 4. Make an authenticated request
+
+Use the key `id` as the HTTP Basic password with username `subscriber`:
+
+```bash
+KEY=abc123...
+
+# GPG key (unauthenticated)
+curl http://localhost/gpg/meridian.asc
+
+# RPM repo metadata (authenticated)
+curl -u subscriber:${KEY} http://localhost/rpm/core/2025/el9-x86_64/repodata/repomd.xml
+
+# Check auth metrics
+curl -s http://localhost:9090/metrics | grep packyard_auth
+```
+
+### 5. Tear down
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.ci.yml down -v
+```
+
+> **Note:** The local stack runs HTTP only — no TLS, no ACME. Port 80 serves public and authenticated routes; the admin API is on `localhost:8080`. Promotion workflows (RPM/DEB/OCI signing) require a running production host with SSH access.
+>
+> **Apple Silicon (arm64):** `aptly` (`urpylka/aptly:1.6.2`) and `zot` (`zot-linux-amd64`) ship x86-only binaries and will crash-loop on arm64 hosts. RPM serving and auth work correctly; DEB and OCI routes will return 502 until arm64-compatible images are substituted.
+
+### Automated verification
+
+A verification script is provided to confirm all core routes work as expected:
+
+```bash
+bash local-testing/verify.sh
+```
+
+This creates a subscription key, exercises authenticated and unauthenticated routes, checks forwardAuth scope enforcement, and verifies Prometheus metrics. Expected output: 12 passed, 0 failed.
+
+---
+
 ## Setup
 
 ### 1. Clone and configure

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/opennms/packyard-auth
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/auth/internal/handler/forward_auth.go
+++ b/auth/internal/handler/forward_auth.go
@@ -87,11 +87,8 @@ func extractComponent(path string) (string, bool) {
 	}
 	switch parts[0] {
 	case "rpm":
-		// /rpm/{os-arch}/{component}/{year}/...
-		if len(parts) < 3 {
-			return "", false
-		}
-		return parts[2], true
+		// /rpm/{component}/{year}/{os-arch}/...
+		return parts[1], true
 	case "deb":
 		// /deb/{component}/{year}/...
 		return parts[1], true

--- a/auth/internal/handler/forward_auth_test.go
+++ b/auth/internal/handler/forward_auth_test.go
@@ -87,7 +87,7 @@ func TestForwardAuth_ValidKey(t *testing.T) {
 	})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("Authorization", basicAuthHeader(validKey))
-	req.Header.Set("X-Forwarded-Uri", "/rpm/el9-x86_64/core/2025/")
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -107,7 +107,7 @@ func TestForwardAuth_ScopeMismatch(t *testing.T) {
 	})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("Authorization", basicAuthHeader(validKey))
-	req.Header.Set("X-Forwarded-Uri", "/rpm/el9-x86_64/core/2025/meridian-core-2025.rpm")
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/meridian-core-2025.rpm")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -127,7 +127,7 @@ func TestForwardAuth_RevokedKey(t *testing.T) {
 	})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("Authorization", basicAuthHeader(validKey))
-	req.Header.Set("X-Forwarded-Uri", "/rpm/el9-x86_64/core/2025/")
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -144,7 +144,7 @@ func TestForwardAuth_NotFound(t *testing.T) {
 	})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("Authorization", basicAuthHeader(validKey))
-	req.Header.Set("X-Forwarded-Uri", "/rpm/el9-x86_64/core/2025/")
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -161,7 +161,7 @@ func TestForwardAuth_MissingAuthHeader(t *testing.T) {
 		},
 	})
 	req := httptest.NewRequest("GET", "/auth", nil)
-	req.Header.Set("X-Forwarded-Uri", "/rpm/el9-x86_64/core/2025/")
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -180,7 +180,7 @@ func TestForwardAuth_WrongKeyLength(t *testing.T) {
 	})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("Authorization", basicAuthHeader(shortKey))
-	req.Header.Set("X-Forwarded-Uri", "/rpm/el9-x86_64/core/2025/")
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -199,7 +199,7 @@ func TestForwardAuth_MalformedAuthHeader(t *testing.T) {
 	})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("Authorization", "Bearer sometoken")
-	req.Header.Set("X-Forwarded-Uri", "/rpm/el9-x86_64/core/2025/")
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -237,7 +237,7 @@ func TestForwardAuth_StoreError(t *testing.T) {
 	})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("Authorization", basicAuthHeader(validKey))
-	req.Header.Set("X-Forwarded-Uri", "/rpm/el9-x86_64/core/2025/")
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 

--- a/local-testing/verify.sh
+++ b/local-testing/verify.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# verify.sh — Walks through the local development instructions from the README
+# and reports pass/fail for each step.
+#
+# Usage:
+#   cd <repo-root>
+#   bash local-testing/verify.sh
+#
+# Prerequisites: Docker Compose v2, curl, jq
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS+1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+info() { echo "       $1"; }
+
+COMPOSE="docker compose -f docker-compose.yml -f docker-compose.override.ci.yml"
+
+echo "=== Packyard local dev verification ==="
+echo ""
+
+# ── Step 1: .env ──────────────────────────────────────────────────────────────
+echo "--- Step 1: .env ---"
+if [ -f .env ]; then
+  pass ".env exists"
+else
+  cat > .env <<'EOF'
+ACME_EMAIL=dev@localhost
+RUSTFS_ACCESS_KEY=dev-access-key
+RUSTFS_SECRET_KEY=dev-secret-key-value
+EOF
+  pass ".env created"
+fi
+
+# ── Step 2: Stack startup ─────────────────────────────────────────────────────
+echo ""
+echo "--- Step 2: Stack startup ---"
+$COMPOSE up -d 2>/dev/null
+pass "docker compose up -d completed"
+
+# ── Step 3: Traefik readiness ─────────────────────────────────────────────────
+echo ""
+echo "--- Step 3: Traefik readiness ---"
+TRIES=0
+while [ $TRIES -lt 30 ]; do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/gpg/meridian.asc)
+  if echo "$STATUS" | grep -qE "^(200|404)$"; then break; fi
+  TRIES=$((TRIES+1)); sleep 1
+done
+if [ $TRIES -lt 30 ]; then
+  pass "Traefik ready (/gpg/meridian.asc probe)"
+else
+  fail "Traefik did not become ready within 30s"
+fi
+
+# ── Step 4: Auth health ───────────────────────────────────────────────────────
+echo ""
+echo "--- Step 4: Auth health ---"
+TRIES=0
+while [ $TRIES -lt 30 ]; do
+  if curl -sf http://localhost:8080/health > /dev/null 2>&1; then break; fi
+  TRIES=$((TRIES+1)); sleep 2
+done
+if [ $TRIES -lt 30 ]; then
+  pass "Auth service healthy"
+else
+  fail "Auth service did not become healthy within 60s"
+  exit 1
+fi
+
+# ── Step 5: GPG unauthenticated ───────────────────────────────────────────────
+echo ""
+echo "--- Step 5: Unauthenticated routes ---"
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/gpg/meridian.asc)
+if [ "$STATUS" = "200" ]; then
+  pass "/gpg/meridian.asc → 200"
+else
+  fail "/gpg/meridian.asc → $STATUS (expected 200)"
+fi
+
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/gpg/cosign.pub)
+if [ "$STATUS" = "200" ]; then
+  pass "/gpg/cosign.pub → 200"
+else
+  fail "/gpg/cosign.pub → $STATUS (expected 200)"
+fi
+
+# ── Step 6: Create subscription key ──────────────────────────────────────────
+echo ""
+echo "--- Step 6: Create subscription key ---"
+RESPONSE=$(curl -s -X POST http://localhost:8080/api/v1/keys \
+  -H 'Content-Type: application/json' \
+  -d '{"component": "core", "label": "verify-test"}')
+KEY=$(echo "$RESPONSE" | jq -r '.id // empty')
+if [ -n "$KEY" ] && [ "$KEY" != "null" ]; then
+  pass "Key created: ${KEY:0:16}..."
+else
+  fail "Key creation failed: $RESPONSE"
+  exit 1
+fi
+
+# ── Step 7: Authenticated routes ──────────────────────────────────────────────
+echo ""
+echo "--- Step 7: Authenticated routes ---"
+
+# RPM — valid key
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "subscriber:${KEY}" \
+  http://localhost/rpm/core/2025/el9-x86_64/)
+if [ "$STATUS" = "200" ]; then
+  pass "/rpm/core/2025/el9-x86_64/ (valid key) → 200"
+else
+  fail "/rpm/core/2025/el9-x86_64/ (valid key) → $STATUS (expected 200)"
+fi
+
+# RPM — bad key (64 x's)
+BAD_KEY=$(printf '%064s' | tr ' ' 'x')
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "subscriber:${BAD_KEY}" \
+  http://localhost/rpm/core/2025/el9-x86_64/)
+if [ "$STATUS" = "401" ]; then
+  pass "/rpm/core/2025/el9-x86_64/ (bad key) → 401"
+else
+  fail "/rpm/core/2025/el9-x86_64/ (bad key) → $STATUS (expected 401)"
+fi
+
+# RPM — wrong component scope
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "subscriber:${KEY}" \
+  http://localhost/rpm/minion/2025/el9-x86_64/)
+if [ "$STATUS" = "401" ]; then
+  pass "/rpm/minion/2025/el9-x86_64/ (core key, minion scope) → 401"
+else
+  fail "/rpm/minion/2025/el9-x86_64/ (scope mismatch) → $STATUS (expected 401)"
+fi
+
+# DEB — valid key (404 expected: aptly has no published content in local dev)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "subscriber:${KEY}" \
+  http://localhost/deb/core/2025/)
+if [ "$STATUS" = "200" ] || [ "$STATUS" = "404" ]; then
+  pass "/deb/core/2025/ (valid key) → $STATUS (auth passed)"
+elif [ "$STATUS" = "401" ]; then
+  fail "/deb/core/2025/ (valid key) → 401 (auth rejected valid key)"
+else
+  info "/deb/core/2025/ → $STATUS"
+fi
+
+# ── Step 8: Metrics ───────────────────────────────────────────────────────────
+echo ""
+echo "--- Step 8: Auth metrics ---"
+METRICS=$(curl -s http://localhost:9090/metrics)
+if echo "$METRICS" | grep -q "packyard_auth_requests_total"; then
+  ALLOWED=$(echo "$METRICS" | grep 'packyard_auth_requests_total{status="allowed"}' | awk '{print $2}')
+  DENIED=$(echo "$METRICS" | grep 'packyard_auth_requests_total{status="denied"}' | awk '{print $2}')
+  pass "packyard_auth_requests_total — allowed=${ALLOWED} denied=${DENIED}"
+else
+  fail "packyard_auth_requests_total not found in metrics"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+# Cleanup key
+curl -s -X DELETE "http://localhost:8080/api/v1/keys/${KEY}" > /dev/null
+info "Test key revoked"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **Bug fix:** `extractComponent` in the forwardAuth handler used the path format `/rpm/{os-arch}/{component}/{year}/...` but the actual nginx directory layout (`init-rpm-tree.sh`) and the e2e subscriber test both use `/rpm/{component}/{year}/{os-arch}/...`. All RPM authenticated requests returned 401 in practice — the handler extracted the year string as the component, which never matched the key's component.
- **Test fix:** Updated unit tests from `/rpm/el9-x86_64/core/2025/` to `/rpm/core/2025/el9-x86_64/` to match the real URL format.
- **Adds** `local-testing/verify.sh` — portable end-to-end smoke test (no GNU `timeout`) covering unauthenticated routes, key creation, forwardAuth allow/deny, scope enforcement, and Prometheus metrics. Confirmed 12/12 passing locally.
- **README** updated with Apple Silicon note (aptly and zot-linux-amd64 are x86-only images) and reference to the verification script.

## How it was found

Running `local-testing/verify.sh` against the live stack revealed the RPM 401 — direct auth logs confirmed `X-Forwarded-Uri` was parsed correctly but component extraction was off by one path segment.

## Test plan

- [ ] `go test ./...` passes in `auth/`
- [ ] `bash local-testing/verify.sh` reports 12 passed, 0 failed
- [ ] CI unit test job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)