### PR TITLE
docs: fill documentation gaps from component management API

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -81,7 +81,8 @@ curl -s -X POST http://localhost:8080/api/v1/keys \
   "component": "core",
   "label": "dev-key",
   "active": true,
-  "created_at": "2025-01-01T00:00:00Z"
+  "created_at": "2025-01-01T00:00:00Z",
+  "component_visibility": "public"
 }
 ```
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -58,10 +58,16 @@ curl -s -X POST http://localhost:8080/api/v1/components \
   -H 'Content-Type: application/json' \
   -d '{
     "name": "core",
+    "visibility": "public",
     "rpm_series": ["2025"],
     "rpm_os_families": ["el9"],
     "rpm_architectures": ["x86_64"]
   }' | jq .
+
+# The auth service loads its component map at startup — restart to make
+# forward-auth recognise the new component.
+docker compose -f compose.yml -f compose.override.ci.yml restart auth
+until curl -sf http://localhost:8080/health > /dev/null; do sleep 2; done
 
 # Create a subscription key scoped to the component
 curl -s -X POST http://localhost:8080/api/v1/keys \

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -115,12 +115,31 @@ docker compose logs auth | grep "loaded components"
 
 - **Key creation** (`POST /api/v1/keys`) queries the database directly — a restart is **not** needed for the auth service to accept keys for a newly provisioned component.
 - **Forward-auth decisions** (subscriber package access) use an in-memory component map loaded at startup — a restart **is** required for new or deleted components to be reflected in access control.
+- **Key list filter** (`GET /api/v1/keys?component=<name>`) also validates the component name against the in-memory map — it returns `400 INVALID_COMPONENT` for a newly provisioned component until the service is restarted.
+- **Authenticated requests to an unrecognised component** return `404` (not `401`) — if a subscriber has a valid key but the component isn't in the in-memory map, the auth service returns `404 Not Found` rather than `401 Unauthorized`. Restart auth to resolve.
 
 If the component record was updated in the database (via the API) but the auth service was not restarted, restart it:
 
 ```bash
 docker compose restart auth
 ```
+
+---
+
+## POST /api/v1/components returns 500 RPM_INIT_FAILED
+
+The auth service failed to create the RPM directory tree for the new component. The component record was rolled back — the name is safe to reuse.
+
+**Common causes:**
+
+| Cause | How to confirm | Fix |
+|-------|---------------|-----|
+| `rpm-data` volume not mounted to auth container | `docker compose exec auth ls /data/rpm` — should list a `rpm/` subdirectory | Verify `compose.yml` has `rpm-data:/data/rpm` under the `auth` service volumes |
+| `RPM_DATA_ROOT` mismatch | `docker compose exec auth env \| grep RPM_DATA_ROOT` | Ensure `RPM_DATA_ROOT` matches the volume mount point (default: `/data/rpm`) |
+| Wrong permissions on the volume | `docker compose exec auth ls -la /data/rpm` | `docker compose exec rpm chown -R nobody:nobody /usr/share/nginx/html/rpm` or adjust mount ownership |
+| Disk full | `docker compose exec auth df -h /data/rpm` | Free disk space |
+
+After fixing the underlying cause, retry `POST /api/v1/components` with the same body — the name is available again.
 
 ---
 

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -103,7 +103,7 @@ curl -s http://127.0.0.1:8088/api/v1/keys | jq '.[] | {id, component, label, act
 
 **Step 4 — Is the component marked public?**
 
-If a component has `visibility: public` (as set via `POST /api/v1/components`), the auth service allows requests to its paths without inspecting credentials. Keys for public components are valid but are not checked during auth — any request, authenticated or not, returns `200`. If a subscriber reports getting `401` on a public component path, confirm the component's visibility via the API and that the auth service has restarted since the change:
+If a component has `visibility: public` (as set via `POST /api/v1/components`), the auth service allows requests to its paths without inspecting credentials. Keys for public components are valid but are not checked during auth — any request, authenticated or not, returns `200`. If a subscriber reports getting `401` on a public component path, confirm the component's visibility via the API and that the auth service has restarted since the component was provisioned:
 
 ```bash
 curl -s http://127.0.0.1:8088/api/v1/components/core | jq .visibility
@@ -111,7 +111,12 @@ docker compose logs auth | grep "loaded components"
 # expect the public component to appear in the list
 ```
 
-If the config was changed but the service was not restarted, restart it:
+**Restart semantics — when a restart is and is not required:**
+
+- **Key creation** (`POST /api/v1/keys`) queries the database directly — a restart is **not** needed for the auth service to accept keys for a newly provisioned component.
+- **Forward-auth decisions** (subscriber package access) use an in-memory component map loaded at startup — a restart **is** required for new or deleted components to be reflected in access control.
+
+If the component record was updated in the database (via the API) but the auth service was not restarted, restart it:
 
 ```bash
 docker compose restart auth

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -73,6 +73,21 @@ curl -s -X POST http://127.0.0.1:8088/api/v1/components \
 | `409 Conflict` | A component with this name already exists (`COMPONENT_EXISTS`) |
 | `500 Internal Server Error` | RPM directory initialisation failed (`RPM_INIT_FAILED`) |
 
+Example `201 Created` response:
+
+```json
+{
+  "name": "minion",
+  "visibility": "private",
+  "rpm_series": ["2025"],
+  "rpm_os_families": ["el9"],
+  "rpm_architectures": ["x86_64", "aarch64"],
+  "created_at": "2025-01-01T00:00:00Z"
+}
+```
+
+Note: when `visibility` is omitted from the request, the response body shows `"visibility": "private"` (the default).
+
 DEB (aptly) and OCI (Zot) provision lazily on first publish.
 
 ### Listing and inspecting components
@@ -85,7 +100,7 @@ curl -s http://127.0.0.1:8088/api/v1/components | jq .
 curl -s http://127.0.0.1:8088/api/v1/components/minion | jq .
 ```
 
-**Response codes for GET `/api/v1/components`:** `200 OK` (always; returns empty array when none exist).
+**Response codes for GET `/api/v1/components`:** `200 OK` (returns empty array when none exist), `500 Internal Server Error` (store error).
 
 **Response codes for GET `/api/v1/components/{name}`:** `200 OK` (found), `404 Not Found` (`COMPONENT_NOT_FOUND`).
 
@@ -111,11 +126,17 @@ With the correct `?confirm={name}`:
 curl -s -X DELETE http://127.0.0.1:8088/api/v1/components/minion?confirm=minion | jq .
 ```
 
-**Response codes for DELETE `/api/v1/components/{name}`:**
+**Response codes — without `?confirm` (impact preview):**
 
 | Code | Condition |
 |------|-----------|
-| `409 Conflict` | `?confirm` absent or does not match the component name exactly (`CONFIRM_REQUIRED`) |
+| `409 Conflict` | `?confirm` absent or value does not match the component name exactly (`CONFIRM_REQUIRED`) |
+| `404 Not Found` | Component does not exist (`COMPONENT_NOT_FOUND`) |
+
+**Response codes — with `?confirm={name}` (confirmed delete):**
+
+| Code | Condition |
+|------|-----------|
 | `200 OK` | Component deleted; keys revoked atomically — returns `{"keys_revoked": N}` |
 | `404 Not Found` | Component does not exist (`COMPONENT_NOT_FOUND`) |
 | `500 Internal Server Error` | Unexpected store error during atomic delete |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -58,7 +58,36 @@ curl -s -X POST http://127.0.0.1:8088/api/v1/components \
   }' | jq .
 ```
 
-Returns `201 Created` with the component record. The RPM directory tree is initialised on disk automatically. DEB (aptly) and OCI (Zot) provision lazily on first publish.
+**Validation rules:**
+
+- `name` is required and must not contain `/`, `\`, or `..`
+- `visibility` must be `"public"` or `"private"` (default: `"private"` when omitted)
+- `rpm_series`, `rpm_os_families`, `rpm_architectures` values must not contain `/`, `\`, or `..`
+
+**Response codes:**
+
+| Code | Condition |
+|------|-----------|
+| `201 Created` | Component created; RPM directory tree initialised on disk |
+| `400 Bad Request` | Validation failure (`INVALID_REQUEST` or `INVALID_VISIBILITY`) |
+| `409 Conflict` | A component with this name already exists (`COMPONENT_EXISTS`) |
+| `500 Internal Server Error` | RPM directory initialisation failed (`RPM_INIT_FAILED`) |
+
+DEB (aptly) and OCI (Zot) provision lazily on first publish.
+
+### Listing and inspecting components
+
+```bash
+# List all components
+curl -s http://127.0.0.1:8088/api/v1/components | jq .
+
+# Inspect a single component
+curl -s http://127.0.0.1:8088/api/v1/components/minion | jq .
+```
+
+**Response codes for GET `/api/v1/components`:** `200 OK` (always; returns empty array when none exist).
+
+**Response codes for GET `/api/v1/components/{name}`:** `200 OK` (found), `404 Not Found` (`COMPONENT_NOT_FOUND`).
 
 ### Deprovisioning a component
 
@@ -82,7 +111,27 @@ With the correct `?confirm={name}`:
 curl -s -X DELETE http://127.0.0.1:8088/api/v1/components/minion?confirm=minion | jq .
 ```
 
-Returns `200 OK` with `{"keys_revoked": 4}`. RPM directory content is **not** removed — the operator is responsible for archiving packages before deleting the directory.
+**Response codes for DELETE `/api/v1/components/{name}`:**
+
+| Code | Condition |
+|------|-----------|
+| `409 Conflict` | `?confirm` absent or does not match the component name exactly (`CONFIRM_REQUIRED`) |
+| `200 OK` | Component deleted; keys revoked atomically — returns `{"keys_revoked": N}` |
+| `404 Not Found` | Component does not exist (`COMPONENT_NOT_FOUND`) |
+| `500 Internal Server Error` | Unexpected store error during atomic delete |
+
+RPM directory content is **not** removed — the operator is responsible for archiving packages before deleting the directory.
+
+### Component API error codes
+
+| Code | Returned by | Description |
+|------|-------------|-------------|
+| `INVALID_REQUEST` | POST | `name` is missing, empty, or contains path-unsafe characters; or an array field contains a path-unsafe value |
+| `INVALID_VISIBILITY` | POST | `visibility` is not `"public"` or `"private"` |
+| `COMPONENT_EXISTS` | POST | A component with the given name already exists |
+| `RPM_INIT_FAILED` | POST | RPM directory tree creation failed; the component record was rolled back |
+| `COMPONENT_NOT_FOUND` | GET `/{name}`, DELETE | No component with the given name exists |
+| `CONFIRM_REQUIRED` | DELETE (no confirm) | `?confirm={name}` was absent or did not match; response includes impact preview |
 
 ## Examples
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -38,7 +38,7 @@ These are set via `compose.yml` and only need overriding when deploying with a n
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `RPM_DATA_ROOT` | `/data/rpm` | Root directory for RPM tree initialisation inside the auth container. Must match the mount point of the `rpm-data` volume. |
+| `RPM_DATA_ROOT` | `/data/rpm` | Root directory for RPM tree initialisation inside the auth container. Must match the mount point of the `rpm-data` volume. The auth service creates trees under `{RPM_DATA_ROOT}/rpm/{component}/{series}/{os_family}-{arch}/` — note the extra `rpm/` subdirectory level. |
 
 ## Compose Override Files
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -32,6 +32,14 @@ RUSTFS_ACCESS_KEY=dev-access-key
 RUSTFS_SECRET_KEY=dev-secret-key-value
 ```
 
+### Advanced (auth service)
+
+These are set via `compose.yml` and only need overriding when deploying with a non-standard volume layout:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RPM_DATA_ROOT` | `/data/rpm` | Root directory for RPM tree initialisation inside the auth container. Must match the mount point of the `rpm-data` volume. |
+
 ## Compose Override Files
 
 | File | Purpose |


### PR DESCRIPTION
## Summary

- **`RPM_DATA_ROOT` now documented** in `docs/reference/configuration.md` (default `/data/rpm`, explains when to override)
- **Component endpoint error codes catalogued** in `docs/reference/api.md` — all 6 codes (`INVALID_REQUEST`, `INVALID_VISIBILITY`, `COMPONENT_EXISTS`, `RPM_INIT_FAILED`, `COMPONENT_NOT_FOUND`, `CONFIRM_REQUIRED`) with one-line descriptions
- **Full response-code tables** added for POST, GET, and DELETE component operations; new "Listing and inspecting" section with curl examples
- **Validation rules documented**: names and array field values must not contain `/`, `\`, or `..`
- **Quick-start fixed** (was broken): added `"visibility":"public"` to `core` POST and a `docker compose restart auth` + health-check wait between provisioning and the authenticated request — without this, step 4 returns 404 because `ValidComponents` is loaded at startup
- **Troubleshooting step 4 updated**: stale "config was changed" wording replaced; split restart semantics explained (key creation uses live DB lookup — no restart; forward-auth uses in-memory map — restart required)

## Test plan

- [ ] Follow quick-start end-to-end locally — step 4 authenticated request returns 200
- [ ] Verify `docs-serve` renders all tables correctly (`make docs-serve`)
- [ ] Confirm no broken links in updated pages

🤖 Generated with [Claude Code](https://claude.ai/claude-code)