### PR TITLE
fix(ci): read version from source file on branch builds

### DIFF
--- a/.github/workflows/build-auth.yml
+++ b/.github/workflows/build-auth.yml
@@ -30,10 +30,11 @@ jobs:
         id: version
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "auth_version=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
+            ver="${GITHUB_REF_NAME#v}"
+            printf 'tags<<EOF\n%s:%s\n%s:latest\nEOF\n' "${IMAGE}" "${ver}" "${IMAGE}" >> "${GITHUB_OUTPUT}"
           else
-            auth_version=$(grep -oP '(?<=const version = ")[^"]+' auth/cmd/server/version.go)
-            echo "auth_version=${auth_version}" >> "${GITHUB_OUTPUT}"
+            ver=$(grep -oP '(?<=const version = ")[^"]+' auth/cmd/server/version.go)
+            printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Set up QEMU (cross-platform builds)
@@ -55,8 +56,6 @@ jobs:
           context: ./auth
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.IMAGE }}:${{ steps.version.outputs.auth_version }}
-            ${{ env.IMAGE }}:latest
+          tags: ${{ steps.version.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-auth.yml
+++ b/.github/workflows/build-auth.yml
@@ -26,13 +26,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Determine image version from git tag
+      - name: Determine image version
         id: version
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "auth_version=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
           else
-            echo "auth_version=latest" >> "${GITHUB_OUTPUT}"
+            auth_version=$(grep -oP '(?<=const version = ")[^"]+' auth/cmd/server/version.go)
+            echo "auth_version=${auth_version}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Set up QEMU (cross-platform builds)

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -30,9 +30,11 @@ jobs:
         id: version
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "rpm_version=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
+            ver="${GITHUB_REF_NAME#v}"
+            printf 'tags<<EOF\n%s:%s\n%s:latest\nEOF\n' "${IMAGE}" "${ver}" "${IMAGE}" >> "${GITHUB_OUTPUT}"
           else
-            echo "rpm_version=$(cat rpm/VERSION)" >> "${GITHUB_OUTPUT}"
+            ver=$(cat rpm/VERSION)
+            printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Set up QEMU (cross-platform builds)
@@ -54,8 +56,6 @@ jobs:
           context: ./rpm
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.IMAGE }}:${{ steps.version.outputs.rpm_version }}
-            ${{ env.IMAGE }}:latest
+          tags: ${{ steps.version.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Determine image version from git tag
+      - name: Determine image version
         id: version
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "rpm_version=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
           else
-            echo "rpm_version=latest" >> "${GITHUB_OUTPUT}"
+            echo "rpm_version=$(cat rpm/VERSION)" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Set up QEMU (cross-platform builds)

--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Determine image version from git tag
+      - name: Determine image version
         id: version
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "static_version=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
           else
-            echo "static_version=latest" >> "${GITHUB_OUTPUT}"
+            echo "static_version=$(cat static/VERSION)" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Set up QEMU (cross-platform builds)

--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -30,9 +30,11 @@ jobs:
         id: version
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "static_version=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
+            ver="${GITHUB_REF_NAME#v}"
+            printf 'tags<<EOF\n%s:%s\n%s:latest\nEOF\n' "${IMAGE}" "${ver}" "${IMAGE}" >> "${GITHUB_OUTPUT}"
           else
-            echo "static_version=$(cat static/VERSION)" >> "${GITHUB_OUTPUT}"
+            ver=$(cat static/VERSION)
+            printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Set up QEMU (cross-platform builds)
@@ -54,8 +56,6 @@ jobs:
           context: ./static
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.IMAGE }}:${{ steps.version.outputs.static_version }}
-            ${{ env.IMAGE }}:latest
+          tags: ${{ steps.version.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- `build-auth`: reads `const version` from `auth/cmd/server/version.go` via grep
- `build-static`: reads `static/VERSION`
- `build-rpm`: reads `rpm/VERSION`

Branch builds now tag images as `:0.0.2-rc` instead of `:latest`.
Tag builds continue to strip the `v` prefix from the git tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)