### PR TITLE
feat(auth): add component visibility — public components bypass auth

### DIFF
--- a/auth/cmd/server/main.go
+++ b/auth/cmd/server/main.go
@@ -50,6 +50,8 @@ func main() {
 		os.Exit(1)
 	}
 	componentList := cfg.ComponentList()
+	publicComponents := cfg.PublicComponents()
+	compVisibility := cfg.ComponentVisibility()
 	logger.Info("loaded components", slog.String("components", componentList))
 
 	dbPath := os.Getenv("DB_PATH")
@@ -73,17 +75,19 @@ func main() {
 	})
 
 	forwardAuth := &handler.ForwardAuthHandler{
-		Store:           st,
-		Logger:          logger,
-		ValidComponents: validComponents,
+		Store:            st,
+		Logger:           logger,
+		ValidComponents:  validComponents,
+		PublicComponents: publicComponents,
 	}
 	r.Get("/auth", forwardAuth.ServeHTTP)
 
 	keys := &handler.KeysHandler{
-		Store:              st,
-		Logger:             logger,
-		ValidComponents:    validComponents,
-		ValidComponentList: componentList,
+		Store:               st,
+		Logger:              logger,
+		ValidComponents:     validComponents,
+		ValidComponentList:  componentList,
+		ComponentVisibility: compVisibility,
 	}
 	r.Post("/api/v1/keys", keys.Create)
 	r.Get("/api/v1/keys", keys.List)

--- a/auth/internal/config/config.go
+++ b/auth/internal/config/config.go
@@ -11,7 +11,8 @@ import (
 )
 
 type ComponentConfig struct {
-	Name string `yaml:"name"`
+	Name       string `yaml:"name"`
+	Visibility string `yaml:"visibility"` // "public" | "private" (default: "private")
 }
 
 type Config struct {
@@ -45,6 +46,35 @@ func (c *Config) ComponentList() string {
 	return strings.Join(c.ComponentNames(), ", ")
 }
 
+// PublicComponents returns the set of component names whose visibility is "public".
+func (c *Config) PublicComponents() map[string]bool {
+	set := make(map[string]bool)
+	for _, comp := range c.Components {
+		if name := strings.TrimSpace(comp.Name); name != "" && comp.Visibility == "public" {
+			set[name] = true
+		}
+	}
+	return set
+}
+
+// ComponentVisibility returns a map of component name to visibility string.
+// Components with no visibility set default to "private".
+func (c *Config) ComponentVisibility() map[string]string {
+	m := make(map[string]string, len(c.Components))
+	for _, comp := range c.Components {
+		name := strings.TrimSpace(comp.Name)
+		if name == "" {
+			continue
+		}
+		vis := comp.Visibility
+		if vis == "" {
+			vis = "private"
+		}
+		m[name] = vis
+	}
+	return m
+}
+
 // Load reads and parses the YAML config file at path.
 // Returns an error if the file cannot be read, is not valid YAML, or defines no components.
 func Load(path string) (*Config, error) {
@@ -56,10 +86,24 @@ func Load(path string) (*Config, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
+	hasValid := false
+	seen := map[string]bool{}
 	for _, comp := range cfg.Components {
-		if strings.TrimSpace(comp.Name) != "" {
-			return &cfg, nil
+		name := strings.TrimSpace(comp.Name)
+		if name == "" {
+			continue
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("config %s: duplicate component name %q", path, name)
+		}
+		seen[name] = true
+		hasValid = true
+		if vis := comp.Visibility; vis != "" && vis != "public" && vis != "private" {
+			return nil, fmt.Errorf("config %s: component %q has invalid visibility %q (must be \"public\" or \"private\")", path, comp.Name, vis)
 		}
 	}
-	return nil, fmt.Errorf("config %s: no components defined", path)
+	if !hasValid {
+		return nil, fmt.Errorf("config %s: no components defined", path)
+	}
+	return &cfg, nil
 }

--- a/auth/internal/config/config_test.go
+++ b/auth/internal/config/config_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "packyard-*.yml")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestLoad_DefaultVisibilityIsPrivate(t *testing.T) {
+	path := writeConfig(t, "components:\n  - name: core\n")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	vis := cfg.ComponentVisibility()
+	if got := vis["core"]; got != "private" {
+		t.Errorf("expected visibility \"private\" for core, got %q", got)
+	}
+}
+
+func TestLoad_InvalidVisibilityRejected(t *testing.T) {
+	path := writeConfig(t, "components:\n  - name: core\n    visibility: restricted\n")
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid visibility, got nil")
+	}
+}
+
+func TestPublicComponents_ReturnsOnlyPublic(t *testing.T) {
+	path := writeConfig(t, `components:
+  - name: core
+    visibility: public
+  - name: minion
+    visibility: private
+  - name: sentinel
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	pub := cfg.PublicComponents()
+	if !pub["core"] {
+		t.Error("expected core in PublicComponents")
+	}
+	if pub["minion"] {
+		t.Error("expected minion NOT in PublicComponents")
+	}
+	if pub["sentinel"] {
+		t.Error("expected sentinel NOT in PublicComponents (no visibility = private)")
+	}
+}
+
+func TestComponentVisibility_AllValues(t *testing.T) {
+	path := writeConfig(t, `components:
+  - name: core
+    visibility: public
+  - name: minion
+    visibility: private
+  - name: sentinel
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	vis := cfg.ComponentVisibility()
+	cases := map[string]string{
+		"core":     "public",
+		"minion":   "private",
+		"sentinel": "private",
+	}
+	for comp, want := range cases {
+		if got := vis[comp]; got != want {
+			t.Errorf("component %q: expected visibility %q, got %q", comp, want, got)
+		}
+	}
+}
+
+func TestLoad_NoComponents_Error(t *testing.T) {
+	path := writeConfig(t, "components:\n")
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for empty components, got nil")
+	}
+}
+
+func TestLoad_WhitespaceOnlyNameSkipped(t *testing.T) {
+	path := writeConfig(t, "components:\n  - name: \"  \"\n  - name: core\n")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := cfg.ComponentVisibility()["  "]; ok {
+		t.Error("whitespace-only name should not appear in ComponentVisibility")
+	}
+	if _, ok := cfg.ComponentVisibility()["core"]; !ok {
+		t.Error("expected core in ComponentVisibility")
+	}
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "nonexistent.yml"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/auth/internal/handler/forward_auth.go
+++ b/auth/internal/handler/forward_auth.go
@@ -15,9 +15,10 @@ import (
 // ForwardAuthHandler validates subscriber credentials for Traefik forwardAuth.
 // GET /auth — returns 200 (allow), 401 (deny), or 503 (error/fail-closed).
 type ForwardAuthHandler struct {
-	Store           store.KeyStore
-	Logger          *slog.Logger
-	ValidComponents map[string]bool // set for O(1) membership checks; nil treated as deny-all
+	Store            store.KeyStore
+	Logger           *slog.Logger
+	ValidComponents  map[string]bool // set for O(1) membership checks; nil treated as deny-all
+	PublicComponents map[string]bool // components that bypass credential checking
 }
 
 // ServeHTTP implements http.Handler.
@@ -29,6 +30,23 @@ func (h *ForwardAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		metrics.RequestDuration.Observe(time.Since(start).Seconds())
 	}()
 
+	// Resolve component to check for public bypass before any credential work.
+	requestedComponent, ok := extractComponent(r.Header.Get("X-Forwarded-Uri"))
+	if !ok {
+		metrics.RequestsTotal.WithLabelValues("denied").Inc()
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	// Public components bypass credential checking entirely.
+	if h.PublicComponents[requestedComponent] {
+		h.Logger.Info("public component access allowed", slog.String("component", requestedComponent))
+		metrics.RequestsTotal.WithLabelValues("allowed-public").Inc()
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// Private component: require valid credentials.
 	// Parse HTTP Basic Auth — r.BasicAuth() handles RFC 7235 decoding correctly.
 	// The username is ignored; the password IS the subscription key value.
 	_, password, ok := r.BasicAuth()
@@ -52,8 +70,14 @@ func (h *ForwardAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requestedComponent, ok := extractComponent(r.Header.Get("X-Forwarded-Uri"))
-	if !ok || !h.ValidComponents[requestedComponent] || key.Component != requestedComponent {
+	// 404 only visible to authenticated callers — prevents component enumeration by unauthenticated actors.
+	if !h.ValidComponents[requestedComponent] {
+		metrics.RequestsTotal.WithLabelValues("denied").Inc()
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if key.Component != requestedComponent {
 		metrics.RequestsTotal.WithLabelValues("denied").Inc()
 		w.WriteHeader(http.StatusUnauthorized)
 		return

--- a/auth/internal/handler/forward_auth_test.go
+++ b/auth/internal/handler/forward_auth_test.go
@@ -74,8 +74,10 @@ func basicAuthHeader(key string) string {
 
 func newTestHandler(s store.KeyStore) *ForwardAuthHandler {
 	return &ForwardAuthHandler{
-		Store:  s,
-		Logger: slog.Default(),
+		Store:            s,
+		Logger:           slog.Default(),
+		ValidComponents:  map[string]bool{"core": true, "minion": true},
+		PublicComponents: map[string]bool{},
 	}
 }
 
@@ -246,5 +248,123 @@ func TestForwardAuth_StoreError(t *testing.T) {
 	}
 	if w.Body.Len() != 0 {
 		t.Errorf("expected empty body, got %q", w.Body.String())
+	}
+}
+
+func TestForwardAuth_PublicComponent_NoCreds(t *testing.T) {
+	h := &ForwardAuthHandler{
+		Store:            &mockStore{},
+		Logger:           slog.Default(),
+		ValidComponents:  map[string]bool{"core": true, "minion": true},
+		PublicComponents: map[string]bool{"core": true},
+	}
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for public component with no creds, got %d", w.Code)
+	}
+}
+
+func TestForwardAuth_PublicComponent_WithCreds(t *testing.T) {
+	// Credentials are present but bypassed entirely — store is never consulted.
+	h := &ForwardAuthHandler{
+		Store: &mockStore{
+			getByValueFn: func(_ context.Context, _ string) (*store.Key, error) {
+				t.Fatal("GetByValue should not be called for public component")
+				return nil, nil
+			},
+		},
+		Logger:           slog.Default(),
+		ValidComponents:  map[string]bool{"core": true, "minion": true},
+		PublicComponents: map[string]bool{"core": true},
+	}
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.Header.Set("Authorization", basicAuthHeader(validKey))
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for public component with any creds, got %d", w.Code)
+	}
+}
+
+func TestForwardAuth_PublicComponent_MalformedAuth(t *testing.T) {
+	// Malformed Authorization header is also bypassed for public components.
+	h := &ForwardAuthHandler{
+		Store: &mockStore{
+			getByValueFn: func(_ context.Context, _ string) (*store.Key, error) {
+				t.Fatal("GetByValue should not be called for public component")
+				return nil, nil
+			},
+		},
+		Logger:           slog.Default(),
+		ValidComponents:  map[string]bool{"core": true, "minion": true},
+		PublicComponents: map[string]bool{"core": true},
+	}
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.Header.Set("Authorization", "Bearer not-basic-auth")
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for public component with malformed auth, got %d", w.Code)
+	}
+}
+
+func TestForwardAuth_PrivateComponent_NoCreds(t *testing.T) {
+	h := &ForwardAuthHandler{
+		Store:            &mockStore{},
+		Logger:           slog.Default(),
+		ValidComponents:  map[string]bool{"core": true, "minion": true},
+		PublicComponents: map[string]bool{"core": true},
+	}
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.Header.Set("X-Forwarded-Uri", "/rpm/minion/2025/el9-x86_64/")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for private component with no creds, got %d", w.Code)
+	}
+}
+
+func TestForwardAuth_NonexistentComponent(t *testing.T) {
+	// 404 is only visible to authenticated callers — credential check runs first.
+	h := newTestHandler(&mockStore{
+		getByValueFn: func(_ context.Context, value string) (*store.Key, error) {
+			return &store.Key{ID: value, Component: "core", Active: true}, nil
+		},
+	})
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.Header.Set("Authorization", basicAuthHeader(validKey))
+	req.Header.Set("X-Forwarded-Uri", "/rpm/unknown/2025/el9-x86_64/")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for nonexistent component (authenticated), got %d", w.Code)
+	}
+}
+
+func TestForwardAuth_NonexistentComponent_NoCreds(t *testing.T) {
+	// Unauthenticated callers get 401 for unknown components — prevents component enumeration.
+	h := newTestHandler(&mockStore{
+		getByValueFn: func(_ context.Context, _ string) (*store.Key, error) {
+			t.Fatal("GetByValue should not be called when no Authorization header")
+			return nil, nil
+		},
+	})
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.Header.Set("X-Forwarded-Uri", "/rpm/unknown/2025/el9-x86_64/")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for nonexistent component with no creds, got %d", w.Code)
 	}
 }

--- a/auth/internal/handler/keys.go
+++ b/auth/internal/handler/keys.go
@@ -15,10 +15,28 @@ import (
 
 // KeysHandler handles admin API key management endpoints (Epic 3).
 type KeysHandler struct {
-	Store               store.KeyStore
-	Logger              *slog.Logger
-	ValidComponents     map[string]bool // set for O(1) membership checks
-	ValidComponentList  string          // pre-formatted for error messages
+	Store              store.KeyStore
+	Logger             *slog.Logger
+	ValidComponents    map[string]bool   // set for O(1) membership checks
+	ValidComponentList string            // pre-formatted for error messages
+	ComponentVisibility map[string]string // component name → "public" | "private"
+}
+
+// keyResponse wraps a store.Key with the component's current visibility, computed at
+// serialisation time from ComponentVisibility so it is never stored in the database.
+type keyResponse struct {
+	*store.Key
+	ComponentVisibility string `json:"component_visibility"`
+}
+
+// wrapKey converts a store.Key into a keyResponse, defaulting visibility to "private"
+// when the component is absent from the map (e.g. component removed from config).
+func (h *KeysHandler) wrapKey(k *store.Key) *keyResponse {
+	vis := h.ComponentVisibility[k.Component]
+	if vis == "" {
+		vis = "private"
+	}
+	return &keyResponse{Key: k, ComponentVisibility: vis}
 }
 
 // createKeyRequest is the JSON body for POST /api/v1/keys.
@@ -59,7 +77,7 @@ func (h *KeysHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(key)
+	_ = json.NewEncoder(w).Encode(h.wrapKey(key))
 }
 
 // Delete handles DELETE /api/v1/keys/{id} — revokes a key immediately.
@@ -115,14 +133,14 @@ func (h *KeysHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// nil slice encodes as JSON null — return [] for empty result (AC4).
-	if keys == nil {
-		keys = []*store.Key{}
+	wrapped := make([]*keyResponse, len(keys))
+	for i, k := range keys {
+		wrapped[i] = h.wrapKey(k)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(keys)
+	_ = json.NewEncoder(w).Encode(wrapped)
 }
 
 // Create handles POST /api/v1/keys — provisions a new component-scoped subscription key.
@@ -149,5 +167,5 @@ func (h *KeysHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(key)
+	_ = json.NewEncoder(w).Encode(h.wrapKey(key))
 }

--- a/auth/internal/handler/keys_test.go
+++ b/auth/internal/handler/keys_test.go
@@ -25,16 +25,17 @@ const testKeyID = "aabbccdd" + "aabbccdd" + "aabbccdd" + "aabbccdd" +
 func newTestKeysHandler(s store.KeyStore) *KeysHandler {
 	testCfg := &config.Config{
 		Components: []config.ComponentConfig{
-			{Name: "core"},
+			{Name: "core", Visibility: "public"},
 			{Name: "minion"},
 			{Name: "sentinel"},
 		},
 	}
 	return &KeysHandler{
-		Store:              s,
-		Logger:             slog.Default(),
-		ValidComponents:    testCfg.ComponentSet(),
-		ValidComponentList: testCfg.ComponentList(),
+		Store:               s,
+		Logger:              slog.Default(),
+		ValidComponents:     testCfg.ComponentSet(),
+		ValidComponentList:  testCfg.ComponentList(),
+		ComponentVisibility: testCfg.ComponentVisibility(),
 	}
 }
 
@@ -603,5 +604,109 @@ func TestDelete_GetByIDStoreError(t *testing.T) {
 	}
 	if w.Body.Len() != 0 {
 		t.Errorf("expected empty body, got %q", w.Body.String())
+	}
+}
+
+// keyWithVisibility mirrors keyResponse for decoding in visibility tests.
+type keyWithVisibility struct {
+	store.Key
+	ComponentVisibility string `json:"component_visibility"`
+}
+
+// TestCreate_ComponentVisibility_Public — Create for a public component includes component_visibility="public".
+func TestCreate_ComponentVisibility_Public(t *testing.T) {
+	h := newTestKeysHandler(&mockStore{
+		createKeyFn: func(_ context.Context, component, label string, _ *time.Time) (*store.Key, error) {
+			return makeKey(component, label), nil
+		},
+	})
+	w := postKeys(h, `{"component":"core","label":"test"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+	var got keyWithVisibility
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ComponentVisibility != "public" {
+		t.Errorf("expected component_visibility=public, got %q", got.ComponentVisibility)
+	}
+}
+
+// TestGet_ComponentVisibility_Private — Get for a private component includes component_visibility="private".
+func TestGet_ComponentVisibility_Private(t *testing.T) {
+	h := newTestKeysHandler(&mockStore{
+		getByIDFn: func(_ context.Context, _ string) (*store.Key, error) {
+			return makeKey("minion", "sub"), nil
+		},
+	})
+	w := inspectKey(h, testKeyID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var got keyWithVisibility
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ComponentVisibility != "private" {
+		t.Errorf("expected component_visibility=private, got %q", got.ComponentVisibility)
+	}
+}
+
+// TestList_ComponentVisibility — List returns correct visibility for each key's component.
+func TestList_ComponentVisibility(t *testing.T) {
+	h := newTestKeysHandler(&mockStore{
+		listKeysFn: func(_ context.Context, _ string) ([]*store.Key, error) {
+			return []*store.Key{makeKey("core", "A"), makeKey("minion", "B")}, nil
+		},
+	})
+	w := getKeys(h, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var got []keyWithVisibility
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(got))
+	}
+	for _, k := range got {
+		switch k.Component {
+		case "core":
+			if k.ComponentVisibility != "public" {
+				t.Errorf("core: expected component_visibility=public, got %q", k.ComponentVisibility)
+			}
+		case "minion":
+			if k.ComponentVisibility != "private" {
+				t.Errorf("minion: expected component_visibility=private, got %q", k.ComponentVisibility)
+			}
+		}
+	}
+}
+
+// TestGet_ComponentVisibility_RemovedComponent — key whose component is absent from the map defaults to "private".
+func TestGet_ComponentVisibility_RemovedComponent(t *testing.T) {
+	h := &KeysHandler{
+		Store:               &mockStore{
+			getByIDFn: func(_ context.Context, _ string) (*store.Key, error) {
+				return makeKey("removed", "orphan"), nil
+			},
+		},
+		Logger:              slog.Default(),
+		ValidComponents:     map[string]bool{"core": true},
+		ValidComponentList:  "core",
+		ComponentVisibility: map[string]string{"core": "public"},
+	}
+	w := inspectKey(h, testKeyID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var got keyWithVisibility
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ComponentVisibility != "private" {
+		t.Errorf("removed component: expected component_visibility=private, got %q", got.ComponentVisibility)
 	}
 }

--- a/compose.override.ci.yml
+++ b/compose.override.ci.yml
@@ -23,3 +23,5 @@ services:
     ports:
       - "127.0.0.1:8080:8080"   # admin API — key seeding from CI runner
       - "127.0.0.1:9090:9090"   # Prometheus metrics — observability.sh AC1
+    volumes:
+      - ./config/packyard.ci.yml:/etc/packyard/packyard.yml:ro

--- a/config/packyard.ci.yml
+++ b/config/packyard.ci.yml
@@ -1,0 +1,9 @@
+# CI fixture config — mounted by compose.override.ci.yml.
+# Provides a mixed-visibility setup so verify.sh can exercise both code paths:
+#   core:   public  — unauthenticated access allowed (--public-component core)
+#   minion: private — credentials required (--test-component minion)
+components:
+  - name: core
+    visibility: public
+  - name: minion
+    visibility: private

--- a/config/packyard.yml
+++ b/config/packyard.yml
@@ -1,5 +1,11 @@
 # Packyard component configuration.
 # Each entry defines an LTS component that subscribers can be scoped to.
 # Add or remove components here and restart the auth service to apply changes.
+#
+# Fields:
+#   name       (required) — component identifier used in RPM/DEB/OCI paths
+#   visibility (optional) — "public" | "private" (default: "private")
+#              public:  requests are allowed without credentials
+#              private: credentials are required and scope-checked
 components:
   - name: core

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -6,6 +6,7 @@
 |---------|-------------|---------|
 | TLS cert not issuing after first `docker compose up` | DNS not propagated, or port 443 not open | [TLS certificate not issuing](#tls-certificate-not-issuing) |
 | Subscribers getting `401` on a key that should work | Key scope mismatch, revoked key, or auth service down | [Subscribers getting 401](#subscribers-getting-401) |
+| Subscribers getting `404` on a path that should exist | Component name in URL not listed in `config/packyard.yml` | [Subscribers getting 401](#subscribers-getting-401) |
 | All requests returning `503` | Auth service is down (fail-closed by design) | [All requests returning 503](#all-requests-returning-503) |
 | Admin API returns connection refused / `000` | SSH tunnel not open | [Admin API unreachable](#admin-api-unreachable) |
 | Container shows `unhealthy` or `exited` | Crash loop, disk full, or DB permissions | [Container unhealthy or crashing](#container-unhealthy-or-crashing) |
@@ -98,6 +99,21 @@ Each key is scoped to a single component (as defined in `config/packyard.yml`). 
 
 ```bash
 curl -s http://127.0.0.1:8088/api/v1/keys | jq '.[] | {id, component, label, active}'
+```
+
+**Step 4 — Is the component marked public?**
+
+If a component has `visibility: public` in `config/packyard.yml`, the auth service allows requests to its paths without inspecting credentials. Keys for public components are valid but are not checked during auth — any request, authenticated or not, returns `200`. If a subscriber reports getting `401` on a public component path, confirm the auth service loaded the updated config:
+
+```bash
+docker compose logs auth | grep "loaded components"
+# expect the public component to appear in the list
+```
+
+If the config was changed but the service was not restarted, restart it:
+
+```bash
+docker compose restart auth
 ```
 
 ---

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -28,10 +28,24 @@ Valid component names are defined in `config/packyard.yml` and loaded by the aut
 # config/packyard.yml
 components:
   - name: core
-  - name: minion   # add as needed
+    visibility: private   # default; credentials required
+  - name: minion          # add as needed
+  - name: enterprise
+    visibility: public    # no credentials required for this component
 ```
 
 A key scoped to `core` grants access only to `/rpm/core/`, `/deb/core/`, and `lts-core` OCI paths. Cross-component access is denied — a `core` key cannot access `/rpm/minion/`. The component name in the key must match the path segment exactly.
+
+### Component visibility
+
+Each component has a `visibility` setting:
+
+| Value | Behaviour |
+|-------|-----------|
+| `private` (default) | Credentials are required and scope-checked |
+| `public` | Requests are allowed without credentials — credentials, if present, are ignored |
+
+Public components are useful for freely distributable software. The auth service returns `200` for any request to a public component path, regardless of whether credentials are present or valid.
 
 ## Examples
 
@@ -51,9 +65,12 @@ curl -s -X POST http://127.0.0.1:8088/api/v1/keys \
   "component": "core",
   "label": "Acme Corp",
   "active": true,
-  "created_at": "2025-01-01T00:00:00Z"
+  "created_at": "2025-01-01T00:00:00Z",
+  "component_visibility": "private"
 }
 ```
+
+`component_visibility` reflects the current visibility of the key's component as defined in `config/packyard.yml`. It is computed at response time — not stored in the database. If the component has been removed from config since the key was created, this field defaults to `"private"`.
 
 **List keys:**
 

--- a/verify.sh
+++ b/verify.sh
@@ -25,6 +25,7 @@ METRICS_URL="http://localhost:9090"
 SKIP_STACK=false
 TEST_KEY=""
 TEST_COMPONENT="core"
+PUBLIC_COMPONENT=""
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 usage() {
@@ -46,8 +47,9 @@ Options:
   --metrics-url URL     Prometheus metrics URL, local mode only (default: http://localhost:9090)
   --skip-stack          Skip docker compose up (stack already running)
   --test-key KEY        Subscriber key for remote mode (required when --base-url is not localhost)
-  --test-component NAME Component scope of the test key — must match a name in config/packyard.yml (default: core)
-  -h, --help            Show this help and exit
+  --test-component NAME   Component scope of the test key — must match a name in config/packyard.yml (default: core)
+  --public-component NAME Component configured with visibility: public; enables unauthenticated-access tests (default: "")
+  -h, --help              Show this help and exit
 
 Examples:
   bash verify.sh
@@ -64,7 +66,8 @@ while [[ $# -gt 0 ]]; do
     --metrics-url)    METRICS_URL="$2";    shift 2 ;;
     --skip-stack)     SKIP_STACK=true;     shift ;;
     --test-key)       TEST_KEY="$2";       shift 2 ;;
-    --test-component) TEST_COMPONENT="$2"; shift 2 ;;
+    --test-component)    TEST_COMPONENT="$2";    shift 2 ;;
+    --public-component) PUBLIC_COMPONENT="$2";  shift 2 ;;
     *) echo "Unknown option: $1" >&2; echo "Run 'bash verify.sh --help' for usage." >&2; exit 1 ;;
   esac
 done
@@ -224,6 +227,18 @@ if [[ "$MODE" == "local" ]]; then
     MINION_KEY=""
   fi
 
+  if [[ -n "$PUBLIC_COMPONENT" ]]; then
+    RESPONSE=$(curl -s -X POST "$ADMIN_URL/api/v1/keys" \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -n --arg comp "$PUBLIC_COMPONENT" '{"component":$comp,"label":"verify-public"}')" || true)
+    PUB_KEY=$(echo "$RESPONSE" | jq -r '.id // empty')
+    if [[ -n "$PUB_KEY" ]]; then
+      info "public component ($PUBLIC_COMPONENT) key created: ${PUB_KEY:0:16}..."
+    else
+      info "public component ($PUBLIC_COMPONENT) key creation failed (non-fatal): $RESPONSE"
+    fi
+  fi
+
   TEST_KEY="$CORE_KEY"
   TEST_COMPONENT="core"
   if [[ -n "$MINION_KEY" ]]; then
@@ -250,12 +265,47 @@ STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/gpg/cosign.pub" || tr
   && pass "/gpg/cosign.pub → 200" \
   || fail "/gpg/cosign.pub → $STATUS (expected 200)"
 
-# Negative: authenticated route without credentials → 401
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-  "$BASE_URL/rpm/$TEST_COMPONENT/2025/el9-x86_64/" || true)
-[[ "$STATUS" == "401" ]] \
-  && pass "/rpm/$TEST_COMPONENT/ (no creds) → 401" \
-  || fail "/rpm/$TEST_COMPONENT/ (no creds) → $STATUS (expected 401)"
+# Negative: authenticated route without credentials → 401 (skip when TEST_COMPONENT is public)
+if [[ "$TEST_COMPONENT" != "$PUBLIC_COMPONENT" || -z "$PUBLIC_COMPONENT" ]]; then
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    "$BASE_URL/rpm/$TEST_COMPONENT/2025/el9-x86_64/" || true)
+  [[ "$STATUS" == "401" ]] \
+    && pass "/rpm/$TEST_COMPONENT/ (no creds) → 401" \
+    || fail "/rpm/$TEST_COMPONENT/ (no creds) → $STATUS (expected 401)"
+else
+  info "/rpm/$TEST_COMPONENT/ no-creds check skipped ($TEST_COMPONENT is a public component)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Public access  (skipped when --public-component is not set)
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ -n "$PUBLIC_COMPONENT" ]]; then
+  section "Public access ($PUBLIC_COMPONENT)"
+  BAD_KEY_PUB=$(printf '%064s' "" | tr ' ' 'x')
+
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    "$BASE_URL/rpm/$PUBLIC_COMPONENT/2025/el9-x86_64/" || true)
+  [[ "$STATUS" == "200" ]] \
+    && pass "/rpm/$PUBLIC_COMPONENT/ (no creds) → 200" \
+    || fail "/rpm/$PUBLIC_COMPONENT/ (no creds) → $STATUS (expected 200)"
+
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -u "subscriber:${BAD_KEY_PUB}" "$BASE_URL/rpm/$PUBLIC_COMPONENT/2025/el9-x86_64/" || true)
+  [[ "$STATUS" == "200" ]] \
+    && pass "/rpm/$PUBLIC_COMPONENT/ (invalid creds) → 200" \
+    || fail "/rpm/$PUBLIC_COMPONENT/ (invalid creds) → $STATUS (expected 200)"
+
+  # Private component must still enforce auth even when a public component is configured.
+  if [[ -n "$CROSS_COMPONENT" ]]; then
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+      "$BASE_URL/rpm/$CROSS_COMPONENT/2025/el9-x86_64/" || true)
+    [[ "$STATUS" == "401" ]] \
+      && pass "/rpm/$CROSS_COMPONENT/ (no creds, private) → 401" \
+      || fail "/rpm/$CROSS_COMPONENT/ (no creds, private) → $STATUS (expected 401)"
+  else
+    info "Private component no-creds check skipped (no cross-component available)"
+  fi
+fi
 
 # ─────────────────────────────────────────────────────────────────────────────
 # ForwardAuth allow / deny  (shared)
@@ -481,15 +531,23 @@ if [[ "$MODE" == "local" ]]; then
 
   METRICS=$(curl -s "$METRICS_URL/metrics" || true)
   if echo "$METRICS" | grep -q "packyard_auth_requests_total"; then
-    ALLOWED=$(echo "$METRICS" | grep 'packyard_auth_requests_total{status="allowed"}' | awk '{print $2}' || true)
-    DENIED=$(echo  "$METRICS" | grep 'packyard_auth_requests_total{status="denied"}'  | awk '{print $2}' || true)
-    pass "packyard_auth_requests_total present — allowed=${ALLOWED:-?} denied=${DENIED:-?}"
+    ALLOWED=$(echo "$METRICS"         | grep 'packyard_auth_requests_total{status="allowed"}'        | awk '{print $2}' || true)
+    ALLOWED_PUB=$(echo "$METRICS"     | grep 'packyard_auth_requests_total{status="allowed-public"}' | awk '{print $2}' || true)
+    DENIED=$(echo  "$METRICS"         | grep 'packyard_auth_requests_total{status="denied"}'         | awk '{print $2}' || true)
+    pass "packyard_auth_requests_total present — allowed=${ALLOWED:-?} allowed-public=${ALLOWED_PUB:-?} denied=${DENIED:-?}"
+    if [[ -n "$PUBLIC_COMPONENT" ]]; then
+      if [[ -n "${ALLOWED_PUB:-}" ]]; then
+        pass "allowed-public counter present (${ALLOWED_PUB})"
+      else
+        fail "allowed-public counter missing — expected after public component requests"
+      fi
+    fi
   else
     fail "packyard_auth_requests_total not found in metrics"
     ALLOWED=""
   fi
 
-  # Counter increment: snapshot before/after one allowed request
+  # Counter increment: snapshot before/after one allowed request (uses minion key — private component)
   if [[ -n "${ALLOWED:-}" && -n "$MINION_KEY" ]]; then
     BEFORE="$ALLOWED"
     curl -s -u "subscriber:${MINION_KEY}" \
@@ -561,6 +619,8 @@ if [[ "$MODE" == "local" ]]; then
   echo "--- Cleanup ---"
   [[ -n "$MINION_KEY" ]] && \
     curl -s -X DELETE "$ADMIN_URL/api/v1/keys/${MINION_KEY}" > /dev/null || true
+  [[ -n "${PUB_KEY:-}" ]] && \
+    curl -s -X DELETE "$ADMIN_URL/api/v1/keys/${PUB_KEY}" > /dev/null || true
   info "Test keys revoked"
 fi
 


### PR DESCRIPTION
## Summary

- Components can now declare `visibility: public` in `packyard.yml`; any request to a public component path returns `200` regardless of credentials
- `!ValidComponents` 404 check moved to after credential verification so unauthenticated callers cannot enumerate component names (get `401` instead of `404`)
- Keys API responses now include `component_visibility` computed from config at response time

## Changes

**Config (`config.go`, `config_test.go`)**
- `ComponentConfig.Visibility` field (`public` | `private`, default `private`)
- `PublicComponents()` and `ComponentVisibility()` methods
- `Load()` validates visibility values and rejects duplicate component names
- Unit tests for all new methods and error paths

**ForwardAuth (`forward_auth.go`, `forward_auth_test.go`)**
- Public-component early return before any credential parsing
- 404 for unknown components gated behind successful credential verification (anti-enumeration)
- New tests: authenticated unknown component → 404, unauthenticated unknown → 401, malformed auth on public component → 200

**Keys API (`keys.go`, `keys_test.go`)**
- `keyResponse` wrapper embeds `*store.Key` + `component_visibility` string
- `List`, `Get`, and `Create` all serialise via `wrapKey()`; defaults to `"private"` when component not in config

**Wiring (`main.go`)**
- Builds and injects `PublicComponents` and `ComponentVisibility` maps

**CI fixtures**
- `config/packyard.ci.yml`: `core=public`, `minion=private`
- `compose.override.ci.yml`: mounts CI config over default

**verify.sh**
- `--public-component` flag with unauthenticated-access test section
- Shell injection fix: `jq -n --arg` replaces direct `$PUBLIC_COMPONENT` interpolation
- `PUB_KEY` cleanup added to teardown
- Private-component no-creds → 401 assertion in public-component test path

**Docs**
- `docs/reference/api.md`: `component_visibility` field documented; visibility table added
- `docs/ops/troubleshooting.md`: Step 4 added to "Subscribers getting 401" section

## Test plan

- [ ] `go test ./...` passes (all packages green)
- [ ] `verify.sh --local --public-component core` against a local stack with `packyard.ci.yml` mounted
- [ ] Public component path returns 200 with no credentials
- [ ] Public component path returns 200 with bad credentials
- [ ] Private component path still returns 401 with no credentials
- [ ] Unknown component returns 401 (unauthenticated) and 404 (authenticated)
- [ ] `GET /api/v1/keys` response includes `component_visibility` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)