### PR TITLE
chore: update compose.yml image tags to 0.1.0

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,11 +4,15 @@ This covers cutting a new version of the Packyard infrastructure itself — the 
 
 ## 1. Bump version numbers
 
-Two files must match the intended release tag (without the `v` prefix):
+Three places must match the intended release tag (without the `v` prefix):
 
 ```bash
 sed -i "s/const version = .*/const version = \"1.2.3\"/" auth/cmd/server/version.go
 echo "1.2.3" > rpm/VERSION
+
+sed -i "s|packyard-auth:[^ ]*|packyard-auth:1.2.3|" compose.yml
+sed -i "s|packyard-rpm:[^ ]*|packyard-rpm:1.2.3|" compose.yml
+sed -i "s|packyard-static:[^ ]*|packyard-static:1.2.3|" compose.yml
 ```
 
 Open a PR and merge to `main` before tagging.
@@ -60,7 +64,11 @@ git checkout -b chore/bump-1.2.4-rc
 sed -i "s/const version = .*/const version = \"1.2.4-rc\"/" auth/cmd/server/version.go
 echo "1.2.4-rc" > rpm/VERSION
 
-git add auth/cmd/server/version.go rpm/VERSION
+sed -i "s|packyard-auth:[^ ]*|packyard-auth:1.2.4-rc|" compose.yml
+sed -i "s|packyard-rpm:[^ ]*|packyard-rpm:1.2.4-rc|" compose.yml
+sed -i "s|packyard-static:[^ ]*|packyard-static:1.2.4-rc|" compose.yml
+
+git add auth/cmd/server/version.go rpm/VERSION compose.yml
 git commit -m "chore: bump versions to 1.2.4-rc post v1.2.3 release"
 git push -u origin chore/bump-1.2.4-rc
 gh pr create --title "chore: bump versions to 1.2.4-rc post v1.2.3" --fill

--- a/compose.yml
+++ b/compose.yml
@@ -28,7 +28,7 @@ services:
       - proxy
 
   auth:
-    image: ghcr.io/no42-org/packyard-auth:0.0.2-rc
+    image: ghcr.io/no42-org/packyard-auth:0.1.0
     restart: unless-stopped
     cap_drop: [ALL]
     security_opt:
@@ -88,7 +88,7 @@ services:
       - proxy
 
   rpm:
-    image: ghcr.io/no42-org/packyard-rpm:0.0.2-rc
+    image: ghcr.io/no42-org/packyard-rpm:0.1.0
     restart: unless-stopped
     user: "101:101"             # run directly as nginx user — no privilege drop, no cap_add needed
     cap_drop: [ALL]
@@ -190,7 +190,7 @@ services:
       - backend
 
   static:
-    image: ghcr.io/no42-org/packyard-static:0.0.2-rc
+    image: ghcr.io/no42-org/packyard-static:0.1.0
     restart: unless-stopped
     user: "101:101"             # run directly as nginx user — no privilege drop, no cap_add needed
     cap_drop: [ALL]


### PR DESCRIPTION
Fixes image tags in `compose.yml` that were missed in the version bump PR.

- `packyard-auth`, `packyard-rpm`, `packyard-static`: `0.0.2-rc` → `0.1.0`

Also updates `RELEASING.md` to include `compose.yml` image tag updates in both §1 (pre-release bump) and §4 (post-release -rc bump) so this is not missed in future releases.