### PR TITLE
fix(auth): replace bare 500s with structured error responses

### DIFF
--- a/auth/internal/handler/components.go
+++ b/auth/internal/handler/components.go
@@ -125,7 +125,7 @@ func (h *ComponentsHandler) Create(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.Logger.Error("failed to create component", slog.String("name", req.Name), slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "COMPONENT_CREATE_FAILED", "failed to create component")
 		return
 	}
 
@@ -151,7 +151,7 @@ func (h *ComponentsHandler) List(w http.ResponseWriter, r *http.Request) {
 	comps, err := h.Store.ListComponents(r.Context())
 	if err != nil {
 		h.Logger.Error("failed to list components", slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "COMPONENT_LIST_FAILED", "failed to list components")
 		return
 	}
 
@@ -172,7 +172,7 @@ func (h *ComponentsHandler) GetOne(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.Logger.Error("failed to get component", slog.String("name", name), slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "COMPONENT_GET_FAILED", "failed to get component")
 		return
 	}
 
@@ -195,14 +195,14 @@ func (h *ComponentsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.Logger.Error("failed to get component for delete", slog.String("name", name), slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "COMPONENT_DELETE_FAILED", "failed to get component for delete")
 		return
 	}
 
 	activeKeys, err := h.Store.CountActiveComponentKeys(r.Context(), name)
 	if err != nil {
 		h.Logger.Error("failed to count keys", slog.String("name", name), slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "COMPONENT_DELETE_FAILED", "failed to count keys")
 		return
 	}
 
@@ -228,7 +228,7 @@ func (h *ComponentsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	revoked, err := h.Store.DeleteComponentWithRevoke(r.Context(), name)
 	if err != nil {
 		h.Logger.Error("failed to delete component", slog.String("name", name), slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "COMPONENT_DELETE_FAILED", "failed to delete component")
 		return
 	}
 
@@ -268,7 +268,7 @@ func (h *ComponentsHandler) Update(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.Logger.Error("failed to update component", slog.String("name", name), slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "COMPONENT_UPDATE_FAILED", "failed to update component")
 		return
 	}
 

--- a/auth/internal/handler/components_test.go
+++ b/auth/internal/handler/components_test.go
@@ -20,8 +20,9 @@ import (
 // ─── in-memory ComponentStore stub ───────────────────────────────────────────
 
 type stubComponentStore struct {
-	comps map[string]*store.Component
-	keys  map[string]int64 // component → active key count (for impact preview)
+	comps    map[string]*store.Component
+	keys     map[string]int64 // component → active key count (for impact preview)
+	updateFn func(ctx context.Context, name, visibility string) (*store.Component, error)
 }
 
 func newStubComponentStore() *stubComponentStore {
@@ -96,12 +97,16 @@ func (s *stubComponentStore) DeleteComponentWithRevoke(ctx context.Context, name
 	return n, nil
 }
 
-func (s *stubComponentStore) UpdateComponentVisibility(_ context.Context, name, visibility string) (*store.Component, error) {
+func (s *stubComponentStore) UpdateComponentVisibility(ctx context.Context, name, visibility string) (*store.Component, error) {
+	if s.updateFn != nil {
+		return s.updateFn(ctx, name, visibility)
+	}
 	c, ok := s.comps[name]
 	if !ok {
 		return nil, store.ErrComponentNotFound
 	}
 	c.Visibility = visibility
+	s.comps[name] = c // explicit re-store so callers see the mutation via map lookup
 	return c, nil
 }
 
@@ -494,6 +499,35 @@ func TestComponentUpdate_InvalidVisibility(t *testing.T) {
 		t.Errorf("status: want 400, got %d", w.Code)
 	}
 	assertErrorCode(t, w, "INVALID_VISIBILITY")
+}
+
+func TestComponentUpdate_MalformedBody(t *testing.T) {
+	h, _ := newTestComponentsHandler(t)
+	r := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", []byte("not-json"))
+	w := httptest.NewRecorder()
+	h.Update(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+	assertErrorCode(t, w, "INVALID_REQUEST")
+}
+
+func TestComponentUpdate_StoreError(t *testing.T) {
+	h, cs := newTestComponentsHandler(t)
+	cs.updateFn = func(_ context.Context, _, _ string) (*store.Component, error) {
+		return nil, errors.New("database locked")
+	}
+
+	body, _ := json.Marshal(updateComponentRequest{Visibility: "public"})
+	r := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", body)
+	w := httptest.NewRecorder()
+	h.Update(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status: want 500, got %d", w.Code)
+	}
+	assertErrorCode(t, w, "COMPONENT_UPDATE_FAILED")
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────

--- a/auth/internal/handler/forward_auth_test.go
+++ b/auth/internal/handler/forward_auth_test.go
@@ -288,7 +288,7 @@ func TestForwardAuth_StoreError(t *testing.T) {
 	}
 }
 
-func newPublicCoreHandler(keyStore store.KeyStore) *ForwardAuthHandler {
+func newMixedVisibilityHandler(keyStore store.KeyStore) *ForwardAuthHandler {
 	cs := newStubComponentStore()
 	cs.comps["core"] = &store.Component{Name: "core", Visibility: "public"}
 	cs.comps["minion"] = &store.Component{Name: "minion", Visibility: "private"}
@@ -296,7 +296,7 @@ func newPublicCoreHandler(keyStore store.KeyStore) *ForwardAuthHandler {
 }
 
 func TestForwardAuth_PublicComponent_NoCreds(t *testing.T) {
-	h := newPublicCoreHandler(&mockStore{})
+	h := newMixedVisibilityHandler(&mockStore{})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
 	w := httptest.NewRecorder()
@@ -309,7 +309,7 @@ func TestForwardAuth_PublicComponent_NoCreds(t *testing.T) {
 
 func TestForwardAuth_PublicComponent_WithCreds(t *testing.T) {
 	// Credentials are present but bypassed entirely — key store is never consulted.
-	h := newPublicCoreHandler(&mockStore{
+	h := newMixedVisibilityHandler(&mockStore{
 		getByValueFn: func(_ context.Context, _ string) (*store.Key, error) {
 			t.Fatal("GetByValue should not be called for public component")
 			return nil, nil
@@ -328,7 +328,7 @@ func TestForwardAuth_PublicComponent_WithCreds(t *testing.T) {
 
 func TestForwardAuth_PublicComponent_MalformedAuth(t *testing.T) {
 	// Malformed Authorization header is also bypassed for public components.
-	h := newPublicCoreHandler(&mockStore{
+	h := newMixedVisibilityHandler(&mockStore{
 		getByValueFn: func(_ context.Context, _ string) (*store.Key, error) {
 			t.Fatal("GetByValue should not be called for public component")
 			return nil, nil
@@ -346,7 +346,7 @@ func TestForwardAuth_PublicComponent_MalformedAuth(t *testing.T) {
 }
 
 func TestForwardAuth_PrivateComponent_NoCreds(t *testing.T) {
-	h := newPublicCoreHandler(&mockStore{})
+	h := newMixedVisibilityHandler(&mockStore{})
 	req := httptest.NewRequest("GET", "/auth", nil)
 	req.Header.Set("X-Forwarded-Uri", "/rpm/minion/2025/el9-x86_64/")
 	w := httptest.NewRecorder()

--- a/auth/internal/handler/keys.go
+++ b/auth/internal/handler/keys.go
@@ -92,7 +92,7 @@ func (h *KeysHandler) Get(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.Logger.Error("failed to get key", slog.String("id", id), slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "KEY_GET_FAILED", "failed to get key")
 		return
 	}
 
@@ -130,12 +130,12 @@ func (h *KeysHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.Logger.Error("failed to get key after revoke", slog.String("id", id), slog.String("error", getErr.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "KEY_DELETE_FAILED", "failed to get key after revoke")
 		return
 	}
 
 	h.Logger.Error("failed to revoke key", slog.String("id", id), slog.String("error", err.Error()))
-	w.WriteHeader(http.StatusInternalServerError)
+	writeError(w, http.StatusInternalServerError, "KEY_DELETE_FAILED", "failed to revoke key")
 }
 
 // List handles GET /api/v1/keys — returns all keys, optionally filtered by ?component=.
@@ -150,7 +150,7 @@ func (h *KeysHandler) List(w http.ResponseWriter, r *http.Request) {
 	keys, err := h.Store.ListKeys(r.Context(), component)
 	if err != nil {
 		h.Logger.Error("failed to list keys", slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "KEY_LIST_FAILED", "failed to list keys")
 		return
 	}
 
@@ -180,14 +180,14 @@ func (h *KeysHandler) Create(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.Logger.Error("failed to validate component", slog.String("component", req.Component), slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "KEY_CREATE_FAILED", "failed to validate component")
 		return
 	}
 
 	key, err := h.Store.CreateKey(r.Context(), req.Component, req.Label, req.ExpiresAt)
 	if err != nil {
 		h.Logger.Error("failed to create key", slog.String("error", err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "KEY_CREATE_FAILED", "failed to create key")
 		return
 	}
 

--- a/auth/internal/handler/keys_test.go
+++ b/auth/internal/handler/keys_test.go
@@ -205,8 +205,10 @@ func TestCreate_StoreError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected 500, got %d", w.Code)
 	}
-	if w.Body.Len() != 0 {
-		t.Errorf("expected empty body on 500, got %q", w.Body.String())
+	var ae apiError
+	json.NewDecoder(w.Body).Decode(&ae)
+	if ae.Code != "KEY_CREATE_FAILED" {
+		t.Errorf("expected KEY_CREATE_FAILED, got %q", ae.Code)
 	}
 }
 
@@ -350,8 +352,10 @@ func TestList_StoreError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected 500, got %d", w.Code)
 	}
-	if w.Body.Len() != 0 {
-		t.Errorf("expected empty body on 500, got %q", w.Body.String())
+	var ae apiError
+	json.NewDecoder(w.Body).Decode(&ae)
+	if ae.Code != "KEY_LIST_FAILED" {
+		t.Errorf("expected KEY_LIST_FAILED, got %q", ae.Code)
 	}
 }
 
@@ -486,8 +490,10 @@ func TestGet_StoreError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected 500, got %d", w.Code)
 	}
-	if w.Body.Len() != 0 {
-		t.Errorf("expected empty body on 500, got %q", w.Body.String())
+	var ae apiError
+	json.NewDecoder(w.Body).Decode(&ae)
+	if ae.Code != "KEY_GET_FAILED" {
+		t.Errorf("expected KEY_GET_FAILED, got %q", ae.Code)
 	}
 }
 
@@ -573,7 +579,7 @@ func TestDelete_NotFound(t *testing.T) {
 	}
 }
 
-// TestDelete_RevokeStoreError — unexpected RevokeKey error returns 500 with empty body.
+// TestDelete_RevokeStoreError — unexpected RevokeKey error returns 500 KEY_DELETE_FAILED.
 func TestDelete_RevokeStoreError(t *testing.T) {
 	h := newTestKeysHandler(&mockStore{
 		revokeKeyFn: func(_ context.Context, _ string) error {
@@ -584,12 +590,14 @@ func TestDelete_RevokeStoreError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected 500, got %d", w.Code)
 	}
-	if w.Body.Len() != 0 {
-		t.Errorf("expected empty body, got %q", w.Body.String())
+	var ae apiError
+	json.NewDecoder(w.Body).Decode(&ae)
+	if ae.Code != "KEY_DELETE_FAILED" {
+		t.Errorf("expected KEY_DELETE_FAILED, got %q", ae.Code)
 	}
 }
 
-// TestDelete_GetByIDStoreError — RevokeKey returns ErrNotFound but GetByID errors → 500.
+// TestDelete_GetByIDStoreError — RevokeKey returns ErrNotFound but GetByID errors → 500 KEY_DELETE_FAILED.
 func TestDelete_GetByIDStoreError(t *testing.T) {
 	h := newTestKeysHandler(&mockStore{
 		revokeKeyFn: func(_ context.Context, _ string) error {
@@ -603,8 +611,10 @@ func TestDelete_GetByIDStoreError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected 500, got %d", w.Code)
 	}
-	if w.Body.Len() != 0 {
-		t.Errorf("expected empty body, got %q", w.Body.String())
+	var ae apiError
+	json.NewDecoder(w.Body).Decode(&ae)
+	if ae.Code != "KEY_DELETE_FAILED" {
+		t.Errorf("expected KEY_DELETE_FAILED, got %q", ae.Code)
 	}
 }
 

--- a/auth/internal/store/sqlite.go
+++ b/auth/internal/store/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -115,7 +116,7 @@ func (s *SQLiteStore) GetByValue(ctx context.Context, value string) (*Key, error
 		 FROM subscription_key WHERE id = ?`, value)
 
 	k, err := scanKey(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("get key: %w", ErrNotFound)
 	}
 	if err != nil {
@@ -138,7 +139,7 @@ func (s *SQLiteStore) GetByID(ctx context.Context, id string) (*Key, error) {
 		 FROM subscription_key WHERE id = ?`, id)
 
 	k, err := scanKey(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("get key: %w", ErrNotFound)
 	}
 	if err != nil {
@@ -322,7 +323,7 @@ func (s *SQLiteStore) GetComponent(ctx context.Context, name string) (*Component
 		`SELECT name, visibility, rpm_series, rpm_os_families, rpm_architectures, created_at
 		 FROM components WHERE name = ?`, name)
 	c, err := scanComponent(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("get component: %w", ErrComponentNotFound)
 	}
 	if err != nil {
@@ -450,7 +451,7 @@ func (s *SQLiteStore) UpdateComponentVisibility(ctx context.Context, name, visib
 		 RETURNING name, visibility, rpm_series, rpm_os_families, rpm_architectures, created_at`,
 		visibility, name)
 	c, err := scanComponent(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("update component visibility: %w", ErrComponentNotFound)
 	}
 	if err != nil {


### PR DESCRIPTION
## Summary

- Replaces all bare `w.WriteHeader(http.StatusInternalServerError)` calls in `keys.go` (6) and `components.go` (7) with `writeError(w, 500, "CODE", "message")` responses
- Error codes: `KEY_GET_FAILED`, `KEY_LIST_FAILED`, `KEY_CREATE_FAILED`, `KEY_DELETE_FAILED`, `COMPONENT_CREATE_FAILED`, `COMPONENT_LIST_FAILED`, `COMPONENT_GET_FAILED`, `COMPONENT_DELETE_FAILED`, `COMPONENT_UPDATE_FAILED`
- Forward-auth bare 503s are intentionally unchanged (fail-closed, no body)

## Test plan

- [ ] `go test ./...` passes
- [ ] Callers can now distinguish operation-specific 500 failures by `code` field

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)