### PR TITLE
fix: change admin entrypoint port from 8443 to 8088

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,14 @@ _bmad-output/
 # Claude Code & agent integration (local IDE tooling)
 .claude/
 .agents/
+.agent/
+.gemini/
+openspec/
+
+# Scan results and local key material — never commit
+trivy_scan.txt
+cosign.key
+cosign.pub
 
 site/
 .venv/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Traefik (TLS termination, forwardAuth, routing)
     ├── /deb/   → nginx → Aptly (signed DEB snapshots)
     ├── /oci/   → Zot (OCI registry, cosign signatures)
     ├── /gpg/   → nginx (public keys — unauthenticated)
-    └── /api/   → auth service (admin API, internal :8443)
+    └── /api/   → auth service (admin API, internal :8088)
          │
          └── auth service (forwardAuth + key management)
                   │

--- a/compose.override.ci.yml
+++ b/compose.override.ci.yml
@@ -8,7 +8,7 @@
 #
 # The base compose.yml port mapping for Traefik (443) is merged in by
 # Compose but harmless — Traefik only listens on the entryPoints defined in
-# traefik.ci.yml (web:80 and admin:8443).
+# traefik.ci.yml (web:80 and admin:8088).
 
 services:
 

--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,7 @@ services:
       - /tmp                    # Go runtime scratch
     ports:
       - "443:443"
-      - "127.0.0.1:8443:8443"
+      - "127.0.0.1:8088:8088"
     volumes:
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./traefik/dynamic:/etc/traefik/dynamic:ro

--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -31,7 +31,7 @@ All records are on the `example.org` zone. Apply these **before** starting the d
 | CAA   | `pkg.example.org`     | `0 issue "letsencrypt.org"`      | 3600  | Restricts TLS cert issuance to Let's Encrypt |
 | CAA   | `pkg.example.org`     | `0 iodef "mailto:ops@example.org"`   | 3600  | CAA violation notification address |
 
-> **No other subdomains are needed.** The admin API is loopback-only (`127.0.0.1:8443`), reached via SSH tunnel. RPM, DEB, OCI, and GPG key endpoints all share `pkg.example.org`.
+> **No other subdomains are needed.** The admin API is loopback-only (`127.0.0.1:8088`), reached via SSH tunnel. RPM, DEB, OCI, and GPG key endpoints all share `pkg.example.org`.
 
 ### DNS propagation check
 
@@ -287,8 +287,8 @@ curl -sI -u subscriber:<CORE_KEY> https://pkg.example.org/rpm/minion/2025/el9-x8
 # Expect: HTTP/2 401
 
 # 5. Admin API reachable only via SSH tunnel
-ssh -L 8443:127.0.0.1:8443 deploy@pkg.example.org -N &
-curl -s http://127.0.0.1:8443/api/v1/keys
+ssh -L 8088:127.0.0.1:8088 deploy@pkg.example.org -N &
+curl -s http://127.0.0.1:8088/api/v1/keys
 # Expect: JSON array (empty if no keys created yet)
 ```
 
@@ -298,10 +298,10 @@ curl -s http://127.0.0.1:8443/api/v1/keys
 
 ```bash
 # Open SSH tunnel to admin API
-ssh -L 8443:127.0.0.1:8443 deploy@pkg.example.org -N &
+ssh -L 8088:127.0.0.1:8088 deploy@pkg.example.org -N &
 
 # Create an API key for a subscriber
-curl -s -X POST http://127.0.0.1:8443/api/v1/keys \
+curl -s -X POST http://127.0.0.1:8088/api/v1/keys \
   -H 'Content-Type: application/json' \
   -d '{"component": "core", "label": "Acme Corp — Core"}'
 # Response contains the key value — share only this with the subscriber

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -78,14 +78,14 @@ If the state is `unhealthy` or `exited`, see [Container unhealthy or crashing](#
 Open an SSH tunnel to the admin API, then look up the key:
 
 ```bash
-ssh -L 8443:127.0.0.1:8443 deploy@pkg.example.org -N &
-curl -s http://127.0.0.1:8443/api/v1/keys | jq '.[] | select(.id == "<KEY>")'
+ssh -L 8088:127.0.0.1:8088 deploy@pkg.example.org -N &
+curl -s http://127.0.0.1:8088/api/v1/keys | jq '.[] | select(.id == "<KEY>")'
 ```
 
 If the key is absent, it was created after the last backup and lost during a keystore restore. Re-provision it:
 
 ```bash
-curl -s -X POST http://127.0.0.1:8443/api/v1/keys \
+curl -s -X POST http://127.0.0.1:8088/api/v1/keys \
   -H 'Content-Type: application/json' \
   -d '{"component": "core", "label": "re-provisioned"}'
 ```
@@ -97,7 +97,7 @@ If the key is present but `"active": false`, it has been revoked. Issue a new ke
 Each key is scoped to a single component (`core`, `minion`, or `sentinel`). A `core` key cannot access `/rpm/minion/` — that is the expected behaviour, not a bug. Confirm the subscriber is using a key whose `component` matches the path they are requesting.
 
 ```bash
-curl -s http://127.0.0.1:8443/api/v1/keys | jq '.[] | {id, component, label, active}'
+curl -s http://127.0.0.1:8088/api/v1/keys | jq '.[] | {id, component, label, active}'
 ```
 
 ---
@@ -126,23 +126,23 @@ Common causes:
 
 ## Admin API unreachable
 
-The admin API listens on `127.0.0.1:8443` (loopback only). It is not reachable from outside the VM without an SSH tunnel.
+The admin API listens on `127.0.0.1:8088` (loopback only). It is not reachable from outside the VM without an SSH tunnel.
 
 **Open the tunnel:**
 
 ```bash
-ssh -L 8443:127.0.0.1:8443 deploy@pkg.example.org -N &
+ssh -L 8088:127.0.0.1:8088 deploy@pkg.example.org -N &
 ```
 
 **Verify:**
 
 ```bash
-curl -s http://127.0.0.1:8443/api/v1/keys
+curl -s http://127.0.0.1:8088/api/v1/keys
 # Expected: JSON array (empty if no keys)
 # Connection refused → tunnel not open, or auth service down
 ```
 
-Note: port 8443 serves plain HTTP (not HTTPS) — do not use `-k` or `https://`.
+Note: port 8088 serves plain HTTP (not HTTPS) — do not use `-k` or `https://`.
 
 If the admin API returns `404` on port 443 (the public entrypoint), that is correct — the admin route is intentionally not exposed publicly.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,9 +1,9 @@
 # Admin API
 
-The admin API is available at `/api/v1/` via Traefik's loopback admin entrypoint (`:8443`). It is not reachable from the internet — access via SSH tunnel:
+The admin API is available at `/api/v1/` via Traefik's loopback admin entrypoint (`:8088`). It is not reachable from the internet — access via SSH tunnel:
 
 ```bash
-ssh -L 8443:127.0.0.1:8443 deploy@pkg.example.org -N &
+ssh -L 8088:127.0.0.1:8088 deploy@pkg.example.org -N &
 ```
 
 ## Endpoints
@@ -33,7 +33,7 @@ The following examples assume the SSH tunnel is active (see above).
 **Create a key:**
 
 ```bash
-curl -s -X POST http://127.0.0.1:8443/api/v1/keys \
+curl -s -X POST http://127.0.0.1:8088/api/v1/keys \
   -H 'Content-Type: application/json' \
   -d '{"component": "core", "label": "Acme Corp"}' | jq .
 ```
@@ -51,13 +51,13 @@ curl -s -X POST http://127.0.0.1:8443/api/v1/keys \
 **List keys:**
 
 ```bash
-curl -s http://127.0.0.1:8443/api/v1/keys | jq .
+curl -s http://127.0.0.1:8088/api/v1/keys | jq .
 ```
 
 **Revoke a key:**
 
 ```bash
-curl -s -X DELETE http://127.0.0.1:8443/api/v1/keys/abc123...
+curl -s -X DELETE http://127.0.0.1:8088/api/v1/keys/abc123...
 ```
 
 ## Error responses

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -12,7 +12,7 @@ Traefik (TLS termination, forwardAuth, routing)
     ├── /deb/   → nginx → Aptly (signed DEB snapshots)
     ├── /oci/   → Zot (OCI registry, cosign signatures)
     ├── /gpg/   → nginx (public keys — unauthenticated)
-    └── /api/   → auth service (admin API, internal :8443)
+    └── /api/   → auth service (admin API, internal :8088)
          │
          └── auth service (forwardAuth + key management)
                   │

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -9,7 +9,7 @@ Metrics are exposed by the auth service at `http://auth:9090/metrics` (Docker-in
 | `packyard_auth_requests_total{status="allowed\|denied\|error"}` | Counter | forwardAuth request outcomes |
 | `packyard_auth_duration_seconds` | Histogram | forwardAuth latency |
 
-Traefik metrics are available at `http://localhost:8443/metrics` (loopback only).
+Traefik metrics are available at `http://localhost:8088/metrics` (loopback only).
 
 ## Accessing metrics locally
 
@@ -18,7 +18,7 @@ Traefik metrics are available at `http://localhost:8443/metrics` (loopback only)
 curl -s http://localhost:9090/metrics | grep packyard_auth
 
 # Traefik metrics (via loopback admin entrypoint)
-curl -s http://localhost:8443/metrics
+curl -s http://localhost:8088/metrics
 ```
 
 ## Accessing metrics in production

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -35,18 +35,18 @@ else
 fi
 
 # Auth service health check via admin API entrypoint (Story 2.3)
-# Hits GET /api/v1/keys on the admin entrypoint (127.0.0.1:8443) — the only path routed
+# Hits GET /api/v1/keys on the admin entrypoint (127.0.0.1:8088) — the only path routed
 # on that entrypoint. Returns 200 + empty array when auth is up, proving both that the
 # auth service is reachable and that the admin API route is live.
 # Note: /health is NOT routed on the admin entrypoint (only PathPrefix(/api/v1/) is).
 echo ""
-echo "==> Checking auth service (admin API reachable on loopback 8443)..."
+echo "==> Checking auth service (admin API reachable on loopback 8088)..."
 AUTH_STATUS=$(curl -s --max-time 10 --write-out '%{http_code}' --output /dev/null \
-    "http://127.0.0.1:8443/api/v1/keys" 2>/dev/null || echo "000")
+    "http://127.0.0.1:8088/api/v1/keys" 2>/dev/null || echo "000")
 if [[ "${AUTH_STATUS}" == "200" ]]; then
     echo "OK:   auth /api/v1/keys returned HTTP 200 via admin entrypoint"
 else
-    echo "FAIL: auth /api/v1/keys returned HTTP ${AUTH_STATUS} (expected 200 via 127.0.0.1:8443)"
+    echo "FAIL: auth /api/v1/keys returned HTTP ${AUTH_STATUS} (expected 200 via 127.0.0.1:8088)"
     FAILED=1
 fi
 

--- a/traefik/dynamic-ci/routers-admin.yml
+++ b/traefik/dynamic-ci/routers-admin.yml
@@ -5,7 +5,7 @@ http:
         - admin
       rule: "PathPrefix(`/api/v1/`)"
       service: packyard-auth-admin-svc
-      # No middleware — admin entrypoint is 127.0.0.1:8443 (loopback-only, NFR8, FR34)
+      # No middleware — admin entrypoint is 127.0.0.1:8088 (loopback-only, NFR8, FR34)
       # No tls: — loopback-only plain HTTP; matches production behaviour
 
   services:

--- a/traefik/dynamic-dev/routers-admin.yml
+++ b/traefik/dynamic-dev/routers-admin.yml
@@ -5,7 +5,7 @@ http:
         - admin
       rule: "PathPrefix(`/api/v1/`)"
       service: packyard-auth-admin-svc
-      # No middleware — admin entrypoint is 127.0.0.1:8443 (loopback-only, NFR8, FR34)
+      # No middleware — admin entrypoint is 127.0.0.1:8088 (loopback-only, NFR8, FR34)
       # Operators access via SSH tunnel or jump host; internal trust model
       # No tls: — loopback-only plain HTTP; TLS adds no security on localhost
 

--- a/traefik/dynamic/routers-admin.yml
+++ b/traefik/dynamic/routers-admin.yml
@@ -5,7 +5,7 @@ http:
         - admin
       rule: "PathPrefix(`/api/v1/`)"
       service: packyard-auth-admin-svc
-      # No middleware — admin entrypoint is 127.0.0.1:8443 (loopback-only, NFR8, FR34)
+      # No middleware — admin entrypoint is 127.0.0.1:8088 (loopback-only, NFR8, FR34)
       # Operators access via SSH tunnel or jump host; internal trust model
       # No tls: — loopback-only plain HTTP; TLS adds no security on localhost
 

--- a/traefik/traefik.ci.yml
+++ b/traefik/traefik.ci.yml
@@ -17,7 +17,7 @@ entryPoints:
   web:
     address: "0.0.0.0:80"
   admin:
-    address: "127.0.0.1:8443"
+    address: "127.0.0.1:8088"
 
 # No certificatesResolvers — TLS/ACME disabled for CI
 

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -17,7 +17,7 @@ entryPoints:
   websecure:
     address: "0.0.0.0:443"
   admin:
-    address: "127.0.0.1:8443"
+    address: "127.0.0.1:8088"
 
 certificatesResolvers:
   letsencrypt:


### PR DESCRIPTION
Port 8443 conventionally implies HTTPS, which confused users when the admin API serves plain HTTP.

**Changed:** `traefik/traefik.yml`, `traefik/traefik.ci.yml`, `compose.yml`, `scripts/health-check.sh`, and all documentation.

Also adds `.agent/`, `.gemini/`, `openspec/`, `trivy_scan.txt`, and `cosign.key`/`cosign.pub` to `.gitignore`.