### PR TITLE
chore: replace real GPG key in lts.asc with placeholder

### DIFF
--- a/static/content/gpg/lts.asc
+++ b/static/content/gpg/lts.asc
@@ -1,65 +1,47 @@
------BEGIN PGP PUBLIC KEY BLOCK-----
-
-mQINBGnJqr8BEADG2lvtQ43Oarh5aG+r+1qgUpo29Ne/rkT2XGcP700N7wcINoio
-8x/vVnWh92sUoi6yJwkXsugMC7qO1qXA1y8528cg4oKRdixCb5QQLaazTJYLfrxL
-/oVKrAqkl1cMyZ+2OAWaQmXC68tGg7XoICfvJqI/hDFn4XxMZlJpG9YHGFvMeMKL
-jSx/GDl4P+RZgTUcudaNCP19DTkyHVN4u02AN/C0omfZDEgqehdPUVuSz6HMA2Qt
-mEte01EzsdDV/YeL0b6scRKQgFnlLWePrDdXFoTXDNcammWFGlj/A/LpOBqp+Cnj
-M1gXVZbjUy8Kha07MVjFZtsLoYAygq7i2oZ6IxKer8Ep2tT1VPF1+DPp9E52HGHn
-tdTT3KKmLDaOUHD8EzjL9i7ZiV4FP38PdfRpGMBvwOnLgO173cHnjdtdCPwLgIU0
-vR2HHb9xzaoV1zNJqeoIhZkQGg2vHwoLucawzKuSt2vU3plAtPVk9lFT+m99cUmg
-H1tyacdxK6pqS9nG8aYS1ndtcrmU2a1CNKACj4pwf1r4a8EqSDJZpsLbzZLB2Wxm
-HVpJW12U6d484eou0gHHL4qjeLBqfunAZPKZRgRx5J4E6JNk0B8LbgeXe0cDVjlV
-XD1r0Impxexl23MXQE0yH+ZW5Y1oH1llIvZUSaN2HzAATQpB86fgwlBKKwARAQAB
-tC9PcGVuTk1TIE1lcmlkaWFuIERldiA8bWVyaWRpYW4tZGV2QG9wZW5ubXMuY29t
-PokCawQTAQoAVRYhBG24rLyZFD+YsCzby93yf8aBLmIUBQJpyaq/GxSAAAAAAAQA
-Dm1hbnUyLDIuNSsxLjEyLDAsMwMbLwQFCwkIBwMFFQoJCAsFFgIDAQACHgUCF4AA
-CgkQ3fJ/xoEuYhTFAw/9GjlpdB7raQ2bjyuhkTHbX6Te+itWyKJ74WnLVWeoRIst
-61RbaLZD/9ytSLD6JRSVUXRnPp0+JcfRq6bZYrhfL4uccAGM/sdue+XLzKyvYh7C
-fWRI+6TEg/Ngfd41yyjU9yiVgyOqq5ep2xFdN97l1tGzgNrblFJWK56HS1om2b+E
-lXnsUm+U54s7Zmv2+fF9dMYPkk163mSwMJ2eFBJArGSYcU40/ZXYlYmiOXXnAgcI
-BU6Vafh2b3EQTxYJJJJfnM8E4+lhf3pBxjVyJ5uVHeJxrCxh064e+bPGzo1Sn3A3
-/HM1Y7J/hwe4wPx/yoqSUXqnMwxVaq72M3k5hxhFkHgAaHzEwBIn+PZXQYbhE8au
-IOIC7zwGjZftNjrt9uZB/lxwwG/yarKBqkE8Ir6XtvEHp+7zoBNNfw2OSsvdgG0J
-Xei76EWxbu4rWKUemBqAZlX4JzCYPOS3xS1klczreGvlWSSkiPkKwboWP5FqLVCF
-B1Rzt8uwh0IzhKdLQ+c8hu6FSQEMwQPeKYQupRPDoFt+VA7ayYKbxY3sPRZ/+w42
-HrtlXnnLMI8wlWvN/aBsAyN37hU8Ww3O2I8pGCeGEvGcn+AmutFuyLs3t+ZkHkPc
-NWrrcH9CvWxfYejJTu6LuoXZaCQY5l8gaf/T8rIdZOn7s9/88EZlYi2buqczlte5
-Ag0EacmqvwEQALHSYMTKHyod3Cj3QAY8HAxjsXIOcimu04gbUbBtX68/fGg0ziy8
-FdrWfrd7aBxfuocLVtWAN2HRd9WeISf4JOzg/ZJgb8jm7OAVBp1mIb1M7iZV66RV
-sftvNXhod5yTnUstUZmIOR8Z4ctRCnWn+s+zRFUEzVpgxjLnnUbFD7ietS1fxeN/
-PoYnRNUUmfeuejrnjIbeDq+7+HhLoocJ90Tr5AipTX1ZeGgPl1E88ZPbartVPaS7
-GdIv/YF/Rc3rTIgd79ybAh5X/y87nVZR/qebJhYeqqHm4PYR+f6pFV7oXbQZcZcL
-inQh0kC6q/6e2n2Cx0oYLthw4HDFdY9/27cxXkztbqsan+1tWEzlehZum3C+70It
-+a5WipsvxE7RpxUwdSnwmq7r99j3SNfu+cSKlGnmn54ypAPnQPtm9ugtL7vN7iti
-jaG7AUyCpt4sP7vDFNtVv71jGEt7lsJ3JdjGK/fVj4Y2v3ABKY4+tzlD3Dr/VQ8N
-txzCMCCoW0EjtpHg+lbvEbW/BaGCTM6or80ICSw9FM/htGZlUMUuqyiHh0tG5zCO
-L5bfN4tihw7OPvtS1mG9Dw6Y6n3EEDYNsK1kdYPw8Oa1bpPEqh471WbFavP78SvM
-QnVG36MTIpetuyJAPK4xqqYFQOJvuxu6pnfnA+amxblpl/VVkDJu617PABEBAAGJ
-BIgEGAEKADwWIQRtuKy8mRQ/mLAs28vd8n/GgS5iFAUCacmqvxsUgAAAAAAEAA5t
-YW51MiwyLjUrMS4xMiwwLDMCGy4CQAkQ3fJ/xoEuYhTBdCAEGQEKAB0WIQS2W12S
-+osLprQjB0yw36hSqX7GgQUCacmqvwAKCRCw36hSqX7GgTeeD/0RB3R2Lx2O2697
-EYNk4jyKiS7w1JqQUb0VNEExXqlFHexn//Sv3B9gXew6go/2lq+7ueYsaRuy0qKM
-MJffn0lAPN2/ahSOUxOJcP2R1ClInVNax9c+vMuqkStSRf9CPbihfzBVRyDlHrCM
-rv7EoZe2Pdcyw2IR+MaTE9upunpImz16P4f94R0h/xbxyAAGhyX83dZHGcsEvMby
-rHxNHWgSRiMiFFrSagnXuH9Y7rsTFqJoUUCIVciqAJ5lGHko5deklxkyPhqpavyD
-KnvCyUS+7imaatst+vrDl9le9r1iBcZ0iS67orWJkH/IfDHXXQUQ2UdYGeficlWl
-92PxaBbb3fbIqBO1h2WV/zGlgBQU52Xrqr3MkwMHU54s1Aw9sCT1V9EXYlVeWrrl
-iYmsHOiAbapQcly8ESvuy44/0OAVYFmY0nl75hOuHZxoYhF6ZtCPDzIeRyUNmzka
-A3iaV5Fj5GWm5GGlcmkhv6YZRDoaGDANbM9XlIydwe4YuTjnA9HlBzbipKOBecYS
-M4SIECemJm/MtoeRabdYPhDHtFm7L6RvKhKlf5Rtvl+3IwJIPx4cPAwdnFKp7UJc
-9xUCZLoLbpF9NqHYZebilCIOvX+ng5s1+p7WA7VEtnn5qCWtfwcKTG+xM/MnQ2Kr
-fk9scziZavEw4U9YfZ5KeCTFXBKPFFKFEACeJ7Rv0IPvUlde1LSiS9ABQmp9mi4O
-rz8/tixexo0FXyxKf/FGHgxZST2ooMkZ+rcswElL9yGnmlkW8/RkNkEFtPdt2Obe
-Z7K1LS5YNNwf1RVOREdrZ9YNSflEbXDGXKr7VYEl5/Q6VsguNp85EJh1OeXFhkSl
-QE4na/3NL3nwCLtTL47WTDA9cZpIkDKyY8iPLSX0Dt5Wks8tYflfii74vUFA28mq
-dmpgcICp2X9zOmR4OPpbwZgZa+/jnKfYyEsxe7zemwdWY7iNpC+/UjN2kDyvxF/e
-GmTM8ijEn+4bNCCUlW7UWSm4VvHmus07BVJ/KD3/NIMzN9yYwz7ylQIgzPko4R3s
-3Md3/S4ZSuPPQ/XjDzao23HkWtxp0wrzWPHD9rdpHK+NCiHgOvqPV6pj9NGf8oqz
-ipYeMGpzOXoAvzYe5rhhPDOCDMO37LS8Rur7J50QjImVza29pX5fGRsmGsOhg8st
-BUcpBjrxlbenb4WFfbG1OJSrJaYQVvXWbQjHQt8OO7j0lcsUXAtpVBlzd5BwfzHD
-/p2WIXO9NtbRoGjnqZVvU442CwPK1UhgccXGjNNK1ousy50TFnrlWcdHH9dfZrNM
-0eSOO8yMmNhfXyKJGRzvKUcVgKFmoJEH4+KZ4M1YOmkVjA63y4rSV1q4Fruz41wK
-J+xEVhp9V1e3ng==
-=eFKz
------END PGP PUBLIC KEY BLOCK-----
+# PLACEHOLDER: Replace with the real LTS GPG public key (ASCII-armored PEM format).
+#
+# To generate a dedicated LTS signing keypair:
+#
+#   cat > /tmp/lts-gpg-params <<'EOF'
+#   %echo Generating LTS signing key
+#   Key-Type: RSA
+#   Key-Length: 4096
+#   Subkey-Type: RSA
+#   Subkey-Length: 4096
+#   Name-Real: LTS
+#   Name-Comment: Package Signing Key
+#   Name-Email: lts-signing@example.org
+#   Expire-Date: 0
+#   Passphrase: <CHOOSE_A_STRONG_PASSPHRASE>
+#   %commit
+#   %echo Done
+#   EOF
+#   gpg --batch --gen-key /tmp/lts-gpg-params
+#   rm /tmp/lts-gpg-params
+#
+#   # Find the 40-character fingerprint — this is GPG_KEY_ID
+#   gpg --list-keys --fingerprint lts-signing@example.org
+#   GPG_KEY_ID="<40-char fingerprint, no spaces>"
+#
+#   # Export the public key and replace this file
+#   gpg --armor --export "$GPG_KEY_ID" > static/content/gpg/lts.asc
+#   git add static/content/gpg/lts.asc && git commit
+#
+#   # Export the private key — store as GHA secret GPG_PRIVATE_KEY
+#   gpg --armor --export-secret-keys "$GPG_KEY_ID"
+#
+# GHA secrets to set:
+#   GPG_PRIVATE_KEY  — output of gpg --armor --export-secret-keys
+#   GPG_KEY_ID       — 40-character fingerprint (no spaces)
+#   GPG_PASSPHRASE   — passphrase chosen during key generation
+#
+# This file is served at https://pkg.example.org/gpg/lts.asc
+# (no authentication — public-unauthenticated route via Traefik /gpg/ prefix)
+#
+# Subscribers use it to verify package signatures:
+#   rpm --import https://pkg.example.org/gpg/lts.asc        # RPM
+#   curl https://pkg.example.org/gpg/lts.asc | apt-key add  # DEB (legacy)
+#
+# See docs/ops/production-deployment.md §4.1 for full instructions.
+#
+# DO NOT commit the private key. Store it exclusively as the GHA secret GPG_PRIVATE_KEY.


### PR DESCRIPTION
The committed `lts.asc` contained a real GPG public key with old OpenNMS/Meridian branding. Replaced with a comment-only placeholder matching the `cosign.pub` pattern.

The `promote-rpm.yml` and `promote-deb.yml` workflows already guard against this — they check for `BEGIN PGP PUBLIC KEY BLOCK` and exit with `ERROR: lts.asc is still a placeholder` until a real key is committed.

Generation instructions are inline in the placeholder and cross-referenced to `docs/ops/production-deployment.md §4.1`.