### PR TITLE
docs(scaffold): add MkDocs + Material + mike scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ _bmad-output/
 .claude/
 .agents/
 
+# MkDocs build output
+site/
+
 # Local secrets — never commit
 .env
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ _bmad-output/
 .claude/
 .agents/
 
-# MkDocs build output
 site/
 
 # Local secrets — never commit

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: docs-install docs-serve docs-build docs-clean
+
+docs-install:
+	pip install -r docs/requirements.txt
+
+docs-serve:
+	mkdocs serve
+
+docs-build:
+	mkdocs build --strict
+
+docs-clean:
+	rm -rf site/

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -1,0 +1,6 @@
+# Local Development
+
+!!! note
+    Content coming in Phase 3 — content migration.
+
+<!-- Source: README §Local Development (full walkthrough + verify.sh) -->

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -1,6 +1,6 @@
 # Local Development
 
 !!! note
-    Content coming in Phase 3 — content migration.
+    Documentation in progress.
 
 <!-- Source: README §Local Development (full walkthrough + verify.sh) -->

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,6 @@
+# Quick Start
+
+!!! note
+    Content coming in Phase 3 — content migration.
+
+<!-- Source: README §Local Development (condensed) -->

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,6 +1,6 @@
 # Quick Start
 
 !!! note
-    Content coming in Phase 3 — content migration.
+    Documentation in progress.
 
 <!-- Source: README §Local Development (condensed) -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+# Packyard
+
+Packyard is a self-hosted, authenticated package distribution service for Meridian. It serves RPM, DEB, and OCI artefacts with per-component API key scoping, Prometheus metrics, and automated keystore backups.
+
+## What's in this documentation
+
+| Section | Content |
+|---------|---------|
+| [Getting Started](getting-started/quick-start.md) | Stand up the stack locally and run your first request |
+| [Operations](ops/production-deployment.md) | Deploy and operate Packyard in production |
+| [Reference](reference/architecture.md) | Architecture, API, configuration, and subscriber integration |
+
+## Source code
+
+[github.com/no42-org/packyard](https://github.com/no42-org/packyard)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,6 @@
+# Admin API
+
+!!! note
+    Content coming in Phase 3 — content migration.
+
+<!-- Source: README §Key Management (expanded into full API reference) -->

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,6 +1,6 @@
 # Admin API
 
 !!! note
-    Content coming in Phase 3 — content migration.
+    Documentation in progress.
 
 <!-- Source: README §Key Management (expanded into full API reference) -->

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
 !!! note
-    Content coming in Phase 3 — content migration.
+    Documentation in progress.
 
 <!-- Source: README §Architecture (diagram + services table) + §Repository Layout -->

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,0 +1,6 @@
+# Architecture
+
+!!! note
+    Content coming in Phase 3 — content migration.
+
+<!-- Source: README §Architecture (diagram + services table) + §Repository Layout -->

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,6 @@
+# Configuration
+
+!!! note
+    Content coming in Phase 3 — content migration.
+
+<!-- Source: README §Prerequisites + .env variable reference -->

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
 !!! note
-    Content coming in Phase 3 — content migration.
+    Documentation in progress.
 
 <!-- Source: README §Prerequisites + .env variable reference -->

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -1,6 +1,6 @@
 # Observability
 
 !!! note
-    Content coming in Phase 3 — content migration.
+    Documentation in progress.
 
 <!-- Source: README §Observability -->

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -1,0 +1,6 @@
+# Observability
+
+!!! note
+    Content coming in Phase 3 — content migration.
+
+<!-- Source: README §Observability -->

--- a/docs/reference/promotion-pipeline.md
+++ b/docs/reference/promotion-pipeline.md
@@ -1,0 +1,6 @@
+# Promotion Pipeline
+
+!!! note
+    Content coming in Phase 3 — content migration.
+
+<!-- Source: README §Promotion Pipeline -->

--- a/docs/reference/promotion-pipeline.md
+++ b/docs/reference/promotion-pipeline.md
@@ -1,6 +1,6 @@
 # Promotion Pipeline
 
 !!! note
-    Content coming in Phase 3 — content migration.
+    Documentation in progress.
 
 <!-- Source: README §Promotion Pipeline -->

--- a/docs/reference/subscriber-usage.md
+++ b/docs/reference/subscriber-usage.md
@@ -1,0 +1,6 @@
+# Subscriber Usage
+
+!!! note
+    Content coming in Phase 3 — content migration.
+
+<!-- Source: README §Subscriber Usage (RPM/DEB/OCI) + §Public Keys -->

--- a/docs/reference/subscriber-usage.md
+++ b/docs/reference/subscriber-usage.md
@@ -1,6 +1,6 @@
 # Subscriber Usage
 
 !!! note
-    Content coming in Phase 3 — content migration.
+    Documentation in progress.
 
 <!-- Source: README §Subscriber Usage (RPM/DEB/OCI) + §Public Keys -->

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material==9.7.6
+mike==2.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+mkdocs==1.6.1
 mkdocs-material==9.7.6
 mike==2.2.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,63 @@
+site_name: Packyard
+site_description: Self-hosted authenticated package distribution for Meridian
+site_url: https://no42-org.github.io/packyard/
+repo_name: no42-org/packyard
+repo_url: https://github.com/no42-org/packyard
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - content.action.edit
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+extra:
+  version:
+    provider: mike
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Quick Start: getting-started/quick-start.md
+    - Local Development: getting-started/local-development.md
+  - Operations:
+    - Production Deployment: ops/production-deployment.md
+    - Restore Keystore: ops/restore-keystore.md
+  - Reference:
+    - Architecture: reference/architecture.md
+    - Subscriber Usage: reference/subscriber-usage.md
+    - Admin API: reference/api.md
+    - Promotion Pipeline: reference/promotion-pipeline.md
+    - Observability: reference/observability.md
+    - Configuration: reference/configuration.md
+
+plugins:
+  - search
+  - mike:
+      version_selector: true
+      canonical_version: latest
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true


### PR DESCRIPTION
## Summary

- Adds `mkdocs.yml` with Material theme, mike versioning plugin, and full nav structure
- Adds `docs/requirements.txt` pinned to `mkdocs-material==9.7.6` and `mike==2.2.0`
- Adds `docs/index.md` site homepage
- Adds stub pages for all nav entries under `getting-started/` and `reference/`
- Adds `site/` to `.gitignore` (mkdocs build output)

`mkdocs build --strict` passes locally. No content has moved yet — stubs carry `!!! note` placeholders pointing to Phase 3.

Part of [MkDocs Documentation Migration](https://github.com/orgs/no42-org/projects/2) — Phase 1.

Closes #40

## Test plan

- [ ] `mkdocs build --strict` passes (CI)
- [ ] `mkdocs serve` renders all nav entries without errors
- [ ] No existing content has moved

🤖 Generated with [Claude Code](https://claude.ai/claude-code)