### PR TITLE
refactor: rename year/YEAR/YEARS to series/SERIES throughout

### DIFF
--- a/.github/workflows/promote-deb.yml
+++ b/.github/workflows/promote-deb.yml
@@ -6,8 +6,8 @@ on:
       component:
         description: "LTS component name (as defined in config/packyard.yml)"
         required: true
-      year:
-        description: "LTS year (e.g. 2025)"
+      series:
+        description: "LTS series (e.g. 2025)"
         required: true
       distro:
         description: "Debian distro (bookworm|trixie|jammy|noble)"
@@ -50,7 +50,7 @@ jobs:
           AWS_ACCESS_KEY_ID=${{ secrets.RUSTFS_ACCESS_KEY }} \
           AWS_SECRET_ACCESS_KEY=${{ secrets.RUSTFS_SECRET_KEY }} \
             aws s3 sync \
-              "s3://staging/${{ inputs.component }}/${{ inputs.year }}/deb/${{ inputs.distro }}-amd64/" \
+              "s3://staging/${{ inputs.component }}/${{ inputs.series }}/deb/${{ inputs.distro }}-amd64/" \
               ./staging/ \
               --endpoint-url "$RUSTFS_ENDPOINT"
 
@@ -101,14 +101,14 @@ jobs:
       - name: Create Aptly snapshot on host
         env:
           COMPONENT: ${{ inputs.component }}
-          YEAR: ${{ inputs.year }}
+          SERIES: ${{ inputs.series }}
           DISTRO: ${{ inputs.distro }}
         run: |
           SNAPSHOT_NAME=$(ssh deploy@${{ secrets.HOST }} \
             "docker compose -f /opt/packyard/compose.yml exec -T \
-              -e COMPONENT='${COMPONENT}' -e YEAR='${YEAR}' -e DISTRO='${DISTRO}' \
+              -e COMPONENT='${COMPONENT}' -e SERIES='${SERIES}' -e DISTRO='${DISTRO}' \
               -e DEB_STAGE_DIR=/tmp/deb-stage \
-              aptly /scripts/create-snapshot.sh '${COMPONENT}' '${YEAR}' '${DISTRO}'")
+              aptly /scripts/create-snapshot.sh '${COMPONENT}' '${SERIES}' '${DISTRO}'")
           [ -n "${SNAPSHOT_NAME}" ] || { echo "ERROR: snapshot name is empty"; exit 1; }
           echo "SNAPSHOT_NAME=${SNAPSHOT_NAME}" >> "$GITHUB_ENV"
           echo "Created snapshot: ${SNAPSHOT_NAME}"
@@ -116,23 +116,23 @@ jobs:
       - name: Publish Aptly snapshot on host
         env:
           COMPONENT: ${{ inputs.component }}
-          YEAR: ${{ inputs.year }}
+          SERIES: ${{ inputs.series }}
           DISTRO: ${{ inputs.distro }}
         run: |
           ssh deploy@${{ secrets.HOST }} \
             "docker compose -f /opt/packyard/compose.yml exec -T aptly \
               /scripts/publish-snapshot.sh \
-              '${SNAPSHOT_NAME}' '${COMPONENT}' '${YEAR}' '${DISTRO}'"
+              '${SNAPSHOT_NAME}' '${COMPONENT}' '${SERIES}' '${DISTRO}'"
 
       - name: Smoke test — verify InRelease published to filesystem
         env:
           COMPONENT: ${{ inputs.component }}
-          YEAR: ${{ inputs.year }}
+          SERIES: ${{ inputs.series }}
           DISTRO: ${{ inputs.distro }}
         run: |
           ssh deploy@${{ secrets.HOST }} "
             docker compose -f /opt/packyard/compose.yml exec -T aptly \
-              test -f '/opt/aptly/public/${COMPONENT}/${YEAR}/dists/${DISTRO}/InRelease' \
+              test -f '/opt/aptly/public/${COMPONENT}/${SERIES}/dists/${DISTRO}/InRelease' \
               && echo 'SMOKE TEST PASS' \
               || { echo 'SMOKE TEST FAIL'; exit 1; }
           "
@@ -140,11 +140,11 @@ jobs:
       - name: Prune old snapshots
         env:
           COMPONENT: ${{ inputs.component }}
-          YEAR: ${{ inputs.year }}
+          SERIES: ${{ inputs.series }}
         run: |
           ssh deploy@${{ secrets.HOST }} \
             "docker compose -f /opt/packyard/compose.yml exec -T aptly \
-              /scripts/prune-snapshots.sh '${COMPONENT}' '${YEAR}'"
+              /scripts/prune-snapshots.sh '${COMPONENT}' '${SERIES}'"
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/promote-oci.yml
+++ b/.github/workflows/promote-oci.yml
@@ -6,8 +6,8 @@ on:
       component:
         description: "LTS component name (as defined in config/packyard.yml)"
         required: true
-      year:
-        description: "LTS year (e.g. 2025)"
+      series:
+        description: "LTS series (e.g. 2025)"
         required: true
 
 env:
@@ -16,7 +16,7 @@ env:
   ZOT_REGISTRY: localhost:5000
 
 concurrency:
-  group: oci-promote-${{ inputs.component }}-${{ inputs.year }}
+  group: oci-promote-${{ inputs.component }}-${{ inputs.series }}
   cancel-in-progress: false
 
 jobs:
@@ -58,7 +58,7 @@ jobs:
       - name: Download OCI archives from RustFS
         env:
           COMPONENT: ${{ inputs.component }}
-          YEAR: ${{ inputs.year }}
+          SERIES: ${{ inputs.series }}
           RUSTFS_ACCESS_KEY: ${{ secrets.RUSTFS_ACCESS_KEY }}
           RUSTFS_SECRET_KEY: ${{ secrets.RUSTFS_SECRET_KEY }}
         run: |
@@ -67,7 +67,7 @@ jobs:
             AWS_ACCESS_KEY_ID="${RUSTFS_ACCESS_KEY}" \
             AWS_SECRET_ACCESS_KEY="${RUSTFS_SECRET_KEY}" \
               aws s3 sync \
-                "s3://staging/${COMPONENT}/${YEAR}/oci/${arch}/" \
+                "s3://staging/${COMPONENT}/${SERIES}/oci/${arch}/" \
                 "./staging/${arch}/" \
                 --endpoint-url "$RUSTFS_ENDPOINT"
           done
@@ -98,39 +98,39 @@ jobs:
       - name: Push images to Zot
         env:
           COMPONENT: ${{ inputs.component }}
-          YEAR: ${{ inputs.year }}
+          SERIES: ${{ inputs.series }}
         run: |
           IMAGE_BASE="${ZOT_REGISTRY}/lts-${COMPONENT}"
           for arch in x86_64 arm64; do
             tarcount=$(ls ./staging/${arch}/*.tar 2>/dev/null | wc -l || echo 0)
             [ "$tarcount" -eq 1 ] || { echo "Expected exactly 1 .tar for ${arch}, found ${tarcount}"; exit 1; }
             tarfile=$(ls ./staging/${arch}/*.tar)
-            crane push "$tarfile" "${IMAGE_BASE}:${YEAR}-${arch}" --insecure
-            echo "Pushed: ${IMAGE_BASE}:${YEAR}-${arch}"
+            crane push "$tarfile" "${IMAGE_BASE}:${SERIES}-${arch}" --insecure
+            echo "Pushed: ${IMAGE_BASE}:${SERIES}-${arch}"
           done
 
       - name: Create multi-arch image index
         env:
           COMPONENT: ${{ inputs.component }}
-          YEAR: ${{ inputs.year }}
+          SERIES: ${{ inputs.series }}
         run: |
           IMAGE_BASE="${ZOT_REGISTRY}/lts-${COMPONENT}"
           crane index append \
-            --tag "${IMAGE_BASE}:${YEAR}" \
-            --manifest "${IMAGE_BASE}:${YEAR}-x86_64" \
-            --manifest "${IMAGE_BASE}:${YEAR}-arm64" \
+            --tag "${IMAGE_BASE}:${SERIES}" \
+            --manifest "${IMAGE_BASE}:${SERIES}-x86_64" \
+            --manifest "${IMAGE_BASE}:${SERIES}-arm64" \
             --insecure
-          echo "Index created: ${IMAGE_BASE}:${YEAR}"
+          echo "Index created: ${IMAGE_BASE}:${SERIES}"
 
       - name: Sign images with cosign (ephemeral)
         env:
           COMPONENT: ${{ inputs.component }}
-          YEAR: ${{ inputs.year }}
+          SERIES: ${{ inputs.series }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
           IMAGE_BASE="${ZOT_REGISTRY}/lts-${COMPONENT}"
-          for tag in "${YEAR}-x86_64" "${YEAR}-arm64" "${YEAR}"; do
+          for tag in "${SERIES}-x86_64" "${SERIES}-arm64" "${SERIES}"; do
             cosign sign \
               --key env://COSIGN_PRIVATE_KEY \
               --allow-insecure-registry \
@@ -143,7 +143,7 @@ jobs:
       - name: Verify cosign signature (sanity check)
         env:
           COMPONENT: ${{ inputs.component }}
-          YEAR: ${{ inputs.year }}
+          SERIES: ${{ inputs.series }}
         run: |
           grep -q 'BEGIN PUBLIC KEY' ./static/content/gpg/cosign.pub \
             || { echo "ERROR: cosign.pub is still a placeholder — replace with real key before promoting"; exit 1; }
@@ -152,7 +152,7 @@ jobs:
             --key ./static/content/gpg/cosign.pub \
             --allow-insecure-registry \
             --insecure-ignore-tlog \
-            "${IMAGE_BASE}:${YEAR}" \
+            "${IMAGE_BASE}:${SERIES}" \
             && echo "SIGNATURE VERIFIED" \
             || { echo "SIGNATURE VERIFICATION FAILED"; exit 1; }
 

--- a/.github/workflows/promote-rpm.yml
+++ b/.github/workflows/promote-rpm.yml
@@ -6,8 +6,8 @@ on:
       component:
         description: "LTS component name (as defined in config/packyard.yml)"
         required: true
-      year:
-        description: "LTS year (e.g. 2025)"
+      series:
+        description: "LTS series (e.g. 2025)"
         required: true
       os:
         description: "OS target (el8-x86_64|el9-x86_64|el10-x86_64|centos10-x86_64)"
@@ -51,7 +51,7 @@ jobs:
           AWS_ACCESS_KEY_ID=${{ secrets.RUSTFS_ACCESS_KEY }} \
           AWS_SECRET_ACCESS_KEY=${{ secrets.RUSTFS_SECRET_KEY }} \
             aws s3 sync \
-              "s3://staging/${{ inputs.component }}/${{ inputs.year }}/rpm/${{ inputs.os }}/" \
+              "s3://staging/${{ inputs.component }}/${{ inputs.series }}/rpm/${{ inputs.os }}/" \
               ./staging/ \
               --endpoint-url "$RUSTFS_ENDPOINT"
 
@@ -112,14 +112,14 @@ jobs:
         env:
           # P1: route inputs through env vars to avoid GHA text interpolation into remote shell
           COMPONENT: ${{ inputs.component }}
-          YEAR: ${{ inputs.year }}
+          SERIES: ${{ inputs.series }}
           OS: ${{ inputs.os }}
         run: |
           ssh deploy@${{ secrets.HOST }} "
             set -euo pipefail
             for f in /tmp/rpm-stage/*.rpm; do
               /opt/packyard/rpm/scripts/add-package.sh \"\$f\" \
-                '${COMPONENT}' '${YEAR}' '${OS}'
+                '${COMPONENT}' '${SERIES}' '${OS}'
             done
           "
 

--- a/aptly/scripts/create-snapshot.sh
+++ b/aptly/scripts/create-snapshot.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # create-snapshot.sh — create an immutable Aptly snapshot from staged DEBs
-# Usage: create-snapshot.sh <component> <year> <distro>
+# Usage: create-snapshot.sh <component> <series> <distro>
 # Example: create-snapshot.sh core 2025 bookworm
 #
 # Staged DEBs must be present in /tmp/deb-stage/ before calling this script.
@@ -8,11 +8,11 @@
 set -euo pipefail
 
 COMPONENT="${1:?component required (core|minion|sentinel)}"
-YEAR="${2:?year required (e.g. 2025)}"
+SERIES="${2:?series required (e.g. 2025)}"
 DISTRO="${3:?distro required (bookworm|trixie|jammy|noble)}"
 
-REPO_NAME="${COMPONENT}-${YEAR}"
-SNAPSHOT_NAME="${COMPONENT}-${YEAR}-$(date -u +%Y%m%dT%H%M%SZ)"
+REPO_NAME="${COMPONENT}-${SERIES}"
+SNAPSHOT_NAME="${COMPONENT}-${SERIES}-$(date -u +%Y%m%dT%H%M%SZ)"
 STAGE_DIR="${DEB_STAGE_DIR:-/tmp/deb-stage}"
 
 echo "Creating snapshot: ${SNAPSHOT_NAME}" >&2

--- a/aptly/scripts/prune-snapshots.sh
+++ b/aptly/scripts/prune-snapshots.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 # prune-snapshots.sh — remove old Aptly snapshots, retaining the 2 most recent
-# Usage: prune-snapshots.sh <component> <year>
+# Usage: prune-snapshots.sh <component> <series>
 # Example: prune-snapshots.sh core 2025
 #
 # C2 CONSTRAINT: MUST use `aptly publish list -raw` to identify published snapshots.
 # NEVER deletes a snapshot that is currently published.
-# Retains the 2 most recent snapshots per component/year (NFR14).
+# Retains the 2 most recent snapshots per component/series (NFR14).
 # Supports dry-run mode: DRY_RUN=1 prune-snapshots.sh core 2025
 set -euo pipefail
 
 COMPONENT="${1:?component required}"
-YEAR="${2:?year required}"
+SERIES="${2:?series required}"
 KEEP_COUNT="${KEEP_COUNT:-2}"
 DRY_RUN="${DRY_RUN:-0}"
 
-PREFIX="${COMPONENT}-${YEAR}-"
+PREFIX="${COMPONENT}-${SERIES}-"
 
-echo "Pruning snapshots for ${COMPONENT}/${YEAR} (keeping ${KEEP_COUNT} most recent)..."
+echo "Pruning snapshots for ${COMPONENT}/${SERIES} (keeping ${KEEP_COUNT} most recent)..."
 [ "${DRY_RUN}" = "1" ] && echo "  [DRY RUN — no deletions will occur]"
 
 # C2: identify snapshot names for all currently-published endpoints
@@ -36,7 +36,7 @@ else
   echo "${PUBLISHED}" | sed 's/^/  /'
 fi
 
-# List all snapshots matching this component/year prefix, sorted by name
+# List all snapshots matching this component/series prefix, sorted by name
 # Timestamp in name (YYYYMMDDTHHMMSSZ) ensures correct chronological sort
 ALL=$(aptly snapshot list -raw 2>/dev/null | grep "^${PREFIX}" | sort || true)
 
@@ -46,7 +46,7 @@ if [ -z "${ALL}" ]; then
 fi
 
 TOTAL=$(echo "${ALL}" | wc -l | tr -d ' ')
-echo "Found ${TOTAL} snapshot(s) for ${COMPONENT}/${YEAR}:"
+echo "Found ${TOTAL} snapshot(s) for ${COMPONENT}/${SERIES}:"
 echo "${ALL}" | sed 's/^/  /'
 
 if [ "${TOTAL}" -le "${KEEP_COUNT}" ]; then

--- a/aptly/scripts/publish-snapshot.sh
+++ b/aptly/scripts/publish-snapshot.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 # publish-snapshot.sh — publish or atomically switch an Aptly snapshot
-# Usage: publish-snapshot.sh <snapshot-name> <component> <year> <distro>
+# Usage: publish-snapshot.sh <snapshot-name> <component> <series> <distro>
 # Example: publish-snapshot.sh core-2025-20260329T120000Z core 2025 bookworm
 #
-# Publish path: :{component}/{year}
-# Maps to subscriber URL: https://pkg.example.org/deb/{component}/{year}/
+# Publish path: :{component}/{series}
+# Maps to subscriber URL: https://pkg.example.org/deb/{component}/{series}/
 # Aptly's publish switch is atomic — subscribers always see a consistent state.
 set -euo pipefail
 
 SNAPSHOT_NAME="${1:?snapshot-name required}"
 COMPONENT="${2:?component required}"
-YEAR="${3:?year required}"
+SERIES="${3:?series required}"
 DISTRO="${4:?distro required (bookworm|trixie|jammy|noble)}"
 
-PUBLISH_POINT=":${COMPONENT}/${YEAR}"
+PUBLISH_POINT=":${COMPONENT}/${SERIES}"
 
 echo "Publishing snapshot: ${SNAPSHOT_NAME}"
 echo "  → publish point: ${PUBLISH_POINT} (distribution: ${DISTRO})"
@@ -28,7 +28,7 @@ if aptly publish show "${DISTRO}" "${PUBLISH_POINT}" > /dev/null 2>&1; then
     "${PUBLISH_POINT}" \
     "${SNAPSHOT_NAME}"
 else
-  # First-time publish for this component/year
+  # First-time publish for this component/series
   echo "Publishing snapshot for the first time at ${PUBLISH_POINT}..."
   aptly publish snapshot \
     -distribution="${DISTRO}" \

--- a/auth/internal/handler/forward_auth.go
+++ b/auth/internal/handler/forward_auth.go
@@ -129,9 +129,9 @@ func isHex(s string) bool {
 //
 // Supported formats:
 //
-//	/rpm/{component}/{year}/{os-arch}/...   → component at index 1
-//	/deb/{component}/{year}/...             → component at index 1
-//	/oci/v2/lts-{component}/...             → strip "lts-" prefix from index 2
+//	/rpm/{component}/{series}/{os-arch}/...   → component at index 1
+//	/deb/{component}/{series}/...             → component at index 1
+//	/oci/v2/lts-{component}/...               → strip "lts-" prefix from index 2
 //
 // Returns ("", false) if the path is unrecognised or too short.
 func extractComponent(path string) (string, bool) {
@@ -142,10 +142,10 @@ func extractComponent(path string) (string, bool) {
 	}
 	switch parts[0] {
 	case "rpm":
-		// /rpm/{component}/{year}/{os-arch}/...
+		// /rpm/{component}/{series}/{os-arch}/...
 		return parts[1], true
 	case "deb":
-		// /deb/{component}/{year}/...
+		// /deb/{component}/{series}/...
 		return parts[1], true
 	case "oci":
 		// /oci/v2/lts-{component}/...

--- a/docs/ops/manual-test-plan.md
+++ b/docs/ops/manual-test-plan.md
@@ -176,7 +176,7 @@ Expected: HTTP 400, `{"code":"INVALID_COMPONENT","message":"..."}`.
 ### 4.1 Valid key — allowed
 
 ```bash
-# RPM: /rpm/{component}/{year}/{os-arch}/
+# RPM: /rpm/{component}/{series}/{os-arch}/
 curl -u "subscriber:${CORE_KEY}" \
   -o /dev/null -w "%{http_code}\n" \
   http://localhost/rpm/core/2025/el9-x86_64/
@@ -185,7 +185,7 @@ curl -u "subscriber:${CORE_KEY}" \
 Expected: `200` — auth allowed, nginx served the directory (empty in local dev).
 
 ```bash
-# DEB: /deb/{component}/{year}/
+# DEB: /deb/{component}/{series}/
 curl -u "subscriber:${CORE_KEY}" \
   -o /dev/null -w "%{http_code}\n" \
   http://localhost/deb/core/2025/

--- a/docs/ops/release-runbook.md
+++ b/docs/ops/release-runbook.md
@@ -12,9 +12,9 @@ Promotion is always manual — one `workflow_dispatch` per component and target.
 
 | Format | Workflow | Key input parameters |
 |--------|----------|---------------------|
-| RPM | `promote-rpm.yml` | `component`, `year`, `os` |
-| DEB | `promote-deb.yml` | `component`, `year`, `distro` |
-| OCI | `promote-oci.yml` | `component`, `year` |
+| RPM | `promote-rpm.yml` | `component`, `series`, `os` |
+| DEB | `promote-deb.yml` | `component`, `series`, `distro` |
+| OCI | `promote-oci.yml` | `component`, `series` |
 
 ---
 
@@ -79,7 +79,7 @@ Promotions are serialised per component/target by GitHub's concurrency groups �
 ```bash
 gh workflow run promote-rpm.yml \
   -f component=core \
-  -f year=2025 \
+  -f series=2025 \
   -f os=el9-x86_64
 ```
 
@@ -90,7 +90,7 @@ Valid `os` values: `el8-x86_64`, `el9-x86_64`, `el10-x86_64`, `centos10-x86_64`
 ```bash
 gh workflow run promote-deb.yml \
   -f component=core \
-  -f year=2025 \
+  -f series=2025 \
   -f distro=noble
 ```
 
@@ -101,7 +101,7 @@ Valid `distro` values: `bookworm`, `trixie`, `jammy`, `noble`
 ```bash
 gh workflow run promote-oci.yml \
   -f component=core \
-  -f year=2025
+  -f series=2025
 ```
 
 OCI promotion builds the multi-arch index from both staged architectures and cosign-signs all manifests in a single run — no per-arch dispatch needed.

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -226,7 +226,7 @@ The promotion workflows SSH into the VM to run `docker exec` commands. If the co
 
 The promotion workflow downloads a staged artifact from RustFS before signing. If the artifact is not found:
 
-1. Confirm the artifact was staged with the correct `component`, `year`, and `os` values that match the workflow inputs.
+1. Confirm the artifact was staged with the correct `component`, `series`, and `os` values that match the workflow inputs.
 2. Open an SSH tunnel to RustFS and list the staging bucket:
    ```bash
    ssh -L 9000:localhost:9000 deploy@pkg.example.org -N &

--- a/docs/reference/promotion-pipeline.md
+++ b/docs/reference/promotion-pipeline.md
@@ -17,11 +17,11 @@ RUSTFS_ACCESS_KEY=... RUSTFS_SECRET_KEY=... \
   bash scripts/stage-artifact.sh core 2025 rpm el9-x86_64 /path/to/artifact.rpm
 ```
 
-Then trigger the corresponding promotion workflow with `component`, `year`, and `os` inputs via the GitHub Actions UI or CLI:
+Then trigger the corresponding promotion workflow with `component`, `series`, and `os` inputs via the GitHub Actions UI or CLI:
 
 ```bash
 gh workflow run promote-rpm.yml \
   -f component=core \
-  -f year=2025 \
+  -f series=2025 \
   -f os=el9-x86_64
 ```

--- a/rpm/nginx.conf
+++ b/rpm/nginx.conf
@@ -24,7 +24,7 @@ http {
         autoindex_localtime on;
 
         # RPM repository metadata and package delivery
-        # URL structure: /rpm/{component}/{year}/{os-arch}/
+        # URL structure: /rpm/{component}/{series}/{os-arch}/
         # Example:       /rpm/core/2025/el9-x86_64/
         location / {
             try_files $uri $uri/ =404;

--- a/rpm/scripts/add-package.sh
+++ b/rpm/scripts/add-package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # add-package.sh — copy a signed RPM into the tree and rebuild metadata
-# Usage: add-package.sh <signed-rpm> <component> <year> <os-arch>
+# Usage: add-package.sh <signed-rpm> <component> <series> <os-arch>
 #
 # Relies on GHA concurrency group (rpm-publish-${component}-${os}) to prevent
 # concurrent createrepo_c runs on the same directory. No shell-level file lock.
@@ -8,12 +8,12 @@ set -euo pipefail
 
 RPM_FILE="${1:?signed RPM path required}"
 COMPONENT="${2:?component required}"
-YEAR="${3:?year required}"
+SERIES="${3:?series required}"
 OS_ARCH="${4:?os-arch required}"
 ROOT="${RPM_ROOT:-/usr/share/nginx/html}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET="${ROOT}/rpm/${COMPONENT}/${YEAR}/${OS_ARCH}"
+TARGET="${ROOT}/rpm/${COMPONENT}/${SERIES}/${OS_ARCH}"
 
 [ -f "${RPM_FILE}" ] || { echo "ERROR: file not found: ${RPM_FILE}"; exit 1; }
 [ -d "${TARGET}" ] || { echo "ERROR: target dir not found: ${TARGET}"; exit 1; }
@@ -21,4 +21,4 @@ TARGET="${ROOT}/rpm/${COMPONENT}/${YEAR}/${OS_ARCH}"
 echo "Copying $(basename "${RPM_FILE}") to ${TARGET}/"
 cp "${RPM_FILE}" "${TARGET}/"
 
-"${SCRIPT_DIR}/rebuild-metadata.sh" "${ROOT}" "${COMPONENT}" "${YEAR}" "${OS_ARCH}"
+"${SCRIPT_DIR}/rebuild-metadata.sh" "${ROOT}" "${COMPONENT}" "${SERIES}" "${OS_ARCH}"

--- a/rpm/scripts/init-rpm-tree.sh
+++ b/rpm/scripts/init-rpm-tree.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
-# init-rpm-tree.sh — creates the year-versioned, per-OS RPM directory tree on first start
+# init-rpm-tree.sh — creates the series-versioned, per-OS RPM directory tree on first start
 # Runs via /docker-entrypoint.d/ before nginx starts (nginx:alpine entrypoint pattern)
 # Idempotent: mkdir -p is safe to run on every container start
 
 set -e
 
 COMPONENTS="core minion sentinel"
-YEARS="2025"
+SERIES="2025"
 OS_TARGETS="el8-x86_64 el9-x86_64 el10-x86_64 centos10-x86_64"
 ROOT="/usr/share/nginx/html"
 
 for component in $COMPONENTS; do
-    for year in $YEARS; do
+    for series in $SERIES; do
         for os in $OS_TARGETS; do
-            mkdir -p "${ROOT}/rpm/${component}/${year}/${os}"
+            mkdir -p "${ROOT}/rpm/${component}/${series}/${os}"
         done
     done
 done

--- a/rpm/scripts/rebuild-metadata.sh
+++ b/rpm/scripts/rebuild-metadata.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# rebuild-metadata.sh — runs createrepo_c for one component/year/os-arch tree
-# Usage: rebuild-metadata.sh <root> <component> <year> <os-arch>
+# rebuild-metadata.sh — runs createrepo_c for one component/series/os-arch tree
+# Usage: rebuild-metadata.sh <root> <component> <series> <os-arch>
 #
 # Serialisation is enforced externally by the GHA concurrency group:
 #   rpm-publish-${component}-${os}  (cancel-in-progress: false)
@@ -10,10 +10,10 @@ set -euo pipefail
 
 ROOT="${1:?RPM tree root required (e.g. /usr/share/nginx/html)}"
 COMPONENT="${2:?component required}"
-YEAR="${3:?year required}"
+SERIES="${3:?series required}"
 OS_ARCH="${4:?os-arch required}"
 
-TARGET="${ROOT}/rpm/${COMPONENT}/${YEAR}/${OS_ARCH}"
+TARGET="${ROOT}/rpm/${COMPONENT}/${SERIES}/${OS_ARCH}"
 [ -d "${TARGET}" ] || { echo "ERROR: directory not found: ${TARGET}"; exit 1; }
 
 echo "Rebuilding RPM metadata for ${TARGET}..."

--- a/scripts/stage-artifact.sh
+++ b/scripts/stage-artifact.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # stage-artifact.sh — upload an unsigned artefact to RustFS staging
-# Usage: stage-artifact.sh <component> <year> <format> <os-arch> <local-file>
+# Usage: stage-artifact.sh <component> <series> <format> <os-arch> <local-file>
 #
 # Required env vars:
 #   RUSTFS_ENDPOINT     — e.g. http://localhost:9000 (via SSH tunnel: ssh -L 9000:localhost:9000 deploy@HOST)
@@ -9,8 +9,8 @@
 #   RUSTFS_BUCKET       — (optional) bucket name, defaults to "staging"
 #
 # Uploads artifact + SHA256 checksum to:
-#   s3://{bucket}/{component}/{year}/{format}/{os-arch}/{filename}
-#   s3://{bucket}/{component}/{year}/{format}/{os-arch}/{filename}.sha256
+#   s3://{bucket}/{component}/{series}/{format}/{os-arch}/{filename}
+#   s3://{bucket}/{component}/{series}/{format}/{os-arch}/{filename}.sha256
 set -euo pipefail
 
 COMPONENT="${1:?component required (e.g. core)}"
@@ -19,9 +19,9 @@ if ! [[ "$COMPONENT" =~ ^[a-zA-Z0-9_-]+$ ]]; then
   echo "       Allowed: letters, digits, hyphens, underscores"
   exit 1
 fi
-YEAR="${2:?year required (e.g. 2025)}"
-if ! [[ "$YEAR" =~ ^[0-9]{4}$ ]]; then
-  echo "ERROR: year must be a 4-digit number (got: ${YEAR})"
+SERIES="${2:?series required (e.g. 2025)}"
+if ! [[ "$SERIES" =~ ^[0-9]{4}$ ]]; then
+  echo "ERROR: series must be a 4-digit number (got: ${SERIES})"
   exit 1
 fi
 FORMAT="${3:?format required (rpm|deb|oci)}"
@@ -47,7 +47,7 @@ esac
 [ -f "${LOCAL_FILE}" ] || { echo "ERROR: file not found: ${LOCAL_FILE}"; exit 1; }
 
 FILENAME=$(basename "${LOCAL_FILE}")
-S3_KEY="${COMPONENT}/${YEAR}/${FORMAT}/${OS_ARCH}/${FILENAME}"
+S3_KEY="${COMPONENT}/${SERIES}/${FORMAT}/${OS_ARCH}/${FILENAME}"
 
 # Generate SHA256 checksum
 echo "Generating checksum for ${FILENAME}..."

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -43,7 +43,7 @@ At least one signed package per format under test must exist in the serving tree
 # 1. Upload a test RPM to RustFS staging:
 RUSTFS_ACCESS_KEY=... RUSTFS_SECRET_KEY=... \
   bash scripts/stage-artifact.sh /path/to/lts-core.rpm core rpm 2025 el9-x86_64
-# 2. Trigger the promote-rpm GHA workflow for component=core, year=2025, os=el9-x86_64
+# 2. Trigger the promote-rpm GHA workflow for component=core, series=2025, os=el9-x86_64
 
 # Option B: Manual (for local dev only)
 docker compose exec rpm cp /path/to/lts-core.rpm /usr/share/nginx/html/core/2025/el9-x86_64/
@@ -56,7 +56,7 @@ docker compose exec rpm createrepo_c --update /usr/share/nginx/html/core/2025/el
 # 1. Upload a test DEB to RustFS staging:
 RUSTFS_ACCESS_KEY=... RUSTFS_SECRET_KEY=... \
   bash scripts/stage-artifact.sh /path/to/lts-core_2025.1.0_amd64.deb core deb 2025 bookworm
-# 2. Trigger the promote-deb GHA workflow for component=core, year=2025, distro=bookworm
+# 2. Trigger the promote-deb GHA workflow for component=core, series=2025, distro=bookworm
 
 # Option B: Manual (for local dev only — requires aptly container access)
 docker compose exec aptly /scripts/create-snapshot.sh core 2025 bookworm
@@ -65,7 +65,7 @@ docker compose exec aptly /scripts/publish-snapshot.sh core 2025 bookworm
 
 **OCI** — must have cosign-signed multi-arch image index in Zot:
 ```bash
-# Use the promote-oci GHA workflow for component=core, year=2025
+# Use the promote-oci GHA workflow for component=core, series=2025
 # The workflow pushes x86_64 and arm64 images, creates a multi-arch index,
 # and signs all three with cosign (stored in Zot alongside the images).
 
@@ -89,7 +89,7 @@ crane push /tmp/test-arm64.tar localhost:5000/lts-core:2025-arm64 --insecure
 | Variable    | Default       | Description                        |
 |-------------|---------------|------------------------------------|
 | `COMPONENT` | `core`        | LTS component                 |
-| `YEAR`      | `2025`        | LTS release year              |
+| `SERIES`    | `2025`        | LTS release series            |
 | `OS_ARCH`   | `el9-x86_64`  | RPM OS/arch path segment           |
 | `DISTRO`    | `bookworm`    | DEB distro name                    |
 | `PACKAGE`   | `lts-core` | Package name to install          |
@@ -123,7 +123,7 @@ Optional overrides:
 BASE_URL=https://pkg.example.org \
 VALID_KEY=your-subscription-key \
 COMPONENT=core \
-YEAR=2025 \
+SERIES=2025 \
 DISTRO=bookworm \
 PACKAGE=lts-core \
 bash tests/e2e/deb-subscriber.sh
@@ -146,7 +146,7 @@ Optional overrides:
 BASE_URL=https://pkg.example.org \
 VALID_KEY=your-subscription-key \
 COMPONENT=core \
-YEAR=2025 \
+SERIES=2025 \
 bash tests/e2e/oci-subscriber.sh
 ```
 
@@ -197,6 +197,6 @@ These tests are integration tests, not unit tests. They require:
 
 | File | Purpose |
 |------|---------|
-| `fixtures/lts-test.repo.tmpl` | RPM `.repo` file template; `{{BASE_URL}}`, `{{COMPONENT}}`, `{{YEAR}}`, `{{OS_ARCH}}` substituted at runtime |
-| `fixtures/lts-test.list.tmpl` | DEB `sources.list` template; `{{KEY}}`, `{{BASE_URL_HOST}}`, `{{COMPONENT}}`, `{{YEAR}}`, `{{DISTRO}}` substituted at runtime |
+| `fixtures/lts-test.repo.tmpl` | RPM `.repo` file template; `{{BASE_URL}}`, `{{COMPONENT}}`, `{{SERIES}}`, `{{OS_ARCH}}` substituted at runtime |
+| `fixtures/lts-test.list.tmpl` | DEB `sources.list` template; `{{KEY}}`, `{{BASE_URL_HOST}}`, `{{COMPONENT}}`, `{{SERIES}}`, `{{DISTRO}}` substituted at runtime |
 | `fixtures/docker-daemon.json.tmpl` | Docker auth template; documents `docker login` as the recommended credential approach for OCI pull |

--- a/tests/e2e/deb-subscriber.sh
+++ b/tests/e2e/deb-subscriber.sh
@@ -11,7 +11,7 @@
 #
 # OPTIONAL ENV VARS:
 #   COMPONENT  — LTS component (default: core)
-#   YEAR       — LTS year (default: 2025)
+#   SERIES     — LTS series (default: 2025)
 #   DISTRO     — DEB distribution codename (default: bookworm)
 #   PACKAGE    — DEB package name to install (default: lts-core)
 #
@@ -22,7 +22,7 @@ set -euo pipefail
 BASE_URL="${BASE_URL:?BASE_URL is required (e.g. https://pkg.example.org)}"
 VALID_KEY="${VALID_KEY:?VALID_KEY is required (a valid subscription key)}"
 COMPONENT="${COMPONENT:-core}"
-YEAR="${YEAR:-2025}"
+SERIES="${SERIES:-2025}"
 DISTRO="${DISTRO:-bookworm}"
 PACKAGE="${PACKAGE:-lts-core}"
 
@@ -59,7 +59,7 @@ echo "LTS GPG key dearmored to ${GPG_KEY_FILE}."
 # ─── Sources file ────────────────────────────────────────────────────────────
 
 cat > "${SOURCES_FILE}" <<LIST
-deb [signed-by=${GPG_KEY_FILE}] ${AUTH_URL}/deb/${COMPONENT}/${YEAR}/ ${DISTRO} main
+deb [signed-by=${GPG_KEY_FILE}] ${AUTH_URL}/deb/${COMPONENT}/${SERIES}/ ${DISTRO} main
 LIST
 
 # Shared apt options — isolate cache and sources from system state
@@ -113,7 +113,7 @@ fi
 
 echo ""
 echo "=== AC3: Invalid key returns 401 ==="
-BAD_AUTH_URL="$(echo "${BASE_URL}" | sed 's|://|://subscriber:invalidkey9999@|')/deb/${COMPONENT}/${YEAR}/dists/${DISTRO}/InRelease"
+BAD_AUTH_URL="$(echo "${BASE_URL}" | sed 's|://|://subscriber:invalidkey9999@|')/deb/${COMPONENT}/${SERIES}/dists/${DISTRO}/InRelease"
 HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' "${BAD_AUTH_URL}" || true)
 if [ "${HTTP_STATUS}" = "401" ]; then
   pass "AC3 — invalid key correctly returns HTTP 401"

--- a/tests/e2e/fixtures/lts-test.list.tmpl
+++ b/tests/e2e/fixtures/lts-test.list.tmpl
@@ -1,1 +1,1 @@
-deb [signed-by=/tmp/lts.gpg] https://subscriber:{{KEY}}@{{BASE_URL_HOST}}/deb/{{COMPONENT}}/{{YEAR}}/ {{DISTRO}} main
+deb [signed-by=/tmp/lts.gpg] https://subscriber:{{KEY}}@{{BASE_URL_HOST}}/deb/{{COMPONENT}}/{{SERIES}}/ {{DISTRO}} main

--- a/tests/e2e/fixtures/lts-test.repo.tmpl
+++ b/tests/e2e/fixtures/lts-test.repo.tmpl
@@ -1,6 +1,6 @@
 [lts-test]
 name=LTS Test Repo
-baseurl=https://subscriber:{{KEY}}@{{BASE_URL_HOST}}/rpm/{{COMPONENT}}/{{YEAR}}/{{OS_ARCH}}/
+baseurl=https://subscriber:{{KEY}}@{{BASE_URL_HOST}}/rpm/{{COMPONENT}}/{{SERIES}}/{{OS_ARCH}}/
 enabled=1
 gpgcheck=1
 gpgkey={{BASE_URL}}/gpg/lts.asc

--- a/tests/e2e/observability.sh
+++ b/tests/e2e/observability.sh
@@ -13,7 +13,7 @@
 #   METRICS_URL — auth metrics endpoint (default: http://localhost:9090/metrics)
 #                 Override if running from outside the Docker network.
 #   COMPONENT   — LTS component (default: core)
-#   YEAR        — LTS year (default: 2025)
+#   SERIES      — LTS series (default: 2025)
 #
 # USAGE:
 #   BASE_URL=https://pkg.example.org VALID_KEY=abc123 bash tests/e2e/observability.sh
@@ -23,7 +23,7 @@ BASE_URL="${BASE_URL:?BASE_URL is required (e.g. https://pkg.example.org)}"
 VALID_KEY="${VALID_KEY:?VALID_KEY is required (a valid subscription key)}"
 METRICS_URL="${METRICS_URL:-http://localhost:9090/metrics}"
 COMPONENT="${COMPONENT:-core}"
-YEAR="${YEAR:-2025}"
+SERIES="${SERIES:-2025}"
 
 FAILED=0
 
@@ -42,7 +42,7 @@ done
 echo "Precondition: sending one authenticated request to generate log and metrics data..."
 curl -s -o /dev/null \
   -u "subscriber:${VALID_KEY}" \
-  "${BASE_URL}/rpm/el9-x86_64/${COMPONENT}/${YEAR}/repodata/repomd.xml" || true
+  "${BASE_URL}/rpm/el9-x86_64/${COMPONENT}/${SERIES}/repodata/repomd.xml" || true
 echo "Precondition complete."
 
 # ─── AC1: Prometheus metrics endpoint ────────────────────────────────────────

--- a/tests/e2e/oci-subscriber.sh
+++ b/tests/e2e/oci-subscriber.sh
@@ -12,7 +12,7 @@
 #
 # OPTIONAL ENV VARS:
 #   COMPONENT  — LTS component (default: core)
-#   YEAR       — LTS year (default: 2025)
+#   SERIES     — LTS series (default: 2025)
 #
 # USAGE:
 #   BASE_URL=https://pkg.example.org VALID_KEY=abc123 bash tests/e2e/oci-subscriber.sh
@@ -21,11 +21,11 @@ set -euo pipefail
 BASE_URL="${BASE_URL:?BASE_URL is required (e.g. https://pkg.example.org)}"
 VALID_KEY="${VALID_KEY:?VALID_KEY is required (a valid subscription key)}"
 COMPONENT="${COMPONENT:-core}"
-YEAR="${YEAR:-2025}"
+SERIES="${SERIES:-2025}"
 
 # Strip scheme — docker/crane use bare registry references
 REGISTRY="${BASE_URL#https://}"
-IMAGE="${REGISTRY}/oci/lts-${COMPONENT}:${YEAR}"
+IMAGE="${REGISTRY}/oci/lts-${COMPONENT}:${SERIES}"
 
 COSIGN_PUB="$(mktemp --suffix=.pub)"
 FAILED=0
@@ -112,7 +112,7 @@ fi
 # AC3b — curl exact HTTP 401 for invalid key
 HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
   -u "subscriber:invalidkey9999" \
-  "${BASE_URL}/oci/v2/lts-${COMPONENT}/manifests/${YEAR}" || true)
+  "${BASE_URL}/oci/v2/lts-${COMPONENT}/manifests/${SERIES}" || true)
 if [ "${HTTP_STATUS}" = "401" ]; then
   pass "AC3b — invalid key correctly returns HTTP 401 on OCI manifest endpoint"
 else

--- a/tests/e2e/rpm-subscriber.sh
+++ b/tests/e2e/rpm-subscriber.sh
@@ -11,7 +11,7 @@
 #
 # OPTIONAL ENV VARS:
 #   COMPONENT  — LTS component (default: core)
-#   YEAR       — LTS year (default: 2025)
+#   SERIES     — LTS series (default: 2025)
 #   OS_ARCH    — RPM OS/arch path segment (default: el9-x86_64)
 #   PACKAGE    — RPM package name to install (default: lts-core)
 #
@@ -22,7 +22,7 @@ set -euo pipefail
 BASE_URL="${BASE_URL:?BASE_URL is required (e.g. https://pkg.example.org)}"
 VALID_KEY="${VALID_KEY:?VALID_KEY is required (a valid subscription key)}"
 COMPONENT="${COMPONENT:-core}"
-YEAR="${YEAR:-2025}"
+SERIES="${SERIES:-2025}"
 OS_ARCH="${OS_ARCH:-el9-x86_64}"
 PACKAGE="${PACKAGE:-lts-core}"
 
@@ -56,7 +56,7 @@ done
 cat > "${REPO_FILE}" <<REPO
 [lts-test]
 name=LTS Test Repo
-baseurl=${AUTH_URL}/rpm/${COMPONENT}/${YEAR}/${OS_ARCH}/
+baseurl=${AUTH_URL}/rpm/${COMPONENT}/${SERIES}/${OS_ARCH}/
 enabled=1
 gpgcheck=1
 gpgkey=${BASE_URL}/gpg/lts.asc
@@ -65,7 +65,7 @@ REPO
 cat > "${BAD_REPO_FILE}" <<REPO
 [lts-bad]
 name=LTS Bad Key Test
-baseurl=$(echo "${BASE_URL}" | sed 's|://|://subscriber:invalidkey9999@|')/rpm/${COMPONENT}/${YEAR}/${OS_ARCH}/
+baseurl=$(echo "${BASE_URL}" | sed 's|://|://subscriber:invalidkey9999@|')/rpm/${COMPONENT}/${SERIES}/${OS_ARCH}/
 enabled=1
 gpgcheck=1
 gpgkey=${BASE_URL}/gpg/lts.asc
@@ -131,7 +131,7 @@ fi
 
 echo ""
 echo "=== AC3: Invalid key returns 401 ==="
-BAD_AUTH_URL="$(echo "${BASE_URL}" | sed 's|://|://subscriber:invalidkey9999@|')/rpm/${COMPONENT}/${YEAR}/${OS_ARCH}/repodata/repomd.xml"
+BAD_AUTH_URL="$(echo "${BASE_URL}" | sed 's|://|://subscriber:invalidkey9999@|')/rpm/${COMPONENT}/${SERIES}/${OS_ARCH}/repodata/repomd.xml"
 HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' "${BAD_AUTH_URL}" || true)
 if [ "${HTTP_STATUS}" = "401" ]; then
   pass "AC3 — invalid key correctly returns HTTP 401"

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -45,7 +45,7 @@ k6-based performance validation against a live packyard stack, targeting the NFR
 | `VUS`           | `50`                      | Virtual users for the baseline scenario                       |
 | `DOWNLOAD_VUS`  | `min(5, VUS/10)`          | Virtual users for the download scenario (capped to avoid bandwidth saturation) |
 | `COMPONENT`     | `core`                    | LTS component                                            |
-| `YEAR`          | `2025`                    | LTS release year                                         |
+| `SERIES`        | `2025`                    | LTS release series                                       |
 | `OS_ARCH`       | `el9-x86_64`              | RPM OS/arch path segment                                      |
 | `RPM_FILE`      | `lts-core.rpm`       | RPM filename for download scenario — **must be set to an existing versioned filename** |
 

--- a/tests/load/packyard-load-test.js
+++ b/tests/load/packyard-load-test.js
@@ -15,7 +15,7 @@
  *   VUS           — number of virtual users for the baseline scenario (default: 50)
  *   DOWNLOAD_VUS  — VUs for the download scenario (default: min(5, VUS/10), capped to avoid bandwidth saturation)
  *   COMPONENT     — LTS component (default: core)
- *   YEAR          — LTS release year (default: 2025)
+ *   SERIES        — LTS release series (default: 2025)
  *   OS_ARCH       — RPM OS/arch segment (default: el9-x86_64)
  *   RPM_FILE      — RPM filename for download scenario (must be set to an existing RPM; default: lts-core.rpm)
  *
@@ -36,7 +36,7 @@ const BASE_URL  = (__ENV.BASE_URL  || 'https://pkg.example.org').replace(/\/$/, 
 const KEY       = __ENV.KEY;
 const VUS       = parseInt(__ENV.VUS)  || 50;
 const COMPONENT = __ENV.COMPONENT || 'core';
-const YEAR      = __ENV.YEAR      || '2025';
+const SERIES    = __ENV.SERIES    || '2025';
 const OS_ARCH   = __ENV.OS_ARCH   || 'el9-x86_64';
 const RPM_FILE  = __ENV.RPM_FILE  || 'lts-core.rpm';
 
@@ -52,7 +52,7 @@ if (!KEY) {
 const AUTH_HEADER = `Basic ${encoding.b64encode('subscriber:' + KEY)}`;
 
 // Commonly referenced URL segments.
-const RPM_BASE     = `${BASE_URL}/rpm/${COMPONENT}/${YEAR}/${OS_ARCH}`;
+const RPM_BASE     = `${BASE_URL}/rpm/${COMPONENT}/${SERIES}/${OS_ARCH}`;
 const METADATA_URL = `${RPM_BASE}/repodata/repomd.xml`;
 const DOWNLOAD_URL = `${RPM_BASE}/${RPM_FILE}`;
 


### PR DESCRIPTION
## Summary

- Renames `year`/`YEAR`/`YEARS` → `series`/`SERIES` across all shell scripts, GitHub Actions workflows, Go doc comments, nginx config, and documentation
- No URL path structure changes — values like `2025` still appear in paths
- No data migrations required
- ⚠️ **Breaking for workflow callers**: any script invoking `promote-rpm.yml`, `promote-deb.yml`, or `promote-oci.yml` via `workflow_dispatch` must update `-f year=` to `-f series=`

## Files changed

| Area | Files |
|------|-------|
| RPM scripts | `init-rpm-tree.sh`, `add-package.sh`, `rebuild-metadata.sh` |
| Aptly scripts | `create-snapshot.sh`, `publish-snapshot.sh`, `prune-snapshots.sh` |
| GitHub Actions | `promote-rpm.yml`, `promote-deb.yml`, `promote-oci.yml` |
| Auth service | `forward_auth.go` (doc comment only) |
| nginx config | `nginx.conf` (comment only) |
| Docs | `release-runbook.md`, `troubleshooting.md`, `manual-test-plan.md`, `promotion-pipeline.md` |

## Test plan

- [x] Grep sweep — no `year`/`YEAR`/`YEARS` identifiers remain in any affected file
- [x] `go test ./...` passes in `auth/`

Closes #77