### PR TITLE
fix: correct PKG_DOMAIN variable name and ACME challenge type

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ACME/TLS — required for production certificate issuance
 ACME_EMAIL=ops@example.org
-DOMAIN=pkg.example.org
+PKG_DOMAIN=pkg.example.org
 
 # RustFS S3 credentials — used by GHA promotion pipeline (Story 4.1)
 RUSTFS_ACCESS_KEY=change-me-access-key

--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -56,11 +56,10 @@ dig +short pkg.example.org CAA
 
 | Source | Protocol/Port | Purpose |
 |--------|---------------|---------|
-| `0.0.0.0/0` | TCP 443 | Package subscribers |
-| `0.0.0.0/0` | TCP 80 | ACME HTTP-01 challenge (initial cert issuance) |
+| `0.0.0.0/0` | TCP 443 | Package subscribers + TLS-ALPN-01 cert issuance |
 | operator CIDR | TCP 22 | SSH for admin API access and port-forwards |
 
-> Port 80 is required for the initial ACME challenge. After cert issuance and auto-renewal is confirmed it can stay open — Traefik only serves `.well-known/acme-challenge` on port 80 and redirects all other HTTP traffic to HTTPS.
+> Traefik uses the **TLS-ALPN-01** challenge for Let's Encrypt — port 443 is the only port required. Port 80 does not need to be open.
 
 ---
 
@@ -71,7 +70,7 @@ dig +short pkg.example.org CAA
 ```dotenv
 # TLS
 ACME_EMAIL=ops@example.org
-DOMAIN=pkg.example.org
+PKG_DOMAIN=pkg.example.org
 
 # RustFS staging storage (generate with: openssl rand -hex 20)
 RUSTFS_ACCESS_KEY=<generate>
@@ -230,7 +229,7 @@ ssh-keyscan pkg.example.org
 
 - [ ] DNS A record for `pkg.example.org` propagated (`dig` confirms VM IP)
 - [ ] DNS CAA record for `pkg.example.org` present
-- [ ] VM firewall: `tcp/443` and `tcp/80` open to internet
+- [ ] VM firewall: `tcp/443` open to internet
 - [ ] Docker + Compose plugin v2 installed on VM
 - [ ] `deploy` user created, added to `docker` group, SSH key authorized (§5)
 - [ ] GPG LTS signing key generated (§4.1); `lts.asc` committed to `static/content/gpg/`

--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -21,7 +21,7 @@
 
 ## 1. DNS Records
 
-All records are on the `example.org` zone. Apply these **before** starting the deployment — Traefik's ACME HTTP-01 challenge requires `pkg.example.org` to resolve to the VM before it can issue the TLS certificate.
+All records are on the `example.org` zone. Apply these **before** starting the deployment — Traefik's ACME TLS-ALPN-01 challenge requires `pkg.example.org` to resolve to the VM before it can issue the TLS certificate.
 
 | Type  | Name              | Value                            | TTL   | Notes |
 |-------|-------------------|----------------------------------|-------|-------|

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -17,7 +17,7 @@ Packyard is configured via a `.env` file at the repository root. This file is ne
 ```dotenv
 # TLS
 ACME_EMAIL=ops@example.org
-DOMAIN=pkg.example.org
+PKG_DOMAIN=pkg.example.org
 
 # RustFS staging storage (generate with: openssl rand -hex 20)
 RUSTFS_ACCESS_KEY=<generate>

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -22,7 +22,7 @@ while IFS= read -r line; do
 done < <(docker compose ps --format json | jq -c 'if type=="array" then .[] else . end')
 
 # GPG endpoint availability check (Story 1.2)
-GPG_DOMAIN="${DOMAIN:-localhost}"
+GPG_DOMAIN="${PKG_DOMAIN:-localhost}"
 echo ""
 echo "==> Checking GPG endpoint availability..."
 HTTP_STATUS=$(curl -s -k --max-time 10 --write-out '%{http_code}' --output /dev/null \


### PR DESCRIPTION
Two bugs found during documentation investigation.

**Bug 1 — `.env` variable mismatch**
`.env.example` defined `DOMAIN=pkg.example.org` but `compose.yml` requires `PKG_DOMAIN`. Any operator following the deployment guide would set `DOMAIN` and the stack would fail immediately with:
```
PKG_DOMAIN must be set in .env
```
Fixed by renaming `DOMAIN` → `PKG_DOMAIN` in `.env.example`, `production-deployment.md`, `configuration.md`, and `health-check.sh`.

**Bug 2 — Wrong ACME challenge type documented**
`traefik.yml` configures `tlsChallenge: {}` (TLS-ALPN-01), which only requires port 443. The deployment docs incorrectly stated port 80 was required for an HTTP-01 challenge. Removed TCP 80 from the firewall table, the explanatory note, and the pre-deployment checklist.