### PR TITLE
ci: add docs build and release publish pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,3 +53,12 @@ updates:
     labels:
       - dependencies
       - docker
+
+  # Python — MkDocs docs dependencies
+  - package-ecosystem: pip
+    directory: /docs
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+    tags-ignore:
+      - '**'
   pull_request:
 
 jobs:
@@ -22,6 +24,22 @@ jobs:
       - name: Run tests
         working-directory: auth
         run: go test ./...
+
+  build-docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - run: pip install -r docs/requirements.txt
+      - run: mkdocs build --strict
 
   build-images:
     name: Build Docker images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
           cache: pip
           cache-dependency-path: docs/requirements.txt
 
-      - run: pip install -r docs/requirements.txt
-      - run: mkdocs build --strict
+      - run: make docs-install
+      - run: make docs-build
 
   build-images:
     name: Build Docker images

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
           cache: pip
           cache-dependency-path: docs/requirements.txt
 
-      - run: pip install -r docs/requirements.txt
+      - run: make docs-install
 
       - run: git config user.name "github-actions[bot]"
       - run: git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: docs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - run: pip install -r docs/requirements.txt
+
+      - run: git config user.name "github-actions[bot]"
+      - run: git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - run: mike deploy --push --update-aliases ${{ github.event.release.tag_name }} latest


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docs.yml` — fires on `release: published`, runs `mike deploy --push --update-aliases $tag latest` to publish versioned docs to `gh-pages`
- Adds `build-docs` job to `ci.yml` — runs `mkdocs build --strict` on every PR and push to main
- Adds `tags-ignore: ['**']` to `ci.yml` push trigger — prevents race condition when a tag push triggers both `ci.yml` and `docs.yml`
- Adds pip ecosystem to `dependabot.yml` — keeps `docs/requirements.txt` pins up to date

Part of [MkDocs Documentation Migration](https://github.com/orgs/no42-org/projects/2) — Phase 2b.

Closes #42

## Test plan

- [ ] `build-docs` job passes in CI on this PR
- [ ] `docs.yml` workflow syntax is valid (checked by GitHub Actions on push)
- [ ] `tags-ignore` present on `ci.yml` push trigger

🤖 Generated with [Claude Code](https://claude.ai/claude-code)