### PR TITLE
chore(auth): add version constant, set main to 0.0.2-rc

### DIFF
--- a/auth/cmd/server/main.go
+++ b/auth/cmd/server/main.go
@@ -79,7 +79,7 @@ func main() {
 		}
 	}()
 
-	logger.Info("starting packyard-auth", slog.String("addr", ":8080"), slog.String("db", dbPath))
+	logger.Info("starting packyard-auth", slog.String("version", version), slog.String("addr", ":8080"), slog.String("db", dbPath))
 	if err := http.ListenAndServe(":8080", r); err != nil {
 		logger.Error("server error", slog.String("error", err.Error()))
 		os.Exit(1)

--- a/auth/cmd/server/version.go
+++ b/auth/cmd/server/version.go
@@ -1,0 +1,5 @@
+package main
+
+// version is the current application version. Update this to the next release
+// number suffixed with -rc on main, and drop the suffix when cutting a release tag.
+const version = "0.0.2-rc"


### PR DESCRIPTION
## Summary

- Adds `auth/cmd/server/version.go` with a `version` constant
- Sets it to `0.0.2-rc` to reflect that main is tracking toward the next release
- Logs the version at startup so it's visible in container logs

## Convention

| State | `version` value |
|---|---|
| main (in development) | `0.0.2-rc` |
| release tag `v0.0.2` | `0.0.2` |

When cutting a release: update `version.go` to drop the `-rc` suffix, tag `v0.0.2`, then bump to `0.0.3-rc` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)