### PR TITLE
docs: add contributor, security and support files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Something does not work as documented
+labels: [bug, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not report security vulnerabilities here. Use private reporting instead: https://github.com/no42-org/packyard/security/advisories/new
+  - type: input
+    id: version
+    attributes:
+      label: Packyard version
+      description: Release tag or image tag, for example `0.3.0` or `0.3.1-rc`.
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - auth service
+        - admin UI
+        - RPM serving
+        - DEB serving (Aptly)
+        - OCI registry (Zot)
+        - promotion workflows
+        - Compose / Traefik
+        - documentation
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you did, what you expected, what you saw instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. docker compose up -d
+        2. curl -u subscriber:<key> https://pkg.example.org/rpm/...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and configuration
+      description: Relevant `docker compose logs` output and the affected part of `compose.yml` or `.env`. Remove secrets and keys.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://no42-org.github.io/packyard/
+    about: Quick-start, operator runbooks, API and configuration reference.
+  - name: Report a security vulnerability
+    url: https://github.com/no42-org/packyard/security/advisories/new
+    about: Private reporting. Never file a vulnerability as a public issue.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,30 @@
+name: Enhancement
+description: Propose a new feature or an improvement
+labels: [enhancement, triage]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that Packyard does not support well today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should change, and roughly how. API shape, config keys, or UI behaviour if you have an opinion.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways to solve the problem, and why they fall short.
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: This is a breaking change for existing deployments
+        - label: I am willing to open a pull request for this

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What and why, in two or three sentences. -->
+
+Closes #<issue>
+
+## Checklist
+
+- [ ] Linked issue exists and is referenced above with a closing keyword
+- [ ] `cd auth && go test ./...` passes for auth changes
+- [ ] `make docs-build` passes for docs changes
+- [ ] Commits are signed off (DCO) and follow Conventional Commits
+- [ ] Docs updated where behaviour changed (README, docs/, RELEASING.md)

--- a/.gitignore
+++ b/.gitignore
@@ -4,17 +4,15 @@
 # IntelliJ
 .idea/
 
-# BMad framework (framework files, not project artifacts)
+# AI tools
 _bmad/
 _bmad-output/
-
-# Claude Code & agent integration (local IDE tooling)
+openspec/
 .claude/
 .agents/
 .agent/
 .codex/
 .gemini/
-openspec/
 
 # Scan results and local key material — never commit
 trivy_scan.txt

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,78 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at ronny@no42.org.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to Packyard
+
+Thanks for helping.
+This page covers the mechanics: how to build, how to commit, and how a change gets in.
+
+## Setup
+
+Requirements: Docker Compose v2, Go (version in `auth/go.mod`), Node 20 (version in `.nvmrc`), `curl`, `jq`.
+
+| Task | Command |
+|------|---------|
+| Install the docs toolchain | `make docs-install` |
+| Build the docs site (fails on broken links) | `make docs-build` |
+| Preview the docs with live reload | `make docs-serve` |
+| Build the admin SPA into the Go embed directory | `make admin-ui` |
+| Build the auth binary with the embedded SPA | `make build` |
+| Run the auth unit tests | `cd auth && go test ./...` |
+| Bring up the full stack and smoke-test it | `docker compose up -d && bash verify.sh` |
+
+Run `make help` to list every target.
+
+## Workflow
+
+1. Open or find an issue first. Every pull request references an issue with a closing keyword (`Closes #123`).
+2. Branch from `main`. Use `<type>/<short-description>`, for example `fix/forward-auth-401`.
+3. Keep one logical change per pull request.
+4. Pull requests are squash-merged. The PR title becomes the commit subject on `main`, so give it a Conventional Commit title.
+5. CI must be green before merge. The required checks are the auth unit tests, the Docker image build and the docs build.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/): `<type>[scope]: <description>`.
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`.
+A breaking change appends `!` to the type or adds a `BREAKING CHANGE:` footer.
+
+## Developer Certificate of Origin
+
+All commits must be signed off, certifying the [DCO](https://developercertificate.org/):
+
+```bash
+git commit -s
+```
+
+The `Signed-off-by` trailer must name a human identity.
+That person is responsible for the contribution, including its license compliance.
+The repository requires signed commits as well, so configure GPG or SSH commit signing.
+
+## AI-assisted contributions
+
+AI assistance is welcome.
+Commits produced with an AI agent carry an additional `Assisted-by: <Agent>:<model>` trailer, placed before the `Signed-off-by` line:
+
+```
+Assisted-by: ClaudeCode:claude-fable-5-1
+Signed-off-by: Jane Doe <jane@example.org>
+```
+
+The human signer reviews all AI-generated code and remains responsible for its correctness and license compliance.
+
+## Source file headers
+
+Every new source file starts with an SPDX header matching the repository license:
+
+```go
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+```
+
+Use the comment syntax of the language. Leave existing headers as they are.
+
+## Releases
+
+Maintainers cut releases from `main` by tag. The procedure is in [RELEASING.md](RELEASING.md).
+
+## Security issues
+
+Do not open a public issue for a vulnerability. See [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Packyard
 
+[![CI](https://github.com/no42-org/packyard/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/no42-org/packyard/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/no42-org/packyard?sort=semver)](https://github.com/no42-org/packyard/releases/latest)
+[![License: GPL-3.0-or-later](https://img.shields.io/badge/license-GPL--3.0--or--later-blue.svg)](LICENSE)
+
 Packyard is a self-hosted, authenticated distribution platform for LTS releases. It serves RPM, DEB, and OCI packages behind subscription key authentication, with a promotion pipeline that signs and publishes artifacts from CI.
 
 ## Architecture
@@ -13,12 +17,18 @@ Traefik (TLS termination, forwardAuth, routing)
     ├── /rpm/   → nginx (RPM repodata + packages)
     ├── /deb/   → nginx → Aptly (signed DEB snapshots)
     ├── /oci/   → Zot (OCI registry, cosign signatures)
-    ├── /gpg/   → nginx (public keys — unauthenticated)
-    └── /api/   → auth service (admin API, internal :8088)
+    └── /gpg/   → nginx (public keys, unauthenticated)
          │
          └── auth service (forwardAuth + key management)
                   │
-                  └── SQLite (subscription key store)
+                  └── SQLite (accounts, keys, components, operators, audit)
+
+Operator (admin.<domain>, OAuth session)
+    │
+    ▼
+Traefik
+    ├── /admin/*  → auth service (embedded React admin UI)
+    └── /api/v1/* → auth service (admin API)
 
 Promotion pipeline (GitHub Actions):
     RustFS (staging) → sign → publish → rpm/deb/zot
@@ -42,17 +52,30 @@ Promotion pipeline (GitHub Actions):
 
 Full documentation: https://no42-org.github.io/packyard/
 
-## Local Development
+## Quick Start
 
 Requires Docker Compose v2, `curl`, `jq`.
 
 ```bash
 git clone https://github.com/no42-org/packyard.git
 cd packyard
+cp .env.example .env        # set ACME_EMAIL, PKG_DOMAIN, ADMIN_DOMAIN and the OAuth provider
+docker compose up -d
 bash verify.sh
 ```
 
-See [Getting Started](https://no42-org.github.io/packyard/getting-started/quick-start) for the full walkthrough.
+Then provision a component and issue a subscriber key through the admin UI at `https://admin.<ADMIN_DOMAIN>/admin/`.
+See [Getting Started](https://no42-org.github.io/packyard/getting-started/quick-start) for the full walkthrough and [Operator onboarding](https://no42-org.github.io/packyard/ops/operator-onboarding) for the OAuth setup.
+
+## Local Development
+
+| Task | Command |
+|------|---------|
+| Auth unit tests | `cd auth && go test ./...` |
+| Auth binary with embedded admin UI | `make build` |
+| Docs site with live reload | `make docs-serve` |
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
 ## Repository Layout
 
@@ -71,3 +94,13 @@ tests/e2e/          End-to-end subscriber tests (RPM, DEB, OCI, observability)
 tests/load/         k6 load tests for NFR validation
 .github/workflows/  Promotion pipeline (RPM, DEB, OCI)
 ```
+
+## Contributing
+
+Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, commit conventions and DCO sign-off.
+Report vulnerabilities privately as described in [SECURITY.md](SECURITY.md).
+Maintainers cut releases as described in [RELEASING.md](RELEASING.md).
+
+## License
+
+Packyard is licensed under the GNU General Public License v3.0 or later. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report vulnerabilities privately through GitHub:
+
+https://github.com/no42-org/packyard/security/advisories/new
+
+Do not open a public issue or pull request for a security problem.
+Include the affected version, steps to reproduce, and the impact you observed.
+
+You will get an acknowledgement within 5 working days.
+We aim to publish a fix and an advisory within 90 days of a confirmed report, sooner for actively exploited issues.
+We will credit you in the advisory unless you ask us not to.
+
+## Supported versions
+
+Only the latest minor release line receives security fixes.
+Check the [releases page](https://github.com/no42-org/packyard/releases) for the current version.
+
+## Scope
+
+In scope: the auth service, the promotion workflows, the Compose stack and its Traefik configuration, and the published container images.
+Out of scope: the upstream images Packyard runs unmodified (Traefik, nginx, Zot, Aptly, RustFS). Report those to their maintainers.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,23 @@
+# Support
+
+## Documentation
+
+Start with the docs: https://no42-org.github.io/packyard/
+
+The quick-start, operator runbooks, API reference and configuration reference live there.
+
+## Questions
+
+Open a GitHub issue and apply the `question` label:
+
+https://github.com/no42-org/packyard/issues/new/choose
+
+Include your Packyard version, the relevant part of your `compose.yml` or `.env` with secrets removed, and what you have already tried.
+
+## Bugs and feature requests
+
+Use the issue forms at the link above. Pick "Bug report" or "Enhancement".
+
+## Security
+
+Vulnerabilities go through private reporting, never a public issue. See [SECURITY.md](SECURITY.md).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "packyard-docs",
   "version": "0.0.0",
   "private": true,
+  "license": "GPL-3.0-or-later",
   "description": "Documentation site for Packyard (Docusaurus)",
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary

Audit batch 1 of 4 (community files). Adds CONTRIBUTING.md with build targets, Conventional Commits, DCO sign-off and the AI-assistance trailer policy; SECURITY.md pointing at private vulnerability reporting; CODE_OF_CONDUCT.md (Contributor Covenant 2.1); SUPPORT.md; bug and enhancement issue forms with a config that disables blank issues; and a pull request template with a `Closes #` line.

README gets CI, release and license badges, a Quick Start, Contributing and License sections, and the architecture diagram drops the retired `:8088` admin entrypoint in favour of the OAuth admin host from #101.

`.gitignore` regroups the AI tool directories under one `# AI tools` block. `package.json` declares `GPL-3.0-or-later` to match `LICENSE`.

Part of the repository standards audit. No workflow or Go changes.

## Checklist

- [x] `make docs-build` unaffected (no docs/ changes); README and package.json validated locally
- [x] Commits are signed off (DCO) and follow Conventional Commits