### PR TITLE
chore(compose): pin auth and static to published ghcr.io images

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -28,7 +28,7 @@ services:
       - proxy
 
   auth:
-    build: ./auth
+    image: ghcr.io/no42-org/packyard-auth:0.0.2-rc
     restart: unless-stopped
     cap_drop: [ALL]
     security_opt:
@@ -190,7 +190,7 @@ services:
       - backend
 
   static:
-    build: ./static
+    image: ghcr.io/no42-org/packyard-static:0.0.2-rc
     restart: unless-stopped
     user: "101:101"             # run directly as nginx user — no privilege drop, no cap_add needed
     cap_drop: [ALL]


### PR DESCRIPTION
## Summary

Switches `auth` and `static` from `build:` to explicit `image:` references, matching how `aptly` and `backup` are configured.

**Before:**
\`\`\`yaml
auth:
  build: ./auth
static:
  build: ./static
\`\`\`

**After:**
\`\`\`yaml
auth:
  image: ghcr.io/no42-org/packyard-auth:0.0.2-rc
static:
  image: ghcr.io/no42-org/packyard-static:0.0.2-rc
\`\`\`

## Release workflow

| Event | Action |
|---|---|
| Cutting a release | Update both image tags to the release version (e.g. `0.0.2`) |
| Post-release bump | Update both to the next `-rc` (e.g. `0.0.3-rc`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)