### PR TITLE
fix(docs): admin API uses HTTP not HTTPS on port 8443

### DIFF
--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -288,7 +288,7 @@ curl -sI -u subscriber:<CORE_KEY> https://pkg.example.org/rpm/minion/2025/el9-x8
 
 # 5. Admin API reachable only via SSH tunnel
 ssh -L 8443:127.0.0.1:8443 deploy@pkg.example.org -N &
-curl -sk https://127.0.0.1:8443/api/v1/keys
+curl -s http://127.0.0.1:8443/api/v1/keys
 # Expect: JSON array (empty if no keys created yet)
 ```
 
@@ -301,7 +301,7 @@ curl -sk https://127.0.0.1:8443/api/v1/keys
 ssh -L 8443:127.0.0.1:8443 deploy@pkg.example.org -N &
 
 # Create an API key for a subscriber
-curl -sk -X POST https://127.0.0.1:8443/api/v1/keys \
+curl -s -X POST http://127.0.0.1:8443/api/v1/keys \
   -H 'Content-Type: application/json' \
   -d '{"component": "core", "label": "Acme Corp — Core"}'
 # Response contains the key value — share only this with the subscriber

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -33,7 +33,7 @@ The following examples assume the SSH tunnel is active (see above).
 **Create a key:**
 
 ```bash
-curl -s -X POST https://127.0.0.1:8443/api/v1/keys \
+curl -s -X POST http://127.0.0.1:8443/api/v1/keys \
   -H 'Content-Type: application/json' \
   -d '{"component": "core", "label": "Acme Corp"}' | jq .
 ```
@@ -51,13 +51,13 @@ curl -s -X POST https://127.0.0.1:8443/api/v1/keys \
 **List keys:**
 
 ```bash
-curl -s https://127.0.0.1:8443/api/v1/keys | jq .
+curl -s http://127.0.0.1:8443/api/v1/keys | jq .
 ```
 
 **Revoke a key:**
 
 ```bash
-curl -s -X DELETE https://127.0.0.1:8443/api/v1/keys/abc123...
+curl -s -X DELETE http://127.0.0.1:8443/api/v1/keys/abc123...
 ```
 
 ## Error responses


### PR DESCRIPTION
The admin API serves plain HTTP — `https://` and `-k` were both wrong and silently produced no response.

**Fixed in:**
- `docs/ops/production-deployment.md` §8 (post-deployment validation) and §9 (first subscriber onboarding)
- `docs/reference/api.md` — all three example commands

Root cause: `troubleshooting.md` had it right (`http://`), the other two docs did not.