### PR TITLE
chore: move verify.sh to repo root, remove local-testing/

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Requires Docker Compose v2, `curl`, `jq`.
 ```bash
 git clone https://github.com/no42-org/packyard.git
 cd packyard
-bash local-testing/verify.sh
+bash verify.sh
 ```
 
 See [Getting Started](https://no42-org.github.io/packyard/latest/getting-started/quick-start/) for the full walkthrough.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -88,7 +88,7 @@ curl -s http://localhost:9090/metrics | grep packyard_auth
 ## 5. Run the verification suite
 
 ```bash
-bash local-testing/verify.sh
+bash verify.sh
 ```
 
 Expected output: all tests passed, 0 failed.
@@ -96,7 +96,7 @@ Expected output: all tests passed, 0 failed.
 The script also supports running against a remote production deployment:
 
 ```bash
-bash local-testing/verify.sh --base-url https://pkg.example.org --test-key <key>
+bash verify.sh --base-url https://pkg.example.org --test-key <key>
 ```
 
 ## 6. Tear down

--- a/docs/ops/manual-test-plan.md
+++ b/docs/ops/manual-test-plan.md
@@ -450,7 +450,7 @@ docker compose -f compose.yml -f compose.override.ci.yml down
 
 ## What verify.sh Covers vs This Plan
 
-`local-testing/verify.sh` is a fast automated smoke test (12 checks, ~60s). This plan goes deeper:
+`verify.sh` is a fast automated smoke test (12 checks, ~60s). This plan goes deeper:
 
 | Scenario | verify.sh | This plan |
 |----------|-----------|-----------|

--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -343,7 +343,7 @@ Run from any machine with network access to the deployment. Requires the subscri
 # Clone the repo locally if needed
 git clone <packyard-repo> packyard && cd packyard
 
-bash local-testing/verify.sh \
+bash verify.sh \
   --base-url https://pkg.example.org \
   --test-key "$KEY" \
   --test-component core

--- a/verify.sh
+++ b/verify.sh
@@ -3,13 +3,13 @@
 #
 # Usage:
 #   Local (full suite, starts stack):
-#     bash local-testing/verify.sh
+#     bash verify.sh
 #
 #   Local (stack already running):
-#     bash local-testing/verify.sh --skip-stack
+#     bash verify.sh --skip-stack
 #
 #   Remote smoke (read-only, no admin API):
-#     bash local-testing/verify.sh \
+#     bash verify.sh \
 #       --base-url https://pkg.example.org \
 #       --test-key "$KEY" \
 #       --test-component core


### PR DESCRIPTION
`local-testing/` only contained `verify.sh` (the `.env` was gitignored). Moved the script to the repo root and updated all references.

**Changed:**
- `local-testing/verify.sh` → `verify.sh`
- Self-referencing usage comments in `verify.sh`
- `README.md`, `docs/getting-started/quick-start.md`, `docs/ops/production-deployment.md`, `docs/ops/manual-test-plan.md`