### PR TITLE
feat: build and publish custom backup image (#20)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,11 @@ updates:
     labels:
       - dependencies
       - docker
+
+  - package-ecosystem: docker
+    directory: /backup
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - docker

--- a/.github/workflows/build-backup.yml
+++ b/.github/workflows/build-backup.yml
@@ -1,0 +1,60 @@
+name: Build and publish backup image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - backup/**
+      - scripts/backup-keystore.sh
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/${{ github.repository_owner }}/packyard-backup
+
+jobs:
+
+  build-and-push:
+    name: Build multi-arch and push to ghcr.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Extract backup version from Dockerfile
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^ARG BACKUP_VERSION=' backup/Dockerfile | cut -d= -f2 | tr -d '"')
+          echo "backup_version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU (cross-platform builds)
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: backup/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BACKUP_VERSION=${{ steps.version.outputs.backup_version }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.version.outputs.backup_version }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-backup.yml
+++ b/.github/workflows/build-backup.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Extract backup version from Dockerfile
         id: version
         run: |
-          VERSION=$(grep -m1 '^ARG BACKUP_VERSION=' backup/Dockerfile | cut -d= -f2 | tr -d '"')
-          echo "backup_version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          SQLITE_VERSION=$(grep -m1 '^ARG SQLITE_VERSION=' backup/Dockerfile | cut -d= -f2 | tr -d '"')
+          echo "backup_version=${SQLITE_VERSION%-r*}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up QEMU (cross-platform builds)
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
@@ -51,8 +51,6 @@ jobs:
           file: backup/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          build-args: |
-            BACKUP_VERSION=${{ steps.version.outputs.backup_version }}
           tags: |
             ${{ env.IMAGE }}:${{ steps.version.outputs.backup_version }}
             ${{ env.IMAGE }}:latest

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.21
-ARG BACKUP_VERSION=1.0.0
+ARG SQLITE_VERSION=3.48.0-r4
+ARG BACKUP_VERSION=3.48.0
 
-RUN apk add --no-cache sqlite
+RUN apk add --no-cache sqlite=${SQLITE_VERSION}
 
 COPY scripts/backup-keystore.sh /scripts/backup-keystore.sh
 RUN chmod +x /scripts/backup-keystore.sh

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.21
+ARG BACKUP_VERSION=1.0.0
+
+RUN apk add --no-cache sqlite
+
+COPY scripts/backup-keystore.sh /scripts/backup-keystore.sh
+RUN chmod +x /scripts/backup-keystore.sh
+
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.21
 ARG SQLITE_VERSION=3.48.0-r4
-ARG BACKUP_VERSION=3.48.0
 
 RUN apk add --no-cache sqlite=${SQLITE_VERSION}
 

--- a/compose.yml
+++ b/compose.yml
@@ -109,7 +109,7 @@ services:
       - backend
 
   backup:
-    image: keinos/sqlite3:latest
+    image: ghcr.io/no42-org/packyard-backup:1.0.0
     restart: unless-stopped
     depends_on:
       auth:
@@ -117,7 +117,6 @@ services:
     volumes:
       - auth-db:/data/db:ro
       - auth-backup:/backup
-      - ./scripts/backup-keystore.sh:/scripts/backup-keystore.sh:ro
     entrypoint: ["/bin/sh", "-c", "while true; do /scripts/backup-keystore.sh; sleep 86400; done"]
     networks:
       - backend

--- a/compose.yml
+++ b/compose.yml
@@ -109,7 +109,7 @@ services:
       - backend
 
   backup:
-    image: ghcr.io/no42-org/packyard-backup:1.0.0
+    image: ghcr.io/no42-org/packyard-backup:3.48.0
     restart: unless-stopped
     depends_on:
       auth:


### PR DESCRIPTION
## Summary

- Adds `backup/Dockerfile` — Alpine 3.21 base with `sqlite` installed and `scripts/backup-keystore.sh` baked in; replaces the third-party `keinos/sqlite3:latest` image
- Adds `.github/workflows/build-backup.yml` — builds `linux/amd64` + `linux/arm64` via QEMU/Buildx and pushes `ghcr.io/no42-org/packyard-backup:{version}` + `:latest` to ghcr.io on changes to `backup/**` or `scripts/backup-keystore.sh`
- Updates `compose.yml` to reference `ghcr.io/no42-org/packyard-backup:1.0.0` and removes the script bind-mount (now baked into the image)
- Adds `/backup` Dependabot docker entry to keep the Alpine base image pin up to date

## Test plan

- [ ] Workflow `build-backup.yml` triggers on push to `main` with changes to `backup/**`
- [ ] Image pushes successfully to `ghcr.io/no42-org/packyard-backup:1.0.0` and `:latest`
- [ ] `docker compose up backup` runs and executes the backup loop without errors
- [ ] Backup file appears in the `auth-backup` volume with correct timestamp

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)