### PR TITLE
ci: build and publish auth image on tag push

### DIFF
--- a/.github/workflows/build-auth.yml
+++ b/.github/workflows/build-auth.yml
@@ -1,0 +1,61 @@
+name: Build and publish auth image
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+    branches: [main]
+    paths:
+      - auth/**
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/${{ github.repository_owner }}/packyard-auth
+
+jobs:
+
+  build-and-push:
+    name: Build multi-arch and push to ghcr.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Determine image version from git tag
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "auth_version=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "auth_version=latest" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Set up QEMU (cross-platform builds)
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: ./auth
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.version.outputs.auth_version }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-auth.yml` to build and push a multi-arch (`amd64`/`arm64`) `packyard-auth` image to ghcr.io
- Triggers on `v*.*.*` tag pushes — version is taken from the git tag (`v0.0.1` → `0.0.1`) rather than a Dockerfile ARG
- Also triggers on `main` pushes touching `auth/**` for continuous `latest` rebuilds
- `workflow_dispatch` added so the workflow can be triggered manually after merge to publish `v0.0.1`

## Test plan

- [ ] Merge and trigger manually via Actions → Build and publish auth image → Run workflow
- [ ] Confirm `ghcr.io/no42-org/packyard-auth:0.0.1` and `:latest` appear in the package registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)