### PR TITLE
docs(ops): add release runbook

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,3 +52,20 @@ gh release create v1.2.3 \
 ```
 
 Publishing the release triggers `docs.yml`, which runs `mike deploy v1.2.3 latest` and pushes the versioned docs to `gh-pages`. Confirm at `https://no42-org.github.io/packyard/`.
+
+## 4. Bump to next development version
+
+After the release is tagged, bump `main` to the next version with a `-dev` suffix so builds on `main` are never mistaken for a release:
+
+```bash
+# auth/cmd/server/version.go — update the version constant
+# const version = "1.2.4-dev"
+
+echo "1.2.4-dev" > rpm/VERSION
+
+git add auth/cmd/server/version.go rpm/VERSION
+git commit -m "chore: bump versions to 1.2.4-dev post v1.2.3 release"
+git push
+```
+
+Open a PR as normal — no special handling needed. Builds on `main` will tag images with the `-dev` version until the next release cycle begins.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,14 +7,11 @@ This covers cutting a new version of the Packyard infrastructure itself — the 
 Two files must match the intended release tag (without the `v` prefix):
 
 ```bash
-# auth service
-# edit the version constant in auth/cmd/server/version.go
-
-# rpm image
+sed -i "s/const version = .*/const version = \"1.2.3\"/" auth/cmd/server/version.go
 echo "1.2.3" > rpm/VERSION
 ```
 
-Commit and merge to `main` before tagging.
+Open a PR and merge to `main` before tagging.
 
 ## 2. Tag and push
 
@@ -58,14 +55,15 @@ Publishing the release triggers `docs.yml`, which runs `mike deploy v1.2.3 lates
 After the release is tagged, bump `main` to the next version with a `-rc` suffix so builds on `main` are never mistaken for a release:
 
 ```bash
-# auth/cmd/server/version.go — update the version constant
-# const version = "1.2.4-rc"
+git checkout -b chore/bump-1.2.4-rc
 
+sed -i "s/const version = .*/const version = \"1.2.4-rc\"/" auth/cmd/server/version.go
 echo "1.2.4-rc" > rpm/VERSION
 
 git add auth/cmd/server/version.go rpm/VERSION
 git commit -m "chore: bump versions to 1.2.4-rc post v1.2.3 release"
-git push
+git push -u origin chore/bump-1.2.4-rc
+gh pr create --title "chore: bump versions to 1.2.4-rc post v1.2.3" --fill
 ```
 
-Open a PR as normal — no special handling needed. Builds on `main` will tag images with the `-rc` version until the next release cycle begins.
+Builds on `main` will tag images with the `-rc` version until the next release cycle begins.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,17 +55,17 @@ Publishing the release triggers `docs.yml`, which runs `mike deploy v1.2.3 lates
 
 ## 4. Bump to next development version
 
-After the release is tagged, bump `main` to the next version with a `-dev` suffix so builds on `main` are never mistaken for a release:
+After the release is tagged, bump `main` to the next version with a `-rc` suffix so builds on `main` are never mistaken for a release:
 
 ```bash
 # auth/cmd/server/version.go — update the version constant
-# const version = "1.2.4-dev"
+# const version = "1.2.4-rc"
 
-echo "1.2.4-dev" > rpm/VERSION
+echo "1.2.4-rc" > rpm/VERSION
 
 git add auth/cmd/server/version.go rpm/VERSION
-git commit -m "chore: bump versions to 1.2.4-dev post v1.2.3 release"
+git commit -m "chore: bump versions to 1.2.4-rc post v1.2.3 release"
 git push
 ```
 
-Open a PR as normal — no special handling needed. Builds on `main` will tag images with the `-dev` version until the next release cycle begins.
+Open a PR as normal — no special handling needed. Builds on `main` will tag images with the `-rc` version until the next release cycle begins.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,54 @@
+# Releasing Packyard
+
+This covers cutting a new version of the Packyard infrastructure itself — the auth service, RPM service, and static service images, plus the versioned docs.
+
+## 1. Bump version numbers
+
+Two files must match the intended release tag (without the `v` prefix):
+
+```bash
+# auth service
+# edit the version constant in auth/cmd/server/version.go
+
+# rpm image
+echo "1.2.3" > rpm/VERSION
+```
+
+Commit and merge to `main` before tagging.
+
+## 2. Tag and push
+
+```bash
+git checkout main && git pull
+
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+Pushing the tag immediately triggers three image build workflows:
+
+| Workflow | Image pushed |
+|----------|-------------|
+| `build-auth.yml` | `ghcr.io/no42-org/packyard-auth:1.2.3` + `latest` |
+| `build-rpm.yml` | `ghcr.io/no42-org/packyard-rpm:1.2.3` + `latest` |
+| `build-static.yml` | `ghcr.io/no42-org/packyard-static:1.2.3` + `latest` |
+
+Monitor them:
+
+```bash
+gh run list --workflow=build-auth.yml
+gh run list --workflow=build-rpm.yml
+gh run list --workflow=build-static.yml
+```
+
+All three must succeed before creating the GitHub release.
+
+## 3. Create the GitHub release
+
+```bash
+gh release create v1.2.3 \
+  --title "v1.2.3" \
+  --generate-notes
+```
+
+Publishing the release triggers `docs.yml`, which runs `mike deploy v1.2.3 latest` and pushes the versioned docs to `gh-pages`. Confirm at `https://no42-org.github.io/packyard/`.

--- a/auth/cmd/server/version.go
+++ b/auth/cmd/server/version.go
@@ -1,5 +1,5 @@
 package main
 
-// version is the current application version. On main this carries a -dev suffix;
-// drop the suffix when cutting a release tag, then bump to the next -dev version.
+// version is the current application version. On main this carries a -rc suffix;
+// drop the suffix when cutting a release tag, then bump to the next -rc version.
 const version = "0.0.2-rc"

--- a/auth/cmd/server/version.go
+++ b/auth/cmd/server/version.go
@@ -1,5 +1,5 @@
 package main
 
-// version is the current application version. Update this to the next release
-// number suffixed with -rc on main, and drop the suffix when cutting a release tag.
+// version is the current application version. On main this carries a -dev suffix;
+// drop the suffix when cutting a release tag, then bump to the next -dev version.
 const version = "0.0.2-rc"

--- a/docs/ops/release-runbook.md
+++ b/docs/ops/release-runbook.md
@@ -1,77 +1,51 @@
-# Release Runbook
+# Package Promotion Runbook
+
+How to promote staged LTS packages (RPM, DEB, OCI) through the signing pipeline and into the serving infrastructure.
 
 **Last updated:** 2026-04-14
 
-## What is automatic vs manual
+---
 
-| Step | Trigger | Workflow |
-|------|---------|----------|
-| Build and push auth image | Tag `v*.*.*` | `build-auth.yml` |
-| Build and push rpm image | Tag `v*.*.*` | `build-rpm.yml` |
-| Build and push static image | Tag `v*.*.*` | `build-static.yml` |
-| Deploy versioned docs | GitHub release published | `docs.yml` |
-| Promote RPM packages | `workflow_dispatch` | `promote-rpm.yml` |
-| Promote DEB packages | `workflow_dispatch` | `promote-deb.yml` |
-| Promote OCI images | `workflow_dispatch` | `promote-oci.yml` |
+## Overview
 
-Tagging triggers image builds. Publishing the GitHub release deploys the docs. Package promotions are always manual — one dispatch per component and target.
+Promotion is always manual — one `workflow_dispatch` per component and target. The workflows download from RustFS staging, verify checksums, sign, and publish directly to the serving stack on the VM.
+
+| Format | Workflow | Key input parameters |
+|--------|----------|---------------------|
+| RPM | `promote-rpm.yml` | `component`, `year`, `os` |
+| DEB | `promote-deb.yml` | `component`, `year`, `distro` |
+| OCI | `promote-oci.yml` | `component`, `year` |
 
 ---
 
-## 1. Pre-release checklist
+## 1. Pre-promotion checklist
 
-- [ ] `auth/cmd/server/version.go` — version string matches the intended release tag (without the `v` prefix)
-- [ ] `rpm/VERSION` — same version string
-- [ ] `static/content/gpg/lts.asc` is a real GPG public key block, not a placeholder
-- [ ] `static/content/gpg/cosign.pub` is a real cosign public key, not a placeholder
+- [ ] `static/content/gpg/lts.asc` is a real GPG public key (not a placeholder)
+- [ ] `static/content/gpg/cosign.pub` is a real cosign public key (not a placeholder)
 - [ ] All 10 GitHub Actions secrets are set (see [Production Deployment §3](production-deployment.md#3-secrets--environment))
-- [ ] Artifacts to be promoted are staged in RustFS (§3 below)
-- [ ] All PRs for this release are merged to `main`
+- [ ] Artifacts are staged in RustFS (§2 below)
 
 ---
 
-## 2. Tag and create the GitHub release
+## 2. Stage artifacts
 
-```bash
-git checkout main && git pull
-
-git tag v1.2.3
-git push origin v1.2.3
-```
-
-Pushing the tag immediately triggers `build-auth.yml`, `build-rpm.yml`, and `build-static.yml`. Watch them in the Actions tab — they must all succeed before creating the release.
-
-Once the image builds pass, create the GitHub release:
-
-```bash
-gh release create v1.2.3 \
-  --title "v1.2.3" \
-  --generate-notes
-```
-
-Publishing the release triggers `docs.yml`, which runs `mike deploy v1.2.3 latest` and pushes to `gh-pages`. Docs are live at `https://no42-org.github.io/packyard/` within a few minutes.
-
----
-
-## 3. Stage artifacts
-
-Artifacts must be in RustFS staging before running the promotion workflows. Stage them from a machine with the RustFS credentials — the endpoint is internal-only, so open an SSH tunnel first:
+RustFS is internal-only. Open an SSH tunnel before staging:
 
 ```bash
 ssh -L 9000:localhost:9000 deploy@pkg.example.org -N &
 ```
 
-Then stage each artifact. The script uploads the file and a paired `.sha256`:
+Set credentials and call `stage-artifact.sh` for each artifact. The script uploads the file and a paired `.sha256` checksum:
 
 ```bash
 export RUSTFS_ENDPOINT=http://localhost:9000
 export RUSTFS_ACCESS_KEY=<key>
 export RUSTFS_SECRET_KEY=<secret>
 
-# RPM — one call per component/os combination
-bash scripts/stage-artifact.sh core    2025 rpm el9-x86_64  ./packyard-core-2025.el9.x86_64.rpm
-bash scripts/stage-artifact.sh minion  2025 rpm el9-x86_64  ./packyard-minion-2025.el9.x86_64.rpm
-bash scripts/stage-artifact.sh sentinel 2025 rpm el9-x86_64 ./packyard-sentinel-2025.el9.x86_64.rpm
+# RPM — one call per component × os combination
+bash scripts/stage-artifact.sh core     2025 rpm el9-x86_64  ./packyard-core-2025.el9.x86_64.rpm
+bash scripts/stage-artifact.sh minion   2025 rpm el9-x86_64  ./packyard-minion-2025.el9.x86_64.rpm
+bash scripts/stage-artifact.sh sentinel 2025 rpm el9-x86_64  ./packyard-sentinel-2025.el9.x86_64.rpm
 
 # DEB — os-arch is {distro}-amd64
 bash scripts/stage-artifact.sh core 2025 deb noble-amd64 ./packyard-core-2025_amd64.deb
@@ -81,7 +55,7 @@ bash scripts/stage-artifact.sh core 2025 oci x86_64 ./lts-core-x86_64.tar
 bash scripts/stage-artifact.sh core 2025 oci arm64  ./lts-core-arm64.tar
 ```
 
-Confirm the artifacts landed in the expected bucket paths:
+Confirm the artifacts are in the bucket:
 
 ```bash
 AWS_ACCESS_KEY_ID=$RUSTFS_ACCESS_KEY \
@@ -94,14 +68,13 @@ AWS_SECRET_ACCESS_KEY=$RUSTFS_SECRET_KEY \
 
 ---
 
-## 4. Promote packages
+## 3. Promote
 
-Trigger one workflow per component and target. Promotions are serialised per component/target by GitHub's concurrency groups — running multiple at once is safe.
+Promotions are serialised per component/target by GitHub's concurrency groups — running multiple dispatches at once is safe.
 
 ### RPM
 
 ```bash
-# Repeat for each component × os combination that has staged artifacts
 gh workflow run promote-rpm.yml \
   -f component=core \
   -f year=2025 \
@@ -131,7 +104,7 @@ gh workflow run promote-oci.yml \
 
 OCI promotion builds the multi-arch index from both staged architectures and cosign-signs all manifests in a single run — no per-arch dispatch needed.
 
-Monitor each workflow run:
+Monitor runs:
 
 ```bash
 gh run list --workflow=promote-rpm.yml
@@ -141,20 +114,20 @@ gh run list --workflow=promote-oci.yml
 
 ---
 
-## 5. Verify
+## 4. Verify
 
-Run the verification suite from [Production Deployment §10](production-deployment.md#10-run-the-verification-suite).
-
-Check that promoted packages are reachable with a valid subscriber key:
+Confirm promoted packages are reachable with a valid subscriber key:
 
 ```bash
-# RPM repodata must be present
+# RPM repodata
 curl -sI -u subscriber:<KEY> \
   https://pkg.example.org/rpm/core/2025/el9-x86_64/repodata/repomd.xml
 # Expect: HTTP/2 200
 
-# DEB InRelease must be present
+# DEB InRelease
 curl -sI -u subscriber:<KEY> \
   https://pkg.example.org/deb/core/2025/dists/noble/InRelease
 # Expect: HTTP/2 200
 ```
+
+For a full stack check, run the verification suite: [Production Deployment §10](production-deployment.md#10-run-the-verification-suite).

--- a/docs/ops/release-runbook.md
+++ b/docs/ops/release-runbook.md
@@ -1,0 +1,160 @@
+# Release Runbook
+
+**Last updated:** 2026-04-14
+
+## What is automatic vs manual
+
+| Step | Trigger | Workflow |
+|------|---------|----------|
+| Build and push auth image | Tag `v*.*.*` | `build-auth.yml` |
+| Build and push rpm image | Tag `v*.*.*` | `build-rpm.yml` |
+| Build and push static image | Tag `v*.*.*` | `build-static.yml` |
+| Deploy versioned docs | GitHub release published | `docs.yml` |
+| Promote RPM packages | `workflow_dispatch` | `promote-rpm.yml` |
+| Promote DEB packages | `workflow_dispatch` | `promote-deb.yml` |
+| Promote OCI images | `workflow_dispatch` | `promote-oci.yml` |
+
+Tagging triggers image builds. Publishing the GitHub release deploys the docs. Package promotions are always manual — one dispatch per component and target.
+
+---
+
+## 1. Pre-release checklist
+
+- [ ] `auth/cmd/server/version.go` — version string matches the intended release tag (without the `v` prefix)
+- [ ] `rpm/VERSION` — same version string
+- [ ] `static/content/gpg/lts.asc` is a real GPG public key block, not a placeholder
+- [ ] `static/content/gpg/cosign.pub` is a real cosign public key, not a placeholder
+- [ ] All 10 GitHub Actions secrets are set (see [Production Deployment §3](production-deployment.md#3-secrets--environment))
+- [ ] Artifacts to be promoted are staged in RustFS (§3 below)
+- [ ] All PRs for this release are merged to `main`
+
+---
+
+## 2. Tag and create the GitHub release
+
+```bash
+git checkout main && git pull
+
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+Pushing the tag immediately triggers `build-auth.yml`, `build-rpm.yml`, and `build-static.yml`. Watch them in the Actions tab — they must all succeed before creating the release.
+
+Once the image builds pass, create the GitHub release:
+
+```bash
+gh release create v1.2.3 \
+  --title "v1.2.3" \
+  --generate-notes
+```
+
+Publishing the release triggers `docs.yml`, which runs `mike deploy v1.2.3 latest` and pushes to `gh-pages`. Docs are live at `https://no42-org.github.io/packyard/` within a few minutes.
+
+---
+
+## 3. Stage artifacts
+
+Artifacts must be in RustFS staging before running the promotion workflows. Stage them from a machine with the RustFS credentials — the endpoint is internal-only, so open an SSH tunnel first:
+
+```bash
+ssh -L 9000:localhost:9000 deploy@pkg.example.org -N &
+```
+
+Then stage each artifact. The script uploads the file and a paired `.sha256`:
+
+```bash
+export RUSTFS_ENDPOINT=http://localhost:9000
+export RUSTFS_ACCESS_KEY=<key>
+export RUSTFS_SECRET_KEY=<secret>
+
+# RPM — one call per component/os combination
+bash scripts/stage-artifact.sh core    2025 rpm el9-x86_64  ./packyard-core-2025.el9.x86_64.rpm
+bash scripts/stage-artifact.sh minion  2025 rpm el9-x86_64  ./packyard-minion-2025.el9.x86_64.rpm
+bash scripts/stage-artifact.sh sentinel 2025 rpm el9-x86_64 ./packyard-sentinel-2025.el9.x86_64.rpm
+
+# DEB — os-arch is {distro}-amd64
+bash scripts/stage-artifact.sh core 2025 deb noble-amd64 ./packyard-core-2025_amd64.deb
+
+# OCI — stage x86_64 and arm64 archives separately
+bash scripts/stage-artifact.sh core 2025 oci x86_64 ./lts-core-x86_64.tar
+bash scripts/stage-artifact.sh core 2025 oci arm64  ./lts-core-arm64.tar
+```
+
+Confirm the artifacts landed in the expected bucket paths:
+
+```bash
+AWS_ACCESS_KEY_ID=$RUSTFS_ACCESS_KEY \
+AWS_SECRET_ACCESS_KEY=$RUSTFS_SECRET_KEY \
+  aws s3 ls s3://staging/ \
+  --endpoint-url http://localhost:9000 \
+  --region us-east-1 \
+  --recursive
+```
+
+---
+
+## 4. Promote packages
+
+Trigger one workflow per component and target. Promotions are serialised per component/target by GitHub's concurrency groups — running multiple at once is safe.
+
+### RPM
+
+```bash
+# Repeat for each component × os combination that has staged artifacts
+gh workflow run promote-rpm.yml \
+  -f component=core \
+  -f year=2025 \
+  -f os=el9-x86_64
+```
+
+Valid `os` values: `el8-x86_64`, `el9-x86_64`, `el10-x86_64`, `centos10-x86_64`
+
+### DEB
+
+```bash
+gh workflow run promote-deb.yml \
+  -f component=core \
+  -f year=2025 \
+  -f distro=noble
+```
+
+Valid `distro` values: `bookworm`, `trixie`, `jammy`, `noble`
+
+### OCI
+
+```bash
+gh workflow run promote-oci.yml \
+  -f component=core \
+  -f year=2025
+```
+
+OCI promotion builds the multi-arch index from both staged architectures and cosign-signs all manifests in a single run — no per-arch dispatch needed.
+
+Monitor each workflow run:
+
+```bash
+gh run list --workflow=promote-rpm.yml
+gh run list --workflow=promote-deb.yml
+gh run list --workflow=promote-oci.yml
+```
+
+---
+
+## 5. Verify
+
+Run the verification suite from [Production Deployment §10](production-deployment.md#10-run-the-verification-suite).
+
+Check that promoted packages are reachable with a valid subscriber key:
+
+```bash
+# RPM repodata must be present
+curl -sI -u subscriber:<KEY> \
+  https://pkg.example.org/rpm/core/2025/el9-x86_64/repodata/repomd.xml
+# Expect: HTTP/2 200
+
+# DEB InRelease must be present
+curl -sI -u subscriber:<KEY> \
+  https://pkg.example.org/deb/core/2025/dists/noble/InRelease
+# Expect: HTTP/2 200
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ nav:
   - Getting Started: getting-started/quick-start.md
   - Operations:
     - Production Deployment: ops/production-deployment.md
-    - Release Runbook: ops/release-runbook.md
+    - Package Promotion: ops/release-runbook.md
     - Restore Keystore: ops/restore-keystore.md
     - Manual Test Plan: ops/manual-test-plan.md
     - Troubleshooting: ops/troubleshooting.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Getting Started: getting-started/quick-start.md
   - Operations:
     - Production Deployment: ops/production-deployment.md
+    - Release Runbook: ops/release-runbook.md
     - Restore Keystore: ops/restore-keystore.md
     - Manual Test Plan: ops/manual-test-plan.md
     - Troubleshooting: ops/troubleshooting.md


### PR DESCRIPTION
## Summary

- Adds `docs/ops/release-runbook.md` — operator-facing guide for cutting a release
- Adds it to `mkdocs.yml` nav under Operations (between Production Deployment and Restore Keystore)

Covers:
- What fires automatically (image builds on tag, docs deploy on release publish) vs what requires manual dispatch
- Pre-release checklist
- Tagging and creating the GitHub release
- Staging artifacts into RustFS via `stage-artifact.sh`
- Triggering promotion workflows per component and target (RPM, DEB, OCI)
- Post-release verification

## Test plan

- [ ] `mkdocs build` passes (CI gates on `docs/**` changes)
- [ ] Page appears under Operations in the published docs