### PR TITLE
ci(docs): add venv bin to PATH before mike deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,8 +22,9 @@ jobs:
           cache-dependency-path: docs/requirements.txt
 
       - run: make docs-install
+      - run: echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
       - run: git config user.name "github-actions[bot]"
       - run: git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - run: .venv/bin/mike deploy --push --update-aliases ${{ github.event.release.tag_name }} latest
+      - run: mike deploy --push --update-aliases ${{ github.event.release.tag_name }} latest


### PR DESCRIPTION
## Problem

`mike deploy` fails in CI with `No such file or directory: 'mkdocs'` because mike spawns `mkdocs` as a subprocess using the system PATH. After `make docs-install`, `mkdocs` exists in `.venv/bin/` but is not on PATH.

## Fix

Add `.venv/bin` to `$GITHUB_PATH` immediately after `make docs-install`. This makes both `mike` and `mkdocs` available by name for all subsequent steps.

Also simplifies the mike deploy call from `.venv/bin/mike deploy` → `mike deploy` since mike is now on PATH.

## Test plan

- [ ] Re-run `v0.0.2` release workflow after merge to confirm `mike deploy` succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)