### PR TITLE
build: use venv in Makefile for isolated Python deps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,4 +26,4 @@ jobs:
       - run: git config user.name "github-actions[bot]"
       - run: git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - run: mike deploy --push --update-aliases ${{ github.event.release.tag_name }} latest
+      - run: .venv/bin/mike deploy --push --update-aliases ${{ github.event.release.tag_name }} latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _bmad-output/
 .agents/
 
 site/
+.venv/
 
 # Local secrets — never commit
 .env

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
+VENV := .venv
+
 .PHONY: docs-install docs-serve docs-build docs-clean
 
 docs-install:
-	pip install -r docs/requirements.txt
+	python3 -m venv $(VENV)
+	$(VENV)/bin/pip install --quiet -r docs/requirements.txt
 
 docs-serve:
-	mkdocs serve
+	$(VENV)/bin/mkdocs serve
 
 docs-build:
-	mkdocs build --strict
+	$(VENV)/bin/mkdocs build --strict
 
 docs-clean:
-	rm -rf site/
+	rm -rf site/ $(VENV)


### PR DESCRIPTION
## Summary

- `make docs-install` now creates `.venv/` via `python3 -m venv` before installing deps — fixes `mike: command not found` on macOS where Homebrew's PEP 668 managed Python blocks bare `pip install` and doesn't shim binaries like `mike` to PATH
- `make docs-serve` and `make docs-build` use `.venv/bin/mkdocs`
- `docs.yml` uses `.venv/bin/mike` for the release deploy step (venv is created by the preceding `make docs-install` step)
- `.venv/` added to `.gitignore`

## Test plan

- [ ] `make docs-install` creates `.venv/` and installs deps
- [ ] `make docs-build` passes using `.venv/bin/mkdocs`
- [ ] `.venv/bin/mike --version` works after `make docs-install`
- [ ] `build-docs` CI job passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)