### PR TITLE
fix(security): replace ssh-keyscan with stored SSH_KNOWN_HOST secret

### DIFF
--- a/.github/workflows/promote-deb.yml
+++ b/.github/workflows/promote-deb.yml
@@ -37,7 +37,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "${{ secrets.HOST }}" >> ~/.ssh/known_hosts
+          echo "${{ secrets.SSH_KNOWN_HOST }}" >> ~/.ssh/known_hosts
 
       - name: Open RustFS tunnel
         run: |

--- a/.github/workflows/promote-oci.yml
+++ b/.github/workflows/promote-oci.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "${{ secrets.HOST }}" >> ~/.ssh/known_hosts
+          echo "${{ secrets.SSH_KNOWN_HOST }}" >> ~/.ssh/known_hosts
 
       - name: Open tunnels (RustFS + Zot)
         run: |

--- a/.github/workflows/promote-rpm.yml
+++ b/.github/workflows/promote-rpm.yml
@@ -37,7 +37,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "${{ secrets.HOST }}" >> ~/.ssh/known_hosts
+          echo "${{ secrets.SSH_KNOWN_HOST }}" >> ~/.ssh/known_hosts
 
       - name: Open RustFS tunnel
         run: |

--- a/README.md
+++ b/README.md
@@ -193,7 +193,36 @@ cp cosign.pub static/content/gpg/cosign.pub
 
 > The private GPG key and `cosign.key` must also be stored as GitHub Actions secrets for the promotion pipeline.
 
-### 3. Start the stack
+### 3. Configure GitHub Actions secrets
+
+The promotion workflows require the following repository secrets (**Settings → Secrets and variables → Actions**):
+
+| Secret | Description |
+|--------|-------------|
+| `SSH_PRIVATE_KEY` | Private key for the `deploy` user on the production host |
+| `SSH_KNOWN_HOST` | Pre-verified host fingerprint — see below |
+| `HOST` | Hostname or IP of the production server |
+| `RUSTFS_ACCESS_KEY` | RustFS S3 access key (same as `.env`) |
+| `RUSTFS_SECRET_KEY` | RustFS S3 secret key (same as `.env`) |
+| `GPG_PRIVATE_KEY` | ASCII-armored GPG private key for RPM/DEB signing |
+| `GPG_KEY_ID` | Key ID or fingerprint (e.g. `ops@example.com`) |
+| `GPG_PASSPHRASE` | Passphrase protecting the GPG private key |
+| `COSIGN_PRIVATE_KEY` | cosign private key (`cosign.key` contents) |
+| `COSIGN_PASSWORD` | Passphrase protecting the cosign private key |
+
+**Obtaining `SSH_KNOWN_HOST`:**
+
+Run the following once from a trusted network connection to your production host:
+
+```bash
+ssh-keyscan -H pkg.example.com
+```
+
+Copy the output line (e.g. `|1|...|... ssh-ed25519 AAAA...`) and store it as the `SSH_KNOWN_HOST` secret. This pre-pins the server's public key so promotion workflows reject any host that presents a different key — preventing MITM attacks during artifact signing.
+
+> Do not use `-H` output from an untrusted network. Verify the fingerprint matches your host's actual key (`ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub` on the server) before adding it as a secret.
+
+### 4. Start the stack
 
 ```bash
 docker compose up -d
@@ -206,7 +235,7 @@ docker compose ps
 
 Traefik will automatically obtain a Let's Encrypt TLS certificate on first start. This requires port 443 to be reachable from the internet.
 
-### 4. Create your first subscription key
+### 5. Create your first subscription key
 
 Use the admin API (available on the loopback admin entrypoint at port 8443, routed via Traefik):
 


### PR DESCRIPTION
Closes #18

## Summary

- Replaces `ssh-keyscan -H "${{ secrets.HOST }}"` with `echo "${{ secrets.SSH_KNOWN_HOST }}"` in all three promotion workflows (`promote-rpm.yml`, `promote-deb.yml`, `promote-oci.yml`)
- Eliminates MITM risk: the trusted fingerprint is stored as a repository secret rather than accepted dynamically on first connection

## Required action before merging

Add a new repository secret `SSH_KNOWN_HOST` populated from a trusted network:

```bash
ssh-keyscan -H <host>
```

Copy the output line (e.g. `|1|...|... ssh-ed25519 AAAA...`) into **Settings → Secrets → Actions → New repository secret** named `SSH_KNOWN_HOST`.

## Test plan

- [ ] Confirm `SSH_KNOWN_HOST` secret is set in repository before enabling workflows
- [ ] Trigger `promote-rpm` or `promote-deb` manually on a test component — SSH connection must succeed without `ssh-keyscan` in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)