### PR TITLE
test(local): expand verify.sh to match TEST-PLAN.md and add remote smoke mode

### DIFF
--- a/docs/ops/production-deployment-onms-eu.md
+++ b/docs/ops/production-deployment-onms-eu.md
@@ -1,0 +1,331 @@
+# Production Deployment — pkg.onms.eu
+
+**Target domain:** `onms.eu` | **Primary hostname:** `pkg.onms.eu` | **Last updated:** 2026-04-13
+
+---
+
+## Table of Contents
+
+1. [DNS Records](#1-dns-records)
+2. [VM Requirements](#2-vm-requirements)
+3. [Secrets & Environment](#3-secrets--environment)
+4. [Generating Signing Keys](#4-generating-signing-keys)
+5. [Creating the deploy User](#5-creating-the-deploy-user)
+6. [Pre-Deployment Checklist](#6-pre-deployment-checklist)
+7. [Deployment Steps](#7-deployment-steps)
+8. [Post-Deployment Validation](#8-post-deployment-validation)
+9. [Monitoring](#9-monitoring)
+10. [First Subscriber Onboarding](#10-first-subscriber-onboarding)
+
+---
+
+## 1. DNS Records
+
+All records are on the `onms.eu` zone. Apply these **before** starting the deployment — Traefik's ACME HTTP-01 challenge requires `pkg.onms.eu` to resolve to the VM before it can issue the TLS certificate.
+
+| Type  | Name              | Value                            | TTL   | Notes |
+|-------|-------------------|----------------------------------|-------|-------|
+| A     | `pkg.onms.eu`     | `<VM_IPV4>`                      | 300   | Primary package serving endpoint |
+| AAAA  | `pkg.onms.eu`     | `<VM_IPV6>`                      | 300   | Only if VM has a public IPv6 address |
+| CAA   | `pkg.onms.eu`     | `0 issue "letsencrypt.org"`      | 3600  | Restricts TLS cert issuance to Let's Encrypt |
+| CAA   | `pkg.onms.eu`     | `0 iodef "mailto:ops@onms.eu"`   | 3600  | CAA violation notification address |
+
+> **No other subdomains are needed.** The admin API is loopback-only (`127.0.0.1:8443`), reached via SSH tunnel. RPM, DEB, OCI, and GPG key endpoints all share `pkg.onms.eu`.
+
+### DNS propagation check
+
+```bash
+dig +short pkg.onms.eu A
+dig +short pkg.onms.eu CAA
+```
+
+---
+
+## 2. VM Requirements
+
+| Resource   | Minimum          | Notes |
+|------------|------------------|-------|
+| OS         | Ubuntu 24.04 LTS | Or any Docker-compatible Linux |
+| CPU        | 2 vCPU           | Auth service + nginx are lightweight |
+| RAM        | 4 GB             | Aptly snapshot creation peaks at ~1.5 GB |
+| Disk       | 100 GB           | RPM/DEB/OCI artifact storage; size to expected package volume |
+| Ports open | TCP 22, TCP 443  | 22 for SSH/operator access; 443 for package serving |
+| Docker     | 26+              | With Compose plugin v2 |
+
+**Firewall rules:**
+
+| Source | Protocol/Port | Purpose |
+|--------|---------------|---------|
+| `0.0.0.0/0` | TCP 443 | Package subscribers |
+| `0.0.0.0/0` | TCP 80 | ACME HTTP-01 challenge (initial cert issuance) |
+| operator CIDR | TCP 22 | SSH for admin API access and port-forwards |
+
+> Port 80 is required for the initial ACME challenge. After cert issuance and auto-renewal is confirmed it can stay open — Traefik only serves `.well-known/acme-challenge` on port 80 and redirects all other HTTP traffic to HTTPS.
+
+---
+
+## 3. Secrets & Environment
+
+### `.env` file (on VM, never committed)
+
+```dotenv
+# TLS
+ACME_EMAIL=ops@onms.eu
+DOMAIN=pkg.onms.eu
+
+# RustFS staging storage (generate with: openssl rand -hex 20)
+RUSTFS_ACCESS_KEY=<generate>
+RUSTFS_SECRET_KEY=<generate>
+```
+
+### GitHub Actions secrets
+
+| Secret name           | Value source                                   |
+|-----------------------|------------------------------------------------|
+| `HOST`                | `pkg.onms.eu`                                  |
+| `SSH_PRIVATE_KEY`     | Private key for the `deploy` user on VM        |
+| `SSH_KNOWN_HOST`      | `ssh-keyscan pkg.onms.eu` output               |
+| `RUSTFS_ACCESS_KEY`   | Same as `.env`                                 |
+| `RUSTFS_SECRET_KEY`   | Same as `.env`                                 |
+| `GPG_PRIVATE_KEY`     | ASCII-armored Meridian GPG signing key         |
+| `GPG_KEY_ID`          | Key fingerprint (40 hex chars, no spaces)      |
+| `GPG_PASSPHRASE`      | GPG key passphrase                             |
+| `COSIGN_PRIVATE_KEY`  | Contents of `cosign.key`                       |
+| `COSIGN_PASSWORD`     | cosign key passphrase                          |
+
+---
+
+## 4. Generating Signing Keys
+
+Keys are generated once, kept offline in a secrets manager (e.g. 1Password, Vault), and loaded into GitHub Actions secrets. **Never commit private keys to the repository.**
+
+### 4.1 GPG signing key
+
+Used to sign RPM and DEB packages at promotion time. Use a dedicated key for Meridian — do not reuse an operator's personal key.
+
+```bash
+# 1. Generate the key (batch mode, no TTY required)
+cat > /tmp/meridian-gpg-params <<'EOF'
+%echo Generating Meridian signing key
+Key-Type: RSA
+Key-Length: 4096
+Subkey-Type: RSA
+Subkey-Length: 4096
+Name-Real: OpenNMS Meridian
+Name-Comment: Package Signing Key
+Name-Email: meridian-signing@onms.eu
+Expire-Date: 0
+Passphrase: <CHOOSE_A_STRONG_PASSPHRASE>
+%commit
+%echo Done
+EOF
+
+gpg --batch --gen-key /tmp/meridian-gpg-params
+rm /tmp/meridian-gpg-params
+
+# 2. Find the 40-character fingerprint — this is GPG_KEY_ID
+gpg --list-keys --fingerprint meridian-signing@onms.eu
+GPG_KEY_ID="<40-char fingerprint, no spaces>"
+
+# 3. Export ASCII-armored private key — this is GPG_PRIVATE_KEY
+gpg --armor --export-secret-keys "$GPG_KEY_ID"
+
+# 4. Export public key and commit it to the repo
+gpg --armor --export "$GPG_KEY_ID" > static/content/gpg/meridian.asc
+# git add static/content/gpg/meridian.asc && git commit
+```
+
+**Secrets to set:**
+
+| Secret | Value |
+|--------|-------|
+| `GPG_PRIVATE_KEY` | Output of `gpg --armor --export-secret-keys "$GPG_KEY_ID"` |
+| `GPG_KEY_ID` | 40-character fingerprint (no spaces) |
+| `GPG_PASSPHRASE` | Passphrase chosen during key generation |
+
+### 4.2 cosign key pair
+
+Used to sign OCI container images at promotion time (offline key-based signing, no Sigstore/Rekor).
+
+```bash
+# 1. Generate the key pair (cosign prompts for a password → COSIGN_PASSWORD)
+cosign generate-key-pair
+# cosign.key  — encrypted private key  → COSIGN_PRIVATE_KEY secret
+# cosign.pub  — public key             → committed to repo
+
+# 2. Commit the public key
+cp cosign.pub static/content/gpg/cosign.pub
+# git add static/content/gpg/cosign.pub && git commit
+
+# 3. Copy private key contents into the COSIGN_PRIVATE_KEY secret, then shred local file
+cat cosign.key
+shred -u cosign.key
+```
+
+**Secrets to set:**
+
+| Secret | Value |
+|--------|-------|
+| `COSIGN_PRIVATE_KEY` | Contents of `cosign.key` |
+| `COSIGN_PASSWORD` | Password entered during `cosign generate-key-pair` |
+
+### 4.3 Key storage checklist
+
+- [ ] GPG private key exported and stored in secrets manager
+- [ ] GPG key ID (fingerprint) noted
+- [ ] GPG passphrase stored in secrets manager
+- [ ] cosign private key stored in secrets manager, local copy shredded
+- [ ] cosign password stored in secrets manager
+- [ ] `static/content/gpg/meridian.asc` committed to repository
+- [ ] `static/content/gpg/cosign.pub` committed to repository
+- [ ] All 10 secrets set in GitHub Actions repository settings
+
+---
+
+## 5. Creating the `deploy` User
+
+Run on the VM as `root` or via `sudo`.
+
+```bash
+# Create user with login shell (required for git clone and docker compose)
+useradd --create-home --shell /bin/bash deploy
+usermod -aG docker deploy
+```
+
+Generate an SSH key pair on your **local machine**:
+
+```bash
+ssh-keygen -t ed25519 -C "packyard-deploy" -f ~/.ssh/packyard_deploy
+# ~/.ssh/packyard_deploy      — private key (keep secret)
+# ~/.ssh/packyard_deploy.pub  — public key  (goes on the VM)
+```
+
+Authorize the public key on the VM:
+
+```bash
+# On the VM as root
+mkdir -p /home/deploy/.ssh
+chmod 700 /home/deploy/.ssh
+echo "<paste ~/.ssh/packyard_deploy.pub>" >> /home/deploy/.ssh/authorized_keys
+chmod 600 /home/deploy/.ssh/authorized_keys
+chown -R deploy:deploy /home/deploy/.ssh
+```
+
+Verify access, then capture secrets:
+
+```bash
+# Test login
+ssh -i ~/.ssh/packyard_deploy deploy@pkg.onms.eu
+
+# SSH_PRIVATE_KEY secret value
+cat ~/.ssh/packyard_deploy
+
+# SSH_KNOWN_HOST secret value (run after DNS propagates)
+ssh-keyscan pkg.onms.eu
+```
+
+---
+
+## 6. Pre-Deployment Checklist
+
+- [ ] DNS A record for `pkg.onms.eu` propagated (`dig` confirms VM IP)
+- [ ] DNS CAA record for `pkg.onms.eu` present
+- [ ] VM firewall: `tcp/443` and `tcp/80` open to internet
+- [ ] Docker + Compose plugin v2 installed on VM
+- [ ] `deploy` user created, added to `docker` group, SSH key authorized (§5)
+- [ ] GPG Meridian signing key generated (§4.1); `meridian.asc` committed to `static/content/gpg/`
+- [ ] cosign key pair generated (§4.2); `cosign.pub` committed to `static/content/gpg/`
+- [ ] `.env` file written on VM with production values (§3)
+- [ ] All 10 GitHub Actions secrets set in repository settings (§3)
+
+---
+
+## 7. Deployment Steps
+
+```bash
+# On the VM as the deploy user
+git clone <packyard-repo> ~/packyard
+cd ~/packyard
+
+# Write .env (see §3)
+# Ensure static/content/gpg/meridian.asc and cosign.pub are present
+
+docker compose pull
+docker compose up -d
+
+# Watch for Traefik to obtain the Let's Encrypt certificate (up to 2 min)
+docker compose logs traefik -f
+```
+
+Expected cert issuance log line:
+
+```
+traefik  | msg="Certificate obtained successfully" domain=pkg.onms.eu
+```
+
+---
+
+## 8. Post-Deployment Validation
+
+Run these from an **external host**, not the VM itself.
+
+```bash
+# 1. GPG key endpoint — tests TLS + routing (unauthenticated)
+curl -sI https://pkg.onms.eu/gpg/meridian.asc
+# Expect: HTTP/2 200, Content-Type: text/plain
+
+# 2. Package endpoint rejects unauthenticated requests
+curl -sI https://pkg.onms.eu/rpm/core/2025/el9-x86_64/repodata/repomd.xml
+# Expect: HTTP/2 401
+
+# 3. Valid key is accepted
+curl -sI -u subscriber:<KEY> https://pkg.onms.eu/rpm/core/2025/el9-x86_64/repodata/repomd.xml
+# Expect: HTTP/2 200 (after first promotion) or 404 if no artifacts yet
+
+# 4. Wrong-component key is rejected
+curl -sI -u subscriber:<CORE_KEY> https://pkg.onms.eu/rpm/minion/2025/el9-x86_64/repodata/repomd.xml
+# Expect: HTTP/2 401
+
+# 5. Admin API reachable only via SSH tunnel
+ssh -L 8443:127.0.0.1:8443 deploy@pkg.onms.eu -N &
+curl -sk https://127.0.0.1:8443/api/v1/keys
+# Expect: JSON array (empty if no keys created yet)
+```
+
+---
+
+## 9. Monitoring
+
+| Check | Method | SLA |
+|-------|--------|-----|
+| Endpoint availability | HTTP GET `https://pkg.onms.eu/gpg/meridian.asc` from external monitor | 99.9% monthly |
+| TLS cert expiry | Alert at ≤ 30 days remaining | — |
+| Auth service health | Traefik health check (auto; returns 503 on failure) | Fail-closed |
+
+Prometheus metrics are available at `http://auth:9090/metrics` (internal Docker network only). Expose to an internal monitoring stack via SSH tunnel or a separate Traefik route on the admin entrypoint.
+
+---
+
+## 10. First Subscriber Onboarding
+
+```bash
+# Open SSH tunnel to admin API
+ssh -L 8443:127.0.0.1:8443 deploy@pkg.onms.eu -N &
+
+# Create an API key for a subscriber
+curl -sk -X POST https://127.0.0.1:8443/api/v1/keys \
+  -H 'Content-Type: application/json' \
+  -d '{"component": "core", "label": "Acme Corp — Core"}'
+# Response contains the key value — share only this with the subscriber
+```
+
+Example subscriber `yum.repos.d` entry:
+
+```ini
+[onms-meridian-core]
+name=OpenNMS Meridian Core
+baseurl=https://subscriber:<KEY>@pkg.onms.eu/rpm/core/2025/el9-x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkg.onms.eu/gpg/meridian.asc
+```

--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -1,6 +1,6 @@
-# Production Deployment — pkg.onms.eu
+# Production Deployment — pkg.example.org
 
-**Target domain:** `onms.eu` | **Primary hostname:** `pkg.onms.eu` | **Last updated:** 2026-04-13
+**Target domain:** `example.org` | **Primary hostname:** `pkg.example.org` | **Last updated:** 2026-04-13
 
 ---
 
@@ -21,22 +21,22 @@
 
 ## 1. DNS Records
 
-All records are on the `onms.eu` zone. Apply these **before** starting the deployment — Traefik's ACME HTTP-01 challenge requires `pkg.onms.eu` to resolve to the VM before it can issue the TLS certificate.
+All records are on the `example.org` zone. Apply these **before** starting the deployment — Traefik's ACME HTTP-01 challenge requires `pkg.example.org` to resolve to the VM before it can issue the TLS certificate.
 
 | Type  | Name              | Value                            | TTL   | Notes |
 |-------|-------------------|----------------------------------|-------|-------|
-| A     | `pkg.onms.eu`     | `<VM_IPV4>`                      | 300   | Primary package serving endpoint |
-| AAAA  | `pkg.onms.eu`     | `<VM_IPV6>`                      | 300   | Only if VM has a public IPv6 address |
-| CAA   | `pkg.onms.eu`     | `0 issue "letsencrypt.org"`      | 3600  | Restricts TLS cert issuance to Let's Encrypt |
-| CAA   | `pkg.onms.eu`     | `0 iodef "mailto:ops@onms.eu"`   | 3600  | CAA violation notification address |
+| A     | `pkg.example.org`     | `<VM_IPV4>`                      | 300   | Primary package serving endpoint |
+| AAAA  | `pkg.example.org`     | `<VM_IPV6>`                      | 300   | Only if VM has a public IPv6 address |
+| CAA   | `pkg.example.org`     | `0 issue "letsencrypt.org"`      | 3600  | Restricts TLS cert issuance to Let's Encrypt |
+| CAA   | `pkg.example.org`     | `0 iodef "mailto:ops@example.org"`   | 3600  | CAA violation notification address |
 
-> **No other subdomains are needed.** The admin API is loopback-only (`127.0.0.1:8443`), reached via SSH tunnel. RPM, DEB, OCI, and GPG key endpoints all share `pkg.onms.eu`.
+> **No other subdomains are needed.** The admin API is loopback-only (`127.0.0.1:8443`), reached via SSH tunnel. RPM, DEB, OCI, and GPG key endpoints all share `pkg.example.org`.
 
 ### DNS propagation check
 
 ```bash
-dig +short pkg.onms.eu A
-dig +short pkg.onms.eu CAA
+dig +short pkg.example.org A
+dig +short pkg.example.org CAA
 ```
 
 ---
@@ -70,8 +70,8 @@ dig +short pkg.onms.eu CAA
 
 ```dotenv
 # TLS
-ACME_EMAIL=ops@onms.eu
-DOMAIN=pkg.onms.eu
+ACME_EMAIL=ops@example.org
+DOMAIN=pkg.example.org
 
 # RustFS staging storage (generate with: openssl rand -hex 20)
 RUSTFS_ACCESS_KEY=<generate>
@@ -82,9 +82,9 @@ RUSTFS_SECRET_KEY=<generate>
 
 | Secret name           | Value source                                   |
 |-----------------------|------------------------------------------------|
-| `HOST`                | `pkg.onms.eu`                                  |
+| `HOST`                | `pkg.example.org`                                  |
 | `SSH_PRIVATE_KEY`     | Private key for the `deploy` user on VM        |
-| `SSH_KNOWN_HOST`      | `ssh-keyscan pkg.onms.eu` output               |
+| `SSH_KNOWN_HOST`      | `ssh-keyscan pkg.example.org` output               |
 | `RUSTFS_ACCESS_KEY`   | Same as `.env`                                 |
 | `RUSTFS_SECRET_KEY`   | Same as `.env`                                 |
 | `GPG_PRIVATE_KEY`     | ASCII-armored Meridian GPG signing key         |
@@ -113,7 +113,7 @@ Subkey-Type: RSA
 Subkey-Length: 4096
 Name-Real: OpenNMS Meridian
 Name-Comment: Package Signing Key
-Name-Email: meridian-signing@onms.eu
+Name-Email: meridian-signing@example.org
 Expire-Date: 0
 Passphrase: <CHOOSE_A_STRONG_PASSPHRASE>
 %commit
@@ -124,7 +124,7 @@ gpg --batch --gen-key /tmp/meridian-gpg-params
 rm /tmp/meridian-gpg-params
 
 # 2. Find the 40-character fingerprint — this is GPG_KEY_ID
-gpg --list-keys --fingerprint meridian-signing@onms.eu
+gpg --list-keys --fingerprint meridian-signing@example.org
 GPG_KEY_ID="<40-char fingerprint, no spaces>"
 
 # 3. Export ASCII-armored private key — this is GPG_PRIVATE_KEY
@@ -215,21 +215,21 @@ Verify access, then capture secrets:
 
 ```bash
 # Test login
-ssh -i ~/.ssh/packyard_deploy deploy@pkg.onms.eu
+ssh -i ~/.ssh/packyard_deploy deploy@pkg.example.org
 
 # SSH_PRIVATE_KEY secret value
 cat ~/.ssh/packyard_deploy
 
 # SSH_KNOWN_HOST secret value (run after DNS propagates)
-ssh-keyscan pkg.onms.eu
+ssh-keyscan pkg.example.org
 ```
 
 ---
 
 ## 6. Pre-Deployment Checklist
 
-- [ ] DNS A record for `pkg.onms.eu` propagated (`dig` confirms VM IP)
-- [ ] DNS CAA record for `pkg.onms.eu` present
+- [ ] DNS A record for `pkg.example.org` propagated (`dig` confirms VM IP)
+- [ ] DNS CAA record for `pkg.example.org` present
 - [ ] VM firewall: `tcp/443` and `tcp/80` open to internet
 - [ ] Docker + Compose plugin v2 installed on VM
 - [ ] `deploy` user created, added to `docker` group, SSH key authorized (§5)
@@ -260,7 +260,7 @@ docker compose logs traefik -f
 Expected cert issuance log line:
 
 ```
-traefik  | msg="Certificate obtained successfully" domain=pkg.onms.eu
+traefik  | msg="Certificate obtained successfully" domain=pkg.example.org
 ```
 
 ---
@@ -271,23 +271,23 @@ Run these from an **external host**, not the VM itself.
 
 ```bash
 # 1. GPG key endpoint — tests TLS + routing (unauthenticated)
-curl -sI https://pkg.onms.eu/gpg/meridian.asc
+curl -sI https://pkg.example.org/gpg/meridian.asc
 # Expect: HTTP/2 200, Content-Type: text/plain
 
 # 2. Package endpoint rejects unauthenticated requests
-curl -sI https://pkg.onms.eu/rpm/core/2025/el9-x86_64/repodata/repomd.xml
+curl -sI https://pkg.example.org/rpm/core/2025/el9-x86_64/repodata/repomd.xml
 # Expect: HTTP/2 401
 
 # 3. Valid key is accepted
-curl -sI -u subscriber:<KEY> https://pkg.onms.eu/rpm/core/2025/el9-x86_64/repodata/repomd.xml
+curl -sI -u subscriber:<KEY> https://pkg.example.org/rpm/core/2025/el9-x86_64/repodata/repomd.xml
 # Expect: HTTP/2 200 (after first promotion) or 404 if no artifacts yet
 
 # 4. Wrong-component key is rejected
-curl -sI -u subscriber:<CORE_KEY> https://pkg.onms.eu/rpm/minion/2025/el9-x86_64/repodata/repomd.xml
+curl -sI -u subscriber:<CORE_KEY> https://pkg.example.org/rpm/minion/2025/el9-x86_64/repodata/repomd.xml
 # Expect: HTTP/2 401
 
 # 5. Admin API reachable only via SSH tunnel
-ssh -L 8443:127.0.0.1:8443 deploy@pkg.onms.eu -N &
+ssh -L 8443:127.0.0.1:8443 deploy@pkg.example.org -N &
 curl -sk https://127.0.0.1:8443/api/v1/keys
 # Expect: JSON array (empty if no keys created yet)
 ```
@@ -298,7 +298,7 @@ curl -sk https://127.0.0.1:8443/api/v1/keys
 
 | Check | Method | SLA |
 |-------|--------|-----|
-| Endpoint availability | HTTP GET `https://pkg.onms.eu/gpg/meridian.asc` from external monitor | 99.9% monthly |
+| Endpoint availability | HTTP GET `https://pkg.example.org/gpg/meridian.asc` from external monitor | 99.9% monthly |
 | TLS cert expiry | Alert at ≤ 30 days remaining | — |
 | Auth service health | Traefik health check (auto; returns 503 on failure) | Fail-closed |
 
@@ -310,7 +310,7 @@ Prometheus metrics are available at `http://auth:9090/metrics` (internal Docker 
 
 ```bash
 # Open SSH tunnel to admin API
-ssh -L 8443:127.0.0.1:8443 deploy@pkg.onms.eu -N &
+ssh -L 8443:127.0.0.1:8443 deploy@pkg.example.org -N &
 
 # Create an API key for a subscriber
 curl -sk -X POST https://127.0.0.1:8443/api/v1/keys \
@@ -324,8 +324,8 @@ Example subscriber `yum.repos.d` entry:
 ```ini
 [onms-meridian-core]
 name=OpenNMS Meridian Core
-baseurl=https://subscriber:<KEY>@pkg.onms.eu/rpm/core/2025/el9-x86_64/
+baseurl=https://subscriber:<KEY>@pkg.example.org/rpm/core/2025/el9-x86_64/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkg.onms.eu/gpg/meridian.asc
+gpgkey=https://pkg.example.org/gpg/meridian.asc
 ```

--- a/local-testing/verify.sh
+++ b/local-testing/verify.sh
@@ -1,170 +1,524 @@
 #!/usr/bin/env bash
-# verify.sh — Walks through the local development instructions from the README
-# and reports pass/fail for each step.
+# verify.sh — Smoke-tests a running Packyard stack.
 #
 # Usage:
-#   cd <repo-root>
-#   bash local-testing/verify.sh
+#   Local (full suite, starts stack):
+#     bash local-testing/verify.sh
 #
-# Prerequisites: Docker Compose v2, curl, jq
+#   Local (stack already running):
+#     bash local-testing/verify.sh --skip-stack
+#
+#   Remote smoke (read-only, no admin API):
+#     bash local-testing/verify.sh \
+#       --base-url https://pkg.example.org \
+#       --test-key "$KEY" \
+#       --test-component core
+#
+# Prerequisites: Docker Compose v2 (local only), curl, jq
 
-set -euo pipefail
+set -uo pipefail
 
+# ── Defaults ──────────────────────────────────────────────────────────────────
+BASE_URL="http://localhost"
+ADMIN_URL="http://localhost:8080"
+METRICS_URL="http://localhost:9090"
+SKIP_STACK=false
+TEST_KEY=""
+TEST_COMPONENT="core"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url)       BASE_URL="$2";       shift 2 ;;
+    --admin-url)      ADMIN_URL="$2";      shift 2 ;;
+    --metrics-url)    METRICS_URL="$2";    shift 2 ;;
+    --skip-stack)     SKIP_STACK=true;     shift ;;
+    --test-key)       TEST_KEY="$2";       shift 2 ;;
+    --test-component) TEST_COMPONENT="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Mode inference ────────────────────────────────────────────────────────────
+if [[ "$BASE_URL" == "http://localhost"* ]]; then
+  MODE="local"
+else
+  MODE="remote"
+  SKIP_STACK=true
+fi
+
+if [[ "$MODE" == "remote" && -z "$TEST_KEY" ]]; then
+  echo "error: --test-key is required for remote mode" >&2
+  exit 1
+fi
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
 PASS=0
 FAIL=0
+CORE_KEY=""
+MINION_KEY=""
 
-pass() { echo "[PASS] $1"; PASS=$((PASS+1)); }
-fail() { echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
-info() { echo "       $1"; }
+pass()    { echo "[PASS] $1"; PASS=$((PASS+1)); }
+fail()    { echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+info()    { echo "       $1"; }
+section() { echo ""; echo "--- $1 ---"; }
+
+# Poll URL until status matches ok_pattern or max_tries is exceeded.
+wait_for() {
+  local url="$1" ok_pattern="$2" max_tries="$3" interval="$4"
+  local tries=0 s
+  while [[ $tries -lt $max_tries ]]; do
+    s=$(curl -s -o /dev/null -w "%{http_code}" "$url" || true)
+    [[ "$s" =~ $ok_pattern ]] && return 0
+    tries=$((tries+1)); sleep "$interval"
+  done
+  return 1
+}
+
+# ── Cross-component for scope mismatch tests ──────────────────────────────────
+case "$TEST_COMPONENT" in
+  core)   CROSS_COMPONENT="minion" ;;
+  minion) CROSS_COMPONENT="core" ;;
+  *)      CROSS_COMPONENT="core" ;;
+esac
 
 COMPOSE="docker compose -f compose.yml -f compose.override.ci.yml"
 
-echo "=== Packyard local dev verification ==="
-echo ""
+echo "=== Packyard verification [mode: $MODE] ==="
+echo "    base:    $BASE_URL"
+if [[ "$MODE" == "local" ]]; then
+  echo "    admin:   $ADMIN_URL"
+  echo "    metrics: $METRICS_URL"
+fi
 
-# ── Step 1: .env ──────────────────────────────────────────────────────────────
-echo "--- Step 1: .env ---"
-if [ -f .env ]; then
-  pass ".env exists"
-else
-  cat > .env <<'EOF'
+# ─────────────────────────────────────────────────────────────────────────────
+# Prerequisites
+# ─────────────────────────────────────────────────────────────────────────────
+section "Prerequisites"
+for cmd in curl jq; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "error: $cmd is required" >&2; exit 1
+  fi
+done
+if [[ "$MODE" == "local" ]] && ! docker compose version &>/dev/null 2>&1; then
+  echo "error: Docker Compose v2 is required" >&2; exit 1
+fi
+pass "prerequisites satisfied"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# .env  (local only)
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "local" ]]; then
+  section ".env"
+  if [[ -f .env ]]; then
+    pass ".env exists"
+  else
+    cat > .env <<'EOF'
 ACME_EMAIL=dev@localhost
 RUSTFS_ACCESS_KEY=dev-access-key
 RUSTFS_SECRET_KEY=dev-secret-key-value
 EOF
-  pass ".env created"
+    pass ".env created"
+  fi
 fi
 
-# ── Step 2: Stack startup ─────────────────────────────────────────────────────
-echo ""
-echo "--- Step 2: Stack startup ---"
-$COMPOSE up -d 2>/dev/null
-pass "docker compose up -d completed"
+# ─────────────────────────────────────────────────────────────────────────────
+# Stack startup  (local only, skippable)
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "local" && "$SKIP_STACK" == false ]]; then
+  section "Stack startup"
+  $COMPOSE up -d 2>/dev/null
+  pass "docker compose up -d completed"
+fi
 
-# ── Step 3: Traefik readiness ─────────────────────────────────────────────────
-echo ""
-echo "--- Step 3: Traefik readiness ---"
-TRIES=0
-while [ $TRIES -lt 30 ]; do
-  STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/gpg/meridian.asc)
-  if echo "$STATUS" | grep -qE "^(200|404)$"; then break; fi
-  TRIES=$((TRIES+1)); sleep 1
-done
-if [ $TRIES -lt 30 ]; then
-  pass "Traefik ready (/gpg/meridian.asc probe)"
+# ─────────────────────────────────────────────────────────────────────────────
+# Traefik readiness  (local only)
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "local" ]]; then
+  section "Traefik readiness"
+  if wait_for "$BASE_URL/gpg/meridian.asc" "^(200|404)$" 30 1; then
+    pass "Traefik ready (/gpg/meridian.asc probe)"
+  else
+    fail "Traefik did not become ready within 30s"
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Auth health  (local only)
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "local" ]]; then
+  section "Auth health"
+  if wait_for "$ADMIN_URL/health" "^200$" 30 2; then
+    pass "Auth service healthy"
+  else
+    fail "Auth service did not become healthy within 60s"
+    echo "Cannot continue: auth service unreachable" >&2
+    exit 1
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Key setup
+#   Local:  create core + minion keys via admin API
+#   Remote: use the caller-supplied --test-key
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "local" ]]; then
+  section "Key creation (admin API)"
+
+  RESPONSE=$(curl -s -X POST "$ADMIN_URL/api/v1/keys" \
+    -H 'Content-Type: application/json' \
+    -d '{"component": "core", "label": "verify-core"}' || true)
+  CORE_KEY=$(echo "$RESPONSE" | jq -r '.id // empty')
+  if [[ -n "$CORE_KEY" ]]; then
+    pass "core key created: ${CORE_KEY:0:16}..."
+  else
+    fail "core key creation failed: $RESPONSE"
+    echo "Cannot continue: key creation failed" >&2
+    exit 1
+  fi
+
+  RESPONSE=$(curl -s -X POST "$ADMIN_URL/api/v1/keys" \
+    -H 'Content-Type: application/json' \
+    -d '{"component": "minion", "label": "verify-minion"}' || true)
+  MINION_KEY=$(echo "$RESPONSE" | jq -r '.id // empty')
+  if [[ -n "$MINION_KEY" ]]; then
+    pass "minion key created: ${MINION_KEY:0:16}..."
+  else
+    fail "minion key creation failed: $RESPONSE"
+    MINION_KEY=""
+  fi
+
+  TEST_KEY="$CORE_KEY"
+  TEST_COMPONENT="core"
+  CROSS_COMPONENT="minion"
 else
-  fail "Traefik did not become ready within 30s"
+  CORE_KEY="$TEST_KEY"
 fi
 
-# ── Step 4: Auth health ───────────────────────────────────────────────────────
-echo ""
-echo "--- Step 4: Auth health ---"
-TRIES=0
-while [ $TRIES -lt 30 ]; do
-  if curl -sf http://localhost:8080/health > /dev/null 2>&1; then break; fi
-  TRIES=$((TRIES+1)); sleep 2
-done
-if [ $TRIES -lt 30 ]; then
-  pass "Auth service healthy"
+# ─────────────────────────────────────────────────────────────────────────────
+# Unauthenticated routes  (shared)
+# ─────────────────────────────────────────────────────────────────────────────
+section "Unauthenticated routes"
+
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/gpg/meridian.asc" || true)
+[[ "$STATUS" == "200" ]] \
+  && pass "/gpg/meridian.asc → 200" \
+  || fail "/gpg/meridian.asc → $STATUS (expected 200)"
+
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/gpg/cosign.pub" || true)
+[[ "$STATUS" == "200" ]] \
+  && pass "/gpg/cosign.pub → 200" \
+  || fail "/gpg/cosign.pub → $STATUS (expected 200)"
+
+# Negative: authenticated route without credentials → 401
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  "$BASE_URL/rpm/$TEST_COMPONENT/2025/el9-x86_64/" || true)
+[[ "$STATUS" == "401" ]] \
+  && pass "/rpm/$TEST_COMPONENT/ (no creds) → 401" \
+  || fail "/rpm/$TEST_COMPONENT/ (no creds) → $STATUS (expected 401)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ForwardAuth allow / deny  (shared)
+# ─────────────────────────────────────────────────────────────────────────────
+section "ForwardAuth allow/deny"
+
+# Short password — fast-reject, no DB lookup
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "subscriber:tooshort" "$BASE_URL/rpm/$TEST_COMPONENT/2025/el9-x86_64/" || true)
+[[ "$STATUS" == "401" ]] \
+  && pass "Short password fast-reject → 401" \
+  || fail "Short password fast-reject → $STATUS (expected 401)"
+
+# Bad key (64 x's)
+BAD_KEY=$(printf '%064s' "" | tr ' ' 'x')
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "subscriber:${BAD_KEY}" "$BASE_URL/rpm/$TEST_COMPONENT/2025/el9-x86_64/" || true)
+[[ "$STATUS" == "401" ]] \
+  && pass "Bad key (64 x's) → 401" \
+  || fail "Bad key (64 x's) → $STATUS (expected 401)"
+
+# Valid key — RPM
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "subscriber:${TEST_KEY}" "$BASE_URL/rpm/$TEST_COMPONENT/2025/el9-x86_64/" || true)
+[[ "$STATUS" == "200" ]] \
+  && pass "/rpm/$TEST_COMPONENT/ (valid key) → 200" \
+  || fail "/rpm/$TEST_COMPONENT/ (valid key) → $STATUS (expected 200)"
+
+# Valid key — DEB (404 expected if no packages published)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "subscriber:${TEST_KEY}" "$BASE_URL/deb/$TEST_COMPONENT/2025/" || true)
+if [[ "$STATUS" == "200" || "$STATUS" == "404" ]]; then
+  pass "/deb/$TEST_COMPONENT/ (valid key) → $STATUS (auth passed)"
+elif [[ "$STATUS" == "401" ]]; then
+  fail "/deb/$TEST_COMPONENT/ (valid key) → 401 (auth rejected valid key)"
 else
-  fail "Auth service did not become healthy within 60s"
-  exit 1
+  info "/deb/$TEST_COMPONENT/ → $STATUS"
 fi
 
-# ── Step 5: GPG unauthenticated ───────────────────────────────────────────────
-echo ""
-echo "--- Step 5: Unauthenticated routes ---"
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/gpg/meridian.asc)
-if [ "$STATUS" = "200" ]; then
-  pass "/gpg/meridian.asc → 200"
+# ─────────────────────────────────────────────────────────────────────────────
+# Scope enforcement  (shared)
+# ─────────────────────────────────────────────────────────────────────────────
+section "Scope enforcement"
+
+# TEST_KEY on cross-component path → 401
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "subscriber:${TEST_KEY}" "$BASE_URL/rpm/$CROSS_COMPONENT/2025/el9-x86_64/" || true)
+[[ "$STATUS" == "401" ]] \
+  && pass "/rpm/$CROSS_COMPONENT/ ($TEST_COMPONENT key, wrong scope) → 401" \
+  || fail "/rpm/$CROSS_COMPONENT/ ($TEST_COMPONENT key, wrong scope) → $STATUS (expected 401)"
+
+# Full matrix — local only, requires both CORE_KEY and MINION_KEY
+if [[ "$MODE" == "local" && -n "$MINION_KEY" ]]; then
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -u "subscriber:${CORE_KEY}" "$BASE_URL/rpm/sentinel/2025/el9-x86_64/" || true)
+  [[ "$STATUS" == "401" ]] \
+    && pass "/rpm/sentinel/ (core key) → 401" \
+    || fail "/rpm/sentinel/ (core key) → $STATUS (expected 401)"
+
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -u "subscriber:${MINION_KEY}" "$BASE_URL/rpm/core/2025/el9-x86_64/" || true)
+  [[ "$STATUS" == "401" ]] \
+    && pass "/rpm/core/ (minion key, wrong scope) → 401" \
+    || fail "/rpm/core/ (minion key, wrong scope) → $STATUS (expected 401)"
+
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -u "subscriber:${MINION_KEY}" "$BASE_URL/rpm/minion/2025/el9-x86_64/" || true)
+  [[ "$STATUS" == "200" ]] \
+    && pass "/rpm/minion/ (minion key, own scope) → 200" \
+    || fail "/rpm/minion/ (minion key, own scope) → $STATUS (expected 200)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OCI scope  (shared)
+# ─────────────────────────────────────────────────────────────────────────────
+section "OCI scope"
+
+# Valid: own meridian-COMPONENT repo
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "subscriber:${TEST_KEY}" "$BASE_URL/oci/v2/meridian-$TEST_COMPONENT/tags/list" || true)
+if [[ "$STATUS" == "200" || "$STATUS" == "404" ]]; then
+  pass "/oci/v2/meridian-$TEST_COMPONENT/ (valid scope) → $STATUS (auth passed)"
+elif [[ "$STATUS" == "401" ]]; then
+  fail "/oci/v2/meridian-$TEST_COMPONENT/ (valid scope) → 401 (auth rejected valid key)"
 else
-  fail "/gpg/meridian.asc → $STATUS (expected 200)"
+  info "/oci/v2/meridian-$TEST_COMPONENT/ → $STATUS"
 fi
 
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/gpg/cosign.pub)
-if [ "$STATUS" = "200" ]; then
-  pass "/gpg/cosign.pub → 200"
-else
-  fail "/gpg/cosign.pub → $STATUS (expected 200)"
+# Wrong scope: cross-component OCI repo → 401
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "subscriber:${TEST_KEY}" "$BASE_URL/oci/v2/meridian-$CROSS_COMPONENT/tags/list" || true)
+[[ "$STATUS" == "401" ]] \
+  && pass "/oci/v2/meridian-$CROSS_COMPONENT/ ($TEST_COMPONENT key, wrong scope) → 401" \
+  || fail "/oci/v2/meridian-$CROSS_COMPONENT/ ($TEST_COMPONENT key, wrong scope) → $STATUS (expected 401)"
+
+# Unrecognised OCI path format → 401
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "subscriber:${TEST_KEY}" "$BASE_URL/oci/v2/someother-repo/tags/list" || true)
+[[ "$STATUS" == "401" ]] \
+  && pass "/oci/v2/someother-repo/ (no meridian- prefix) → 401" \
+  || fail "/oci/v2/someother-repo/ (no meridian- prefix) → $STATUS (expected 401)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Local-only tests
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "local" ]]; then
+
+  ZERO_KEY=$(printf '%064s' "" | tr ' ' '0')
+
+  # ── Key lifecycle ────────────────────────────────────────────────────────
+  section "Key lifecycle (admin API)"
+
+  # List all keys — expect at least 2
+  COUNT=$(curl -s "$ADMIN_URL/api/v1/keys" | jq 'length' || echo 0)
+  (( COUNT >= 2 )) \
+    && pass "Key list → $COUNT keys (≥2 expected)" \
+    || fail "Key list → $COUNT keys (expected ≥2)"
+
+  # Filter by component — all results must match
+  MISMATCHES=$(curl -s "$ADMIN_URL/api/v1/keys?component=core" \
+    | jq '[.[] | select(.component != "core")] | length' || echo 1)
+  [[ "$MISMATCHES" == "0" ]] \
+    && pass "Key filter ?component=core → all results are core" \
+    || fail "Key filter ?component=core → $MISMATCHES non-core result(s) returned"
+
+  # Invalid component filter → 400
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    "$ADMIN_URL/api/v1/keys?component=invalid" || true)
+  [[ "$STATUS" == "400" ]] \
+    && pass "Key filter ?component=invalid → 400" \
+    || fail "Key filter ?component=invalid → $STATUS (expected 400)"
+
+  # Non-existent key GET → 404
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    "$ADMIN_URL/api/v1/keys/${ZERO_KEY}" || true)
+  [[ "$STATUS" == "404" ]] \
+    && pass "Non-existent key GET → 404" \
+    || fail "Non-existent key GET → $STATUS (expected 404)"
+
+  # Invalid component on create → 400
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "$ADMIN_URL/api/v1/keys" \
+    -H 'Content-Type: application/json' \
+    -d '{"component": "unknown", "label": "bad"}' || true)
+  [[ "$STATUS" == "400" ]] \
+    && pass "Create key with invalid component → 400" \
+    || fail "Create key with invalid component → $STATUS (expected 400)"
+
+  # Expired key → 401 at auth time
+  RESPONSE=$(curl -s -X POST "$ADMIN_URL/api/v1/keys" \
+    -H 'Content-Type: application/json' \
+    -d '{"component": "core", "label": "verify-expired", "expires_at": "2020-01-01T00:00:00Z"}' || true)
+  EXPIRED_KEY=$(echo "$RESPONSE" | jq -r '.id // empty')
+  if [[ -n "$EXPIRED_KEY" && "$EXPIRED_KEY" != "null" ]]; then
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+      -u "subscriber:${EXPIRED_KEY}" "$BASE_URL/rpm/core/2025/el9-x86_64/" || true)
+    [[ "$STATUS" == "401" ]] \
+      && pass "Expired key → 401 (auth rejected)" \
+      || fail "Expired key → $STATUS (expected 401)"
+    curl -s -X DELETE "$ADMIN_URL/api/v1/keys/${EXPIRED_KEY}" > /dev/null || true
+  else
+    fail "Could not create expired key for test: $RESPONSE"
+  fi
+
+  # ── Key revocation ───────────────────────────────────────────────────────
+  section "Key revocation"
+
+  # Confirm works before revocation
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -u "subscriber:${CORE_KEY}" "$BASE_URL/rpm/core/2025/el9-x86_64/" || true)
+  [[ "$STATUS" == "200" ]] \
+    && pass "Pre-revocation: core key → 200" \
+    || fail "Pre-revocation: core key → $STATUS (expected 200)"
+
+  # Revoke
+  STATUS=$(curl -s -X DELETE "$ADMIN_URL/api/v1/keys/${CORE_KEY}" \
+    -o /dev/null -w "%{http_code}" || true)
+  [[ "$STATUS" == "204" ]] \
+    && pass "Revoke core key → 204" \
+    || fail "Revoke core key → $STATUS (expected 204)"
+
+  # Immediately denied
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -u "subscriber:${CORE_KEY}" "$BASE_URL/rpm/core/2025/el9-x86_64/" || true)
+  [[ "$STATUS" == "401" ]] \
+    && pass "Post-revocation: core key → 401" \
+    || fail "Post-revocation: core key → $STATUS (expected 401)"
+
+  # Idempotent — revoke again → still 204
+  STATUS=$(curl -s -X DELETE "$ADMIN_URL/api/v1/keys/${CORE_KEY}" \
+    -o /dev/null -w "%{http_code}" || true)
+  [[ "$STATUS" == "204" ]] \
+    && pass "Revoke already-revoked key → 204 (idempotent)" \
+    || fail "Revoke already-revoked key → $STATUS (expected 204)"
+
+  # Non-existent key → 404
+  STATUS=$(curl -s -X DELETE "$ADMIN_URL/api/v1/keys/${ZERO_KEY}" \
+    -o /dev/null -w "%{http_code}" || true)
+  [[ "$STATUS" == "404" ]] \
+    && pass "Revoke non-existent key → 404" \
+    || fail "Revoke non-existent key → $STATUS (expected 404)"
+
+  # Inspect revoked key — active=false
+  ACTIVE=$(curl -s "$ADMIN_URL/api/v1/keys/${CORE_KEY}" \
+    | jq -r '.active // "error"' || echo "error")
+  [[ "$ACTIVE" == "false" ]] \
+    && pass "Revoked key inspect → active=false" \
+    || fail "Revoked key inspect → active=$ACTIVE (expected false)"
+
+  # ── Metrics ──────────────────────────────────────────────────────────────
+  section "Metrics"
+
+  METRICS=$(curl -s "$METRICS_URL/metrics" || true)
+  if echo "$METRICS" | grep -q "packyard_auth_requests_total"; then
+    ALLOWED=$(echo "$METRICS" | grep 'packyard_auth_requests_total{status="allowed"}' | awk '{print $2}' || true)
+    DENIED=$(echo  "$METRICS" | grep 'packyard_auth_requests_total{status="denied"}'  | awk '{print $2}' || true)
+    pass "packyard_auth_requests_total present — allowed=${ALLOWED:-?} denied=${DENIED:-?}"
+  else
+    fail "packyard_auth_requests_total not found in metrics"
+    ALLOWED=""
+  fi
+
+  # Counter increment: snapshot before/after one allowed request
+  if [[ -n "${ALLOWED:-}" && -n "$MINION_KEY" ]]; then
+    BEFORE="$ALLOWED"
+    curl -s -u "subscriber:${MINION_KEY}" \
+      -o /dev/null "$BASE_URL/rpm/minion/2025/el9-x86_64/" || true
+    AFTER=$(curl -s "$METRICS_URL/metrics" \
+      | grep 'packyard_auth_requests_total{status="allowed"}' | awk '{print $2}' || true)
+    if [[ -n "${AFTER:-}" ]] && awk "BEGIN { exit !($AFTER > $BEFORE) }"; then
+      pass "Metric counter incremented: allowed $BEFORE → $AFTER"
+    else
+      fail "Metric counter did not increment: allowed $BEFORE → ${AFTER:-?}"
+    fi
+  else
+    info "Metric increment check skipped (no minion key or counter unavailable)"
+  fi
+
+  # ── Log redaction ────────────────────────────────────────────────────────
+  section "Log redaction"
+
+  if [[ -n "$MINION_KEY" ]]; then
+    curl -s -u "subscriber:${MINION_KEY}" \
+      "$BASE_URL/rpm/minion/2025/el9-x86_64/" > /dev/null || true
+  fi
+
+  LOGS=$($COMPOSE logs --no-log-prefix auth 2>/dev/null | tail -40 || true)
+
+  if [[ -n "$MINION_KEY" ]] && echo "$LOGS" | grep -qF "$MINION_KEY"; then
+    fail "Log redaction: key value found in auth container logs"
+  else
+    pass "Log redaction: key value absent from auth container logs"
+  fi
+
+  # ── Backup integrity ─────────────────────────────────────────────────────
+  section "Backup integrity"
+
+  if $COMPOSE exec -T backup /scripts/backup-keystore.sh > /dev/null 2>&1; then
+    pass "Backup script executed"
+  else
+    fail "Backup script failed or backup container not running"
+  fi
+
+  LATEST=$($COMPOSE exec -T backup ls -t /backup/ 2>/dev/null \
+    | head -1 | tr -d '\r' || true)
+  if [[ -n "$LATEST" ]]; then
+    pass "Backup file found: $LATEST"
+
+    INTEGRITY=$($COMPOSE exec -T backup \
+      sqlite3 "/backup/${LATEST}" "PRAGMA integrity_check;" 2>/dev/null || true)
+    [[ "$INTEGRITY" == "ok" ]] \
+      && pass "Backup integrity check: ok" \
+      || fail "Backup integrity check: ${INTEGRITY:-failed}"
+
+    ROW_COUNT=$($COMPOSE exec -T backup \
+      sqlite3 "/backup/${LATEST}" \
+      "SELECT count(*) FROM subscription_key;" 2>/dev/null || echo "0")
+    (( ROW_COUNT >= 1 )) \
+      && pass "Backup contains $ROW_COUNT subscription key(s)" \
+      || fail "Backup row count unexpected: $ROW_COUNT"
+  else
+    fail "No backup file found in /backup/"
+  fi
+
+fi  # end local-only
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cleanup  (local only)
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "local" ]]; then
+  echo ""
+  echo "--- Cleanup ---"
+  [[ -n "$MINION_KEY" ]] && \
+    curl -s -X DELETE "$ADMIN_URL/api/v1/keys/${MINION_KEY}" > /dev/null || true
+  info "Test keys revoked"
 fi
 
-# ── Step 6: Create subscription key ──────────────────────────────────────────
-echo ""
-echo "--- Step 6: Create subscription key ---"
-RESPONSE=$(curl -s -X POST http://localhost:8080/api/v1/keys \
-  -H 'Content-Type: application/json' \
-  -d '{"component": "core", "label": "verify-test"}')
-KEY=$(echo "$RESPONSE" | jq -r '.id // empty')
-if [ -n "$KEY" ] && [ "$KEY" != "null" ]; then
-  pass "Key created: ${KEY:0:16}..."
-else
-  fail "Key creation failed: $RESPONSE"
-  exit 1
-fi
-
-# ── Step 7: Authenticated routes ──────────────────────────────────────────────
-echo ""
-echo "--- Step 7: Authenticated routes ---"
-
-# RPM — valid key
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "subscriber:${KEY}" \
-  http://localhost/rpm/core/2025/el9-x86_64/)
-if [ "$STATUS" = "200" ]; then
-  pass "/rpm/core/2025/el9-x86_64/ (valid key) → 200"
-else
-  fail "/rpm/core/2025/el9-x86_64/ (valid key) → $STATUS (expected 200)"
-fi
-
-# RPM — bad key (64 x's)
-BAD_KEY=$(printf '%064s' | tr ' ' 'x')
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "subscriber:${BAD_KEY}" \
-  http://localhost/rpm/core/2025/el9-x86_64/)
-if [ "$STATUS" = "401" ]; then
-  pass "/rpm/core/2025/el9-x86_64/ (bad key) → 401"
-else
-  fail "/rpm/core/2025/el9-x86_64/ (bad key) → $STATUS (expected 401)"
-fi
-
-# RPM — wrong component scope
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "subscriber:${KEY}" \
-  http://localhost/rpm/minion/2025/el9-x86_64/)
-if [ "$STATUS" = "401" ]; then
-  pass "/rpm/minion/2025/el9-x86_64/ (core key, minion scope) → 401"
-else
-  fail "/rpm/minion/2025/el9-x86_64/ (scope mismatch) → $STATUS (expected 401)"
-fi
-
-# DEB — valid key (404 expected: aptly has no published content in local dev)
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u "subscriber:${KEY}" \
-  http://localhost/deb/core/2025/)
-if [ "$STATUS" = "200" ] || [ "$STATUS" = "404" ]; then
-  pass "/deb/core/2025/ (valid key) → $STATUS (auth passed)"
-elif [ "$STATUS" = "401" ]; then
-  fail "/deb/core/2025/ (valid key) → 401 (auth rejected valid key)"
-else
-  info "/deb/core/2025/ → $STATUS"
-fi
-
-# ── Step 8: Metrics ───────────────────────────────────────────────────────────
-echo ""
-echo "--- Step 8: Auth metrics ---"
-METRICS=$(curl -s http://localhost:9090/metrics)
-if echo "$METRICS" | grep -q "packyard_auth_requests_total"; then
-  ALLOWED=$(echo "$METRICS" | grep 'packyard_auth_requests_total{status="allowed"}' | awk '{print $2}')
-  DENIED=$(echo "$METRICS" | grep 'packyard_auth_requests_total{status="denied"}' | awk '{print $2}')
-  pass "packyard_auth_requests_total — allowed=${ALLOWED} denied=${DENIED}"
-else
-  fail "packyard_auth_requests_total not found in metrics"
-fi
-
-# ── Summary ───────────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
 
-# Cleanup key
-curl -s -X DELETE "http://localhost:8080/api/v1/keys/${KEY}" > /dev/null
-info "Test key revoked"
-
-if [ "$FAIL" -gt 0 ]; then
+if [[ "$FAIL" -gt 0 ]]; then
   exit 1
 fi


### PR DESCRIPTION
Closes #38

## Changes

**CLI interface**
- `--base-url`, `--admin-url`, `--metrics-url`, `--skip-stack`, `--test-key`, `--test-component`
- Mode inferred from `--base-url`: localhost → local (full suite), anything else → remote (read-only subscriber smoke)

**Remote smoke mode** — bring your own key, no admin API, no Docker:
```bash
bash local-testing/verify.sh \
  --base-url https://pkg.onms.eu \
  --test-key "$KEY" \
  --test-component core
```

**New checks (shared — local + remote)**
- RPM without credentials → 401
- Short password fast-reject → 401
- OCI scope: valid scope, wrong scope, unrecognised prefix

**New checks (local only)**
- Key listing and component filtering
- Invalid component filter → 400
- Non-existent key GET → 404
- Invalid component on create → 400
- Expired key → 401 at auth time
- Full scope matrix: core/minion/sentinel cross-checks
- Revocation: idempotent DELETE → 204, non-existent → 404, inspect shows `active=false`
- Metric counter increment (snapshot before/after)
- Log redaction (key value absent from container logs)
- Backup integrity (`PRAGMA integrity_check` + row count)

**Structural fix**
- `set -euo pipefail` → `set -uo pipefail` — test failures accumulate instead of aborting the run. Hard exits retained only for missing prerequisites and failed key creation (subsequent tests depend on it).

## Test count
Local: ~30 checks. Remote smoke: ~9 checks.