### PR TITLE
feat(auth): PATCH component visibility + live DB lookup in forward-auth

### DIFF
--- a/auth/cmd/server/main.go
+++ b/auth/cmd/server/main.go
@@ -83,7 +83,7 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	forwardAuth := handler.NewForwardAuthHandler(st, logger, validComponents, publicComponents)
+	forwardAuth := handler.NewForwardAuthHandler(st, st, logger)
 	r.Get("/auth", forwardAuth.ServeHTTP)
 
 	keys := handler.NewKeysHandler(st, st, logger, validComponents, componentList, compVisibility)
@@ -97,6 +97,7 @@ func main() {
 	r.Post("/api/v1/components", components.Create)
 	r.Get("/api/v1/components", components.List)
 	r.Get("/api/v1/components/{name}", components.GetOne)
+	r.Patch("/api/v1/components/{name}", components.Update)
 	r.Delete("/api/v1/components/{name}", components.Delete)
 
 	// Metrics server on :9090 — internal Docker network only, not published to host.

--- a/auth/internal/handler/components.go
+++ b/auth/internal/handler/components.go
@@ -237,6 +237,46 @@ func (h *ComponentsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(deleteResult{KeysRevoked: revoked})
 }
 
+// updateComponentRequest is the JSON body for PATCH /api/v1/components/{name}.
+type updateComponentRequest struct {
+	Visibility string `json:"visibility"`
+}
+
+// Update handles PATCH /api/v1/components/{name} — updates mutable component fields.
+// Currently only visibility ("public" or "private") may be changed.
+// The change is persisted immediately; forward-auth picks it up on the next request
+// without a service restart.
+func (h *ComponentsHandler) Update(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req updateComponentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "request body must be valid JSON")
+		return
+	}
+	if req.Visibility != "public" && req.Visibility != "private" {
+		writeError(w, http.StatusBadRequest, "INVALID_VISIBILITY",
+			fmt.Sprintf("visibility %q is invalid; must be \"public\" or \"private\"", req.Visibility))
+		return
+	}
+
+	comp, err := h.Store.UpdateComponentVisibility(r.Context(), name, req.Visibility)
+	if err != nil {
+		if errors.Is(err, store.ErrComponentNotFound) {
+			writeError(w, http.StatusNotFound, "COMPONENT_NOT_FOUND",
+				fmt.Sprintf("component %q not found", name))
+			return
+		}
+		h.Logger.Error("failed to update component", slog.String("name", name), slog.String("error", err.Error()))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(comp)
+}
+
 // initRPMTree creates the RPM directory tree under RPMDataRoot for the component.
 // Path structure: {RPMDataRoot}/rpm/{component}/{series}/{os_family}-{arch}/
 func (h *ComponentsHandler) initRPMTree(ctx context.Context, comp *store.Component) error {

--- a/auth/internal/handler/components_test.go
+++ b/auth/internal/handler/components_test.go
@@ -96,6 +96,15 @@ func (s *stubComponentStore) DeleteComponentWithRevoke(ctx context.Context, name
 	return n, nil
 }
 
+func (s *stubComponentStore) UpdateComponentVisibility(_ context.Context, name, visibility string) (*store.Component, error) {
+	c, ok := s.comps[name]
+	if !ok {
+		return nil, store.ErrComponentNotFound
+	}
+	c.Visibility = visibility
+	return c, nil
+}
+
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 func newTestComponentsHandler(t *testing.T) (*ComponentsHandler, *stubComponentStore) {
@@ -407,6 +416,84 @@ func TestComponentDelete_NotFound(t *testing.T) {
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status: want 404, got %d", w.Code)
 	}
+}
+
+// ─── PATCH /api/v1/components/{name} ─────────────────────────────────────────
+
+func TestComponentUpdate_PrivateToPublic(t *testing.T) {
+	h, st := newTestComponentsHandler(t)
+	ctx := context.Background()
+	_, _ = st.CreateComponent(ctx, &store.Component{
+		Name: "core", Visibility: "private",
+		RPMSeries: []string{}, RPMOSFamilies: []string{}, RPMArchitectures: []string{},
+	})
+
+	body, _ := json.Marshal(updateComponentRequest{Visibility: "public"})
+	r := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", body)
+	w := httptest.NewRecorder()
+	h.Update(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status: want 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+	var comp store.Component
+	if err := json.NewDecoder(w.Body).Decode(&comp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if comp.Visibility != "public" {
+		t.Errorf("visibility: want public, got %q", comp.Visibility)
+	}
+}
+
+func TestComponentUpdate_PublicToPrivate(t *testing.T) {
+	h, st := newTestComponentsHandler(t)
+	ctx := context.Background()
+	_, _ = st.CreateComponent(ctx, &store.Component{
+		Name: "core", Visibility: "public",
+		RPMSeries: []string{}, RPMOSFamilies: []string{}, RPMArchitectures: []string{},
+	})
+
+	body, _ := json.Marshal(updateComponentRequest{Visibility: "private"})
+	r := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", body)
+	w := httptest.NewRecorder()
+	h.Update(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status: want 200, got %d", w.Code)
+	}
+	var comp store.Component
+	if err := json.NewDecoder(w.Body).Decode(&comp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if comp.Visibility != "private" {
+		t.Errorf("visibility: want private, got %q", comp.Visibility)
+	}
+}
+
+func TestComponentUpdate_NotFound(t *testing.T) {
+	h, _ := newTestComponentsHandler(t)
+	body, _ := json.Marshal(updateComponentRequest{Visibility: "public"})
+	r := chiRequest(http.MethodPatch, "/api/v1/components/unknown", "unknown", body)
+	w := httptest.NewRecorder()
+	h.Update(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d", w.Code)
+	}
+	assertErrorCode(t, w, "COMPONENT_NOT_FOUND")
+}
+
+func TestComponentUpdate_InvalidVisibility(t *testing.T) {
+	h, _ := newTestComponentsHandler(t)
+	body, _ := json.Marshal(updateComponentRequest{Visibility: "restricted"})
+	r := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", body)
+	w := httptest.NewRecorder()
+	h.Update(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+	assertErrorCode(t, w, "INVALID_VISIBILITY")
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────

--- a/auth/internal/handler/forward_auth.go
+++ b/auth/internal/handler/forward_auth.go
@@ -14,28 +14,20 @@ import (
 
 // ForwardAuthHandler validates subscriber credentials for Traefik forwardAuth.
 // GET /auth — returns 200 (allow), 401 (deny), or 503 (error/fail-closed).
-// Construct with NewForwardAuthHandler to guarantee non-nil component maps.
+// Component visibility is resolved via a live DB lookup on every request so that
+// visibility changes take effect immediately without a service restart.
 type ForwardAuthHandler struct {
-	Store            store.KeyStore
-	Logger           *slog.Logger
-	ValidComponents  map[string]bool // set for O(1) membership checks
-	PublicComponents map[string]bool // components that bypass credential checking
+	Store          store.KeyStore
+	ComponentStore store.ComponentStore
+	Logger         *slog.Logger
 }
 
-// NewForwardAuthHandler returns a ForwardAuthHandler with nil maps coerced to
-// empty maps so that component lookups in ServeHTTP never misbehave silently.
-func NewForwardAuthHandler(st store.KeyStore, logger *slog.Logger, validComponents, publicComponents map[string]bool) *ForwardAuthHandler {
-	if validComponents == nil {
-		validComponents = map[string]bool{}
-	}
-	if publicComponents == nil {
-		publicComponents = map[string]bool{}
-	}
+// NewForwardAuthHandler returns a ForwardAuthHandler backed by the given stores.
+func NewForwardAuthHandler(st store.KeyStore, cs store.ComponentStore, logger *slog.Logger) *ForwardAuthHandler {
 	return &ForwardAuthHandler{
-		Store:            st,
-		Logger:           logger,
-		ValidComponents:  validComponents,
-		PublicComponents: publicComponents,
+		Store:          st,
+		ComponentStore: cs,
+		Logger:         logger,
 	}
 }
 
@@ -48,7 +40,6 @@ func (h *ForwardAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		metrics.RequestDuration.Observe(time.Since(start).Seconds())
 	}()
 
-	// Resolve component to check for public bypass before any credential work.
 	requestedComponent, ok := extractComponent(r.Header.Get("X-Forwarded-Uri"))
 	if !ok {
 		metrics.RequestsTotal.WithLabelValues("denied").Inc()
@@ -56,8 +47,27 @@ func (h *ForwardAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Live DB lookup — resolves visibility without requiring a restart after PATCH.
+	// Unknown components return 401 (not 404) to prevent component enumeration by
+	// unauthenticated callers.
+	comp, err := h.ComponentStore.GetComponent(r.Context(), requestedComponent)
+	if err != nil {
+		if errors.Is(err, store.ErrComponentNotFound) {
+			metrics.RequestsTotal.WithLabelValues("denied").Inc()
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		h.Logger.Error("store error resolving component",
+			slog.String("component", requestedComponent),
+			slog.String("error", err.Error()),
+		)
+		metrics.RequestsTotal.WithLabelValues("error").Inc()
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
 	// Public components bypass credential checking entirely.
-	if h.PublicComponents[requestedComponent] {
+	if comp.Visibility == "public" {
 		h.Logger.Info("public component access allowed", slog.String("component", requestedComponent))
 		metrics.RequestsTotal.WithLabelValues("allowed-public").Inc()
 		w.WriteHeader(http.StatusOK)
@@ -88,13 +98,7 @@ func (h *ForwardAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 404 only visible to authenticated callers — prevents component enumeration by unauthenticated actors.
-	if !h.ValidComponents[requestedComponent] {
-		metrics.RequestsTotal.WithLabelValues("denied").Inc()
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
+	// Component existence already confirmed by GetComponent above.
 	if key.Component != requestedComponent {
 		metrics.RequestsTotal.WithLabelValues("denied").Inc()
 		w.WriteHeader(http.StatusUnauthorized)

--- a/auth/internal/handler/forward_auth_test.go
+++ b/auth/internal/handler/forward_auth_test.go
@@ -72,22 +72,29 @@ func basicAuthHeader(key string) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte("subscriber:"+key))
 }
 
+// newTestComponentStore returns a stub with "core" (private) and "minion" (private) pre-seeded.
+func newTestComponentStore() *stubComponentStore {
+	cs := newStubComponentStore()
+	cs.comps["core"] = &store.Component{Name: "core", Visibility: "private"}
+	cs.comps["minion"] = &store.Component{Name: "minion", Visibility: "private"}
+	return cs
+}
+
 func newTestHandler(s store.KeyStore) *ForwardAuthHandler {
 	return &ForwardAuthHandler{
-		Store:            s,
-		Logger:           slog.Default(),
-		ValidComponents:  map[string]bool{"core": true, "minion": true},
-		PublicComponents: map[string]bool{},
+		Store:          s,
+		ComponentStore: newTestComponentStore(),
+		Logger:         slog.Default(),
 	}
 }
 
-func TestNewForwardAuthHandler_NilMapsCoerced(t *testing.T) {
-	h := NewForwardAuthHandler(&mockStore{}, slog.Default(), nil, nil)
-	if h.ValidComponents == nil {
-		t.Error("ValidComponents should not be nil after construction with nil input")
+func TestNewForwardAuthHandler_Constructs(t *testing.T) {
+	h := NewForwardAuthHandler(&mockStore{}, newTestComponentStore(), slog.Default())
+	if h.Store == nil {
+		t.Error("Store should not be nil")
 	}
-	if h.PublicComponents == nil {
-		t.Error("PublicComponents should not be nil after construction with nil input")
+	if h.ComponentStore == nil {
+		t.Error("ComponentStore should not be nil")
 	}
 }
 
@@ -281,13 +288,15 @@ func TestForwardAuth_StoreError(t *testing.T) {
 	}
 }
 
+func newPublicCoreHandler(keyStore store.KeyStore) *ForwardAuthHandler {
+	cs := newStubComponentStore()
+	cs.comps["core"] = &store.Component{Name: "core", Visibility: "public"}
+	cs.comps["minion"] = &store.Component{Name: "minion", Visibility: "private"}
+	return &ForwardAuthHandler{Store: keyStore, ComponentStore: cs, Logger: slog.Default()}
+}
+
 func TestForwardAuth_PublicComponent_NoCreds(t *testing.T) {
-	h := &ForwardAuthHandler{
-		Store:            &mockStore{},
-		Logger:           slog.Default(),
-		ValidComponents:  map[string]bool{"core": true, "minion": true},
-		PublicComponents: map[string]bool{"core": true},
-	}
+	h := newPublicCoreHandler(&mockStore{})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
@@ -299,18 +308,13 @@ func TestForwardAuth_PublicComponent_NoCreds(t *testing.T) {
 }
 
 func TestForwardAuth_PublicComponent_WithCreds(t *testing.T) {
-	// Credentials are present but bypassed entirely — store is never consulted.
-	h := &ForwardAuthHandler{
-		Store: &mockStore{
-			getByValueFn: func(_ context.Context, _ string) (*store.Key, error) {
-				t.Fatal("GetByValue should not be called for public component")
-				return nil, nil
-			},
+	// Credentials are present but bypassed entirely — key store is never consulted.
+	h := newPublicCoreHandler(&mockStore{
+		getByValueFn: func(_ context.Context, _ string) (*store.Key, error) {
+			t.Fatal("GetByValue should not be called for public component")
+			return nil, nil
 		},
-		Logger:           slog.Default(),
-		ValidComponents:  map[string]bool{"core": true, "minion": true},
-		PublicComponents: map[string]bool{"core": true},
-	}
+	})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("Authorization", basicAuthHeader(validKey))
 	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
@@ -324,17 +328,12 @@ func TestForwardAuth_PublicComponent_WithCreds(t *testing.T) {
 
 func TestForwardAuth_PublicComponent_MalformedAuth(t *testing.T) {
 	// Malformed Authorization header is also bypassed for public components.
-	h := &ForwardAuthHandler{
-		Store: &mockStore{
-			getByValueFn: func(_ context.Context, _ string) (*store.Key, error) {
-				t.Fatal("GetByValue should not be called for public component")
-				return nil, nil
-			},
+	h := newPublicCoreHandler(&mockStore{
+		getByValueFn: func(_ context.Context, _ string) (*store.Key, error) {
+			t.Fatal("GetByValue should not be called for public component")
+			return nil, nil
 		},
-		Logger:           slog.Default(),
-		ValidComponents:  map[string]bool{"core": true, "minion": true},
-		PublicComponents: map[string]bool{"core": true},
-	}
+	})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("Authorization", "Bearer not-basic-auth")
 	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
@@ -347,12 +346,7 @@ func TestForwardAuth_PublicComponent_MalformedAuth(t *testing.T) {
 }
 
 func TestForwardAuth_PrivateComponent_NoCreds(t *testing.T) {
-	h := &ForwardAuthHandler{
-		Store:            &mockStore{},
-		Logger:           slog.Default(),
-		ValidComponents:  map[string]bool{"core": true, "minion": true},
-		PublicComponents: map[string]bool{"core": true},
-	}
+	h := newPublicCoreHandler(&mockStore{})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("X-Forwarded-Uri", "/rpm/minion/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
@@ -364,37 +358,81 @@ func TestForwardAuth_PrivateComponent_NoCreds(t *testing.T) {
 }
 
 func TestForwardAuth_NonexistentComponent(t *testing.T) {
-	// 404 is only visible to authenticated callers — credential check runs first.
-	h := newTestHandler(&mockStore{
-		getByValueFn: func(_ context.Context, value string) (*store.Key, error) {
-			return &store.Key{ID: value, Component: "core", Active: true}, nil
-		},
-	})
-	req := httptest.NewRequest("GET", "/auth", nil)
-	req.Header.Set("Authorization", basicAuthHeader(validKey))
-	req.Header.Set("X-Forwarded-Uri", "/rpm/unknown/2025/el9-x86_64/")
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-
-	if w.Code != http.StatusNotFound {
-		t.Errorf("expected 404 for nonexistent component (authenticated), got %d", w.Code)
-	}
-}
-
-func TestForwardAuth_NonexistentComponent_NoCreds(t *testing.T) {
-	// Unauthenticated callers get 401 for unknown components — prevents component enumeration.
+	// Unknown components return 401 regardless of auth state — prevents component enumeration.
+	// (Previously returned 404 for authenticated callers; live DB lookup returns 401 uniformly.)
 	h := newTestHandler(&mockStore{
 		getByValueFn: func(_ context.Context, _ string) (*store.Key, error) {
-			t.Fatal("GetByValue should not be called when no Authorization header")
+			t.Fatal("GetByValue should not be called when component is unknown")
 			return nil, nil
 		},
 	})
+	for _, withAuth := range []bool{true, false} {
+		req := httptest.NewRequest("GET", "/auth", nil)
+		if withAuth {
+			req.Header.Set("Authorization", basicAuthHeader(validKey))
+		}
+		req.Header.Set("X-Forwarded-Uri", "/rpm/unknown/2025/el9-x86_64/")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("auth=%v: expected 401 for unknown component, got %d", withAuth, w.Code)
+		}
+	}
+}
+
+func TestForwardAuth_ComponentStoreError(t *testing.T) {
+	// A component store error fails closed (503), not open.
+	cs := newStubComponentStore()
+	cs.comps["core"] = &store.Component{Name: "core", Visibility: "private"}
+	// Override GetComponent to simulate a DB error by using a wrapper.
+	errCS := &errComponentStore{inner: cs, errOn: "core"}
+	h := &ForwardAuthHandler{
+		Store:          &mockStore{},
+		ComponentStore: errCS,
+		Logger:         slog.Default(),
+	}
 	req := httptest.NewRequest("GET", "/auth", nil)
-	req.Header.Set("X-Forwarded-Uri", "/rpm/unknown/2025/el9-x86_64/")
+	req.Header.Set("Authorization", basicAuthHeader(validKey))
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("expected 401 for nonexistent component with no creds, got %d", w.Code)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 on component store error, got %d", w.Code)
 	}
+}
+
+// errComponentStore wraps a stubComponentStore and injects an error for a specific component name.
+type errComponentStore struct {
+	inner *stubComponentStore
+	errOn string
+}
+
+func (e *errComponentStore) GetComponent(ctx context.Context, name string) (*store.Component, error) {
+	if name == e.errOn {
+		return nil, errors.New("database connection lost")
+	}
+	return e.inner.GetComponent(ctx, name)
+}
+func (e *errComponentStore) CreateComponent(ctx context.Context, c *store.Component) (*store.Component, error) {
+	return e.inner.CreateComponent(ctx, c)
+}
+func (e *errComponentStore) ListComponents(ctx context.Context) ([]*store.Component, error) {
+	return e.inner.ListComponents(ctx)
+}
+func (e *errComponentStore) DeleteComponent(ctx context.Context, name string) error {
+	return e.inner.DeleteComponent(ctx, name)
+}
+func (e *errComponentStore) RevokeComponentKeys(ctx context.Context, component string) (int64, error) {
+	return e.inner.RevokeComponentKeys(ctx, component)
+}
+func (e *errComponentStore) CountActiveComponentKeys(ctx context.Context, component string) (int64, error) {
+	return e.inner.CountActiveComponentKeys(ctx, component)
+}
+func (e *errComponentStore) DeleteComponentWithRevoke(ctx context.Context, name string) (int64, error) {
+	return e.inner.DeleteComponentWithRevoke(ctx, name)
+}
+func (e *errComponentStore) UpdateComponentVisibility(ctx context.Context, name, vis string) (*store.Component, error) {
+	return e.inner.UpdateComponentVisibility(ctx, name, vis)
 }

--- a/auth/internal/store/sqlite.go
+++ b/auth/internal/store/sqlite.go
@@ -440,6 +440,24 @@ func (s *SQLiteStore) DeleteComponentWithRevoke(ctx context.Context, name string
 	return revoked, nil
 }
 
+// UpdateComponentVisibility sets the visibility field for a component.
+// Returns the updated component record or ErrComponentNotFound if the component does not exist.
+func (s *SQLiteStore) UpdateComponentVisibility(ctx context.Context, name, visibility string) (*Component, error) {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE components SET visibility = ? WHERE name = ?`, visibility, name)
+	if err != nil {
+		return nil, fmt.Errorf("update component visibility: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("update component visibility rows affected: %w", err)
+	}
+	if n == 0 {
+		return nil, fmt.Errorf("update component visibility: %w", ErrComponentNotFound)
+	}
+	return s.GetComponent(ctx, name)
+}
+
 // LoadComponentSets queries the components table and returns two maps for O(1) lookups:
 //   - validComponents: all component names
 //   - publicComponents: component names with visibility="public"

--- a/auth/internal/store/sqlite.go
+++ b/auth/internal/store/sqlite.go
@@ -442,20 +442,21 @@ func (s *SQLiteStore) DeleteComponentWithRevoke(ctx context.Context, name string
 
 // UpdateComponentVisibility sets the visibility field for a component.
 // Returns the updated component record or ErrComponentNotFound if the component does not exist.
+// Uses RETURNING to read back the row in the same statement, avoiding a TOCTOU between
+// the UPDATE and a subsequent SELECT.
 func (s *SQLiteStore) UpdateComponentVisibility(ctx context.Context, name, visibility string) (*Component, error) {
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE components SET visibility = ? WHERE name = ?`, visibility, name)
+	row := s.db.QueryRowContext(ctx,
+		`UPDATE components SET visibility = ? WHERE name = ?
+		 RETURNING name, visibility, rpm_series, rpm_os_families, rpm_architectures, created_at`,
+		visibility, name)
+	c, err := scanComponent(row)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("update component visibility: %w", ErrComponentNotFound)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("update component visibility: %w", err)
 	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return nil, fmt.Errorf("update component visibility rows affected: %w", err)
-	}
-	if n == 0 {
-		return nil, fmt.Errorf("update component visibility: %w", ErrComponentNotFound)
-	}
-	return s.GetComponent(ctx, name)
+	return c, nil
 }
 
 // LoadComponentSets queries the components table and returns two maps for O(1) lookups:

--- a/auth/internal/store/sqlite_test.go
+++ b/auth/internal/store/sqlite_test.go
@@ -414,3 +414,63 @@ func TestLoadComponentSets(t *testing.T) {
 		t.Error("minion should be public")
 	}
 }
+
+func TestUpdateComponentVisibility_Success(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	if _, err := s.CreateComponent(ctx, newTestComponent("core", "private")); err != nil {
+		t.Fatalf("CreateComponent: %v", err)
+	}
+
+	updated, err := s.UpdateComponentVisibility(ctx, "core", "public")
+	if err != nil {
+		t.Fatalf("UpdateComponentVisibility: %v", err)
+	}
+	if updated.Visibility != "public" {
+		t.Errorf("expected visibility public, got %q", updated.Visibility)
+	}
+	if updated.Name != "core" {
+		t.Errorf("expected name core, got %q", updated.Name)
+	}
+
+	// Confirm the change is persisted.
+	got, err := s.GetComponent(ctx, "core")
+	if err != nil {
+		t.Fatalf("GetComponent after update: %v", err)
+	}
+	if got.Visibility != "public" {
+		t.Errorf("persisted visibility: want public, got %q", got.Visibility)
+	}
+}
+
+func TestUpdateComponentVisibility_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.UpdateComponentVisibility(context.Background(), "nonexistent", "public")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrComponentNotFound) {
+		t.Fatalf("expected ErrComponentNotFound, got: %v", err)
+	}
+}
+
+func TestUpdateComponentVisibility_RoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	if _, err := s.CreateComponent(ctx, newTestComponent("core", "public")); err != nil {
+		t.Fatalf("CreateComponent: %v", err)
+	}
+
+	// public → private → public
+	for _, vis := range []string{"private", "public"} {
+		got, err := s.UpdateComponentVisibility(ctx, "core", vis)
+		if err != nil {
+			t.Fatalf("UpdateComponentVisibility(%q): %v", vis, err)
+		}
+		if got.Visibility != vis {
+			t.Errorf("returned visibility: want %q, got %q", vis, got.Visibility)
+		}
+	}
+}

--- a/auth/internal/store/store.go
+++ b/auth/internal/store/store.go
@@ -54,4 +54,5 @@ type ComponentStore interface {
 	RevokeComponentKeys(ctx context.Context, component string) (int64, error)
 	CountActiveComponentKeys(ctx context.Context, component string) (int64, error)
 	DeleteComponentWithRevoke(ctx context.Context, name string) (int64, error)
+	UpdateComponentVisibility(ctx context.Context, name, visibility string) (*Component, error)
 }

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -64,11 +64,6 @@ curl -s -X POST http://localhost:8080/api/v1/components \
     "rpm_architectures": ["x86_64"]
   }' | jq .
 
-# The auth service loads its component map at startup — restart to make
-# forward-auth recognise the new component.
-docker compose -f compose.yml -f compose.override.ci.yml restart auth
-until curl -sf http://localhost:8080/health > /dev/null; do sleep 2; done
-
 # Create a subscription key scoped to the component
 curl -s -X POST http://localhost:8080/api/v1/keys \
   -H 'Content-Type: application/json' \

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -77,9 +77,12 @@ curl -s -X POST http://localhost:8080/api/v1/keys \
   "label": "dev-key",
   "active": true,
   "created_at": "2025-01-01T00:00:00Z",
-  "component_visibility": "public"
+  "component_visibility": "private"
 }
 ```
+
+!!! note
+    `component_visibility` is derived from a startup-loaded snapshot and shows `"private"` (the safe default) for any component provisioned after the service started. This field is cosmetic — forward-auth always reads visibility live from the database, so `core` is publicly accessible immediately without a restart.
 
 ## 4. Make an authenticated request
 

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -103,26 +103,17 @@ curl -s http://127.0.0.1:8088/api/v1/keys | jq '.[] | {id, component, label, act
 
 **Step 4 — Is the component marked public?**
 
-If a component has `visibility: public` (as set via `POST /api/v1/components`), the auth service allows requests to its paths without inspecting credentials. Keys for public components are valid but are not checked during auth — any request, authenticated or not, returns `200`. If a subscriber reports getting `401` on a public component path, confirm the component's visibility via the API and that the auth service has restarted since the component was provisioned:
+If a component has `visibility: public` (as set via `POST /api/v1/components` or updated via `PATCH /api/v1/components/{name}`), the auth service allows requests to its paths without inspecting credentials. Forward-auth reads visibility from the database on every request — changes take effect immediately without a restart. If a subscriber reports getting `401` on a public component path, confirm the component's current visibility:
 
 ```bash
 curl -s http://127.0.0.1:8088/api/v1/components/core | jq .visibility
-docker compose logs auth | grep "loaded components"
-# expect the public component to appear in the list
 ```
 
 **Restart semantics — when a restart is and is not required:**
 
-- **Key creation** (`POST /api/v1/keys`) queries the database directly — a restart is **not** needed for the auth service to accept keys for a newly provisioned component.
-- **Forward-auth decisions** (subscriber package access) use an in-memory component map loaded at startup — a restart **is** required for new or deleted components to be reflected in access control.
-- **Key list filter** (`GET /api/v1/keys?component=<name>`) also validates the component name against the in-memory map — it returns `400 INVALID_COMPONENT` for a newly provisioned component until the service is restarted.
-- **Authenticated requests to an unrecognised component** return `404` (not `401`) — if a subscriber has a valid key but the component isn't in the in-memory map, the auth service returns `404 Not Found` rather than `401 Unauthorized`. Restart auth to resolve.
-
-If the component record was updated in the database (via the API) but the auth service was not restarted, restart it:
-
-```bash
-docker compose restart auth
-```
+- **Key creation** (`POST /api/v1/keys`) and **forward-auth decisions** both query the database on every request — a restart is **not** needed for new components, deleted components, or visibility changes to take effect.
+- **Key list filter** (`GET /api/v1/keys?component=<name>`) validates the component name against an in-memory map loaded at startup — it returns `400 INVALID_COMPONENT` for a newly provisioned component until the service is restarted.
+- **`component_visibility` in key responses** is also derived from the startup-loaded map — it may show a stale value after a `PATCH /api/v1/components/{name}` visibility change until the service is restarted. This is cosmetic only; forward-auth always uses the live value.
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -22,7 +22,7 @@ The health endpoint `GET /health` returns 200 when the service is up.
 
 ## Components
 
-Components are provisioned via the admin API and stored in the SQLite database. The auth service loads the component list at startup.
+Components are provisioned via the admin API and stored in the SQLite database. Forward-auth resolves component visibility via a live database lookup on every request; the `GET /api/v1/keys?component=` filter and `component_visibility` field in key responses use a snapshot loaded at startup (restart required to pick up new components in those paths).
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -146,7 +146,7 @@ RPM directory content is **not** removed — the operator is responsible for arc
 
 ### Updating a component
 
-`PATCH /api/v1/components/{name}` updates mutable component fields. Currently only `visibility` may be changed. The update is persisted immediately and takes effect on the next subscriber request — no service restart is required.
+`PATCH /api/v1/components/{name}` updates mutable component fields. Currently only `visibility` may be changed. The `visibility` field is **required** — omitting it or sending an empty body returns `400 INVALID_VISIBILITY`. The update is persisted immediately and takes effect on the next subscriber request — no service restart is required.
 
 ```bash
 curl -s -X PATCH http://127.0.0.1:8088/api/v1/components/minion \

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -29,6 +29,7 @@ Components are provisioned via the admin API and stored in the SQLite database. 
 | `POST` | `/api/v1/components` | Provision a new component |
 | `GET` | `/api/v1/components` | List all components |
 | `GET` | `/api/v1/components/{name}` | Get a single component |
+| `PATCH` | `/api/v1/components/{name}` | Update component visibility |
 | `DELETE` | `/api/v1/components/{name}` | Deprovision a component (safe-lock) |
 
 A key scoped to `core` grants access only to `/rpm/core/`, `/deb/core/`, and `lts-core` OCI paths. Cross-component access is denied — a `core` key cannot access `/rpm/minion/`. The component name in the key must match the path segment exactly.
@@ -143,15 +144,36 @@ curl -s -X DELETE http://127.0.0.1:8088/api/v1/components/minion?confirm=minion 
 
 RPM directory content is **not** removed — the operator is responsible for archiving packages before deleting the directory.
 
+### Updating a component
+
+`PATCH /api/v1/components/{name}` updates mutable component fields. Currently only `visibility` may be changed. The update is persisted immediately and takes effect on the next subscriber request — no service restart is required.
+
+```bash
+curl -s -X PATCH http://127.0.0.1:8088/api/v1/components/minion \
+  -H 'Content-Type: application/json' \
+  -d '{"visibility": "public"}' | jq .
+```
+
+Returns the updated component object on success.
+
+**Response codes:**
+
+| Code | Condition |
+|------|-----------|
+| `200 OK` | Visibility updated; returns updated component record |
+| `400 Bad Request` | `visibility` is not `"public"` or `"private"` (`INVALID_VISIBILITY`); or body is not valid JSON (`INVALID_REQUEST`) |
+| `404 Not Found` | Component does not exist (`COMPONENT_NOT_FOUND`) |
+| `500 Internal Server Error` | Unexpected store error |
+
 ### Component API error codes
 
 | Code | Returned by | Description |
 |------|-------------|-------------|
-| `INVALID_REQUEST` | POST | `name` is missing, empty, or contains path-unsafe characters; or an array field contains a path-unsafe value |
-| `INVALID_VISIBILITY` | POST | `visibility` is not `"public"` or `"private"` |
+| `INVALID_REQUEST` | POST, PATCH | `name` is missing, empty, or contains path-unsafe characters; or an array field contains a path-unsafe value; or body is not valid JSON |
+| `INVALID_VISIBILITY` | POST, PATCH | `visibility` is not `"public"` or `"private"` |
 | `COMPONENT_EXISTS` | POST | A component with the given name already exists |
 | `RPM_INIT_FAILED` | POST | RPM directory tree creation failed; the component record was rolled back |
-| `COMPONENT_NOT_FOUND` | GET `/{name}`, DELETE | No component with the given name exists |
+| `COMPONENT_NOT_FOUND` | GET `/{name}`, PATCH, DELETE | No component with the given name exists |
 | `CONFIRM_REQUIRED` | DELETE (no confirm) | `?confirm={name}` was absent or did not match; response includes impact preview |
 
 ## Examples


### PR DESCRIPTION
Closes #82.

## Summary

- Adds `PATCH /api/v1/components/{name}` to update component visibility (`public`/`private`) without reprovisioning
- Replaces startup-loaded in-memory component maps in forward-auth with a live `GetComponent` DB lookup per request — visibility changes and all component lifecycle events take effect immediately, no restart required
- Unknown components now return `401` to all callers (previously `404` for authenticated, `401` for unauthenticated) — prevents component enumeration uniformly

## Behavioural notes

- `component_visibility` field in key responses is still derived from the startup-loaded map (cosmetic only — forward-auth always reads the live value)
- Quick-start no longer requires a restart step between `POST /api/v1/components` and the first authenticated request

## Test plan

- [ ] `go test ./...` passes (all handler and store tests green)
- [ ] `go build ./...` clean
- [ ] `TestForwardAuth_NonexistentComponent` updated: expects `401` in both authed and unauthed cases
- [ ] `TestForwardAuth_ComponentStoreError`: new test, confirms `503` on component store DB error
- [ ] `TestComponentUpdate_*`: 4 new PATCH handler tests (private→public, public→private, not found, invalid visibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)