### PR TITLE
ci: harden workflows and move quality gates into a reusable workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: /auth
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - go
@@ -16,6 +18,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - github-actions
@@ -26,6 +30,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - docker
@@ -34,6 +40,8 @@ updates:
     directory: /auth
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - docker
@@ -42,6 +50,8 @@ updates:
     directory: /rpm
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - docker
@@ -50,6 +60,8 @@ updates:
     directory: /backup
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - docker
@@ -59,6 +71,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - npm
@@ -68,6 +82,24 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus/*"
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+
+  # npm — admin UI SPA embedded in the auth service
+  - package-ecosystem: npm
+    directory: /auth/internal/admin-ui
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    labels:
+      - dependencies
+      - npm
+    groups:
       react:
         patterns:
           - react

--- a/.github/workflows/build-aptly.yml
+++ b/.github/workflows/build-aptly.yml
@@ -11,11 +11,18 @@ env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/${{ github.repository_owner }}/packyard-aptly
 
+permissions:
+  contents: read
+
+concurrency:
+  group: build-aptly-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
 
   build-and-push:
     name: Build multi-arch and push to ghcr.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -23,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Extract aptly version from Dockerfile
         id: version

--- a/.github/workflows/build-auth.yml
+++ b/.github/workflows/build-auth.yml
@@ -13,11 +13,18 @@ env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/${{ github.repository_owner }}/packyard-auth
 
+permissions:
+  contents: read
+
+concurrency:
+  group: build-auth-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
 
   build-and-push:
     name: Build multi-arch and push to ghcr.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -25,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Determine image version
         id: version

--- a/.github/workflows/build-backup.yml
+++ b/.github/workflows/build-backup.yml
@@ -12,11 +12,18 @@ env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/${{ github.repository_owner }}/packyard-backup
 
+permissions:
+  contents: read
+
+concurrency:
+  group: build-backup-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
 
   build-and-push:
     name: Build multi-arch and push to ghcr.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -24,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Extract backup version from Dockerfile
         id: version

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -13,11 +13,18 @@ env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/${{ github.repository_owner }}/packyard-rpm
 
+permissions:
+  contents: read
+
+concurrency:
+  group: build-rpm-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
 
   build-and-push:
     name: Build multi-arch and push to ghcr.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -25,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Determine image version
         id: version

--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -13,11 +13,18 @@ env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/${{ github.repository_owner }}/packyard-static
 
+permissions:
+  contents: read
+
+concurrency:
+  group: build-static-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
 
   build-and-push:
     name: Build multi-arch and push to ghcr.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -25,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Determine image version
         id: version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,92 +3,18 @@ name: CI
 on:
   push:
     branches: [main]
-    tags-ignore:
-      - '**'
   pull_request:
 
+permissions:
+  contents: read
+
+# Supersede in-flight runs for the same ref so a force-push does not leave
+# stale jobs consuming runners.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-
-  changes:
-    name: Detect changed paths
-    runs-on: ubuntu-latest
-    outputs:
-      auth: ${{ steps.filter.outputs.auth }}
-      rpm:  ${{ steps.filter.outputs.rpm }}
-      docs: ${{ steps.filter.outputs.docs }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
-        id: filter
-        with:
-          filters: |
-            auth:
-              - 'auth/**'
-            rpm:
-              - 'rpm/**'
-            docs:
-              - 'docs/**'
-              - 'docusaurus.config.ts'
-              - 'sidebars.ts'
-              - 'src/**'
-              - 'static/**'
-              - 'package.json'
-              - 'package-lock.json'
-              - '.nvmrc'
-              - 'tsconfig.json'
-              - 'Makefile'
-
-  test-auth:
-    name: Auth unit tests
-    needs: changes
-    if: needs.changes.outputs.auth == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
-        with:
-          go-version-file: auth/go.mod
-          cache-dependency-path: auth/go.sum
-
-      - name: Run tests
-        working-directory: auth
-        run: go test ./...
-
-  build-docs:
-    name: Build docs
-    needs: changes
-    if: needs.changes.outputs.docs == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - run: make docs-install
-      - run: make docs-build
-
-  build-images:
-    name: Build Docker images
-    needs: [changes, test-auth]
-    if: |
-      (needs.changes.outputs.auth == 'true' || needs.changes.outputs.rpm == 'true') &&
-      (needs.test-auth.result == 'success' || needs.test-auth.result == 'skipped')
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Build auth image
-        if: needs.changes.outputs.auth == 'true'
-        run: docker build ./auth
-
-      - name: Build rpm image
-        if: needs.changes.outputs.rpm == 'true'
-        run: docker build ./rpm
+  gates:
+    # actionlint 1.7.12 does not yet accept the `$/` self-repository syntax.
+    uses: ./.github/workflows/quality-gates.yml # zizmor: ignore[self-repository]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,12 +26,9 @@ on:
       - 'tsconfig.json'
       - '.github/workflows/docs.yml'
       - 'Makefile'
-  # Rebuild the site after a release so the landing-page hero eyebrow
-  # (version/license/Go version — resolved at build time in
+  # The Release workflow dispatches this workflow after publishing images so
+  # the landing-page hero eyebrow (version resolved at build time in
   # docusaurus.config.ts) picks up the newly pushed tag.
-  workflow_run:
-    workflows: ['Release']
-    types: [completed]
   workflow_dispatch:
 
 permissions: {}
@@ -43,10 +40,8 @@ concurrency:
 jobs:
   build-and-deploy:
     name: Build & deploy
-    runs-on: ubuntu-latest
-    # When triggered by the Release workflow, only proceed if that run
-    # succeeded. On direct pushes and manual dispatches this is trivially true.
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: write
 
@@ -54,6 +49,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0  # deploy action needs history to push to gh-pages
 
       - name: Set up Node

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,15 +3,24 @@ name: Integration
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   integration:
     name: Full stack + observability
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Create .env
         run: |

--- a/.github/workflows/promote-deb.yml
+++ b/.github/workflows/promote-deb.yml
@@ -21,11 +21,17 @@ env:
   AWS_DEFAULT_REGION: us-east-1
   RUSTFS_ENDPOINT: http://localhost:9000
 
+permissions:
+  contents: read
+
 jobs:
   promote:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Verify GPG key is not a placeholder
         run: |
@@ -95,6 +101,7 @@ jobs:
 
       - name: Upload signed DEBs to host and copy into aptly container
         run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "rm -rf /tmp/deb-stage && mkdir -p /tmp/deb-stage"
           scp ./staging/*.deb deploy@${{ secrets.HOST }}:/tmp/deb-stage/
           ssh deploy@${{ secrets.HOST }} "
@@ -108,6 +115,7 @@ jobs:
           SERIES: ${{ inputs.series }}
           DISTRO: ${{ inputs.distro }}
         run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
           SNAPSHOT_NAME=$(ssh deploy@${{ secrets.HOST }} \
             "docker compose -f /opt/packyard/compose.yml exec -T \
               -e COMPONENT='${COMPONENT}' -e SERIES='${SERIES}' -e DISTRO='${DISTRO}' \
@@ -123,6 +131,7 @@ jobs:
           SERIES: ${{ inputs.series }}
           DISTRO: ${{ inputs.distro }}
         run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} \
             "docker compose -f /opt/packyard/compose.yml exec -T aptly \
               /scripts/publish-snapshot.sh \
@@ -134,6 +143,7 @@ jobs:
           SERIES: ${{ inputs.series }}
           DISTRO: ${{ inputs.distro }}
         run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
             docker compose -f /opt/packyard/compose.yml exec -T aptly \
               test -f '/opt/aptly/public/${COMPONENT}/${SERIES}/dists/${DISTRO}/InRelease' \
@@ -146,6 +156,7 @@ jobs:
           COMPONENT: ${{ inputs.component }}
           SERIES: ${{ inputs.series }}
         run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} \
             "docker compose -f /opt/packyard/compose.yml exec -T aptly \
               /scripts/prune-snapshots.sh '${COMPONENT}' '${SERIES}'"

--- a/.github/workflows/promote-oci.yml
+++ b/.github/workflows/promote-oci.yml
@@ -19,11 +19,17 @@ concurrency:
   group: oci-promote-${{ inputs.component }}-${{ inputs.series }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   promote:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install crane
         env:
@@ -76,12 +82,12 @@ jobs:
         run: |
           for arch in x86_64 arm64; do
             # Ensure every archive has a paired .sha256
-            for tar in ./staging/${arch}/*.tar; do
+            for tar in "./staging/${arch}"/*.tar; do
               [ -f "$tar" ] || { echo "No .tar files found in staging/${arch}/"; exit 1; }
               [ -f "${tar}.sha256" ] || { echo "MISSING CHECKSUM: ${tar}.sha256 not found"; exit 1; }
             done
             # Verify each checksum
-            for sha in ./staging/${arch}/*.sha256; do
+            for sha in "./staging/${arch}"/*.sha256; do
               [ -f "$sha" ] || { echo "No .sha256 files found in staging/${arch}/"; exit 1; }
               expected=$(cat "$sha")
               file="${sha%.sha256}"
@@ -102,7 +108,7 @@ jobs:
         run: |
           IMAGE_BASE="${ZOT_REGISTRY}/lts-${COMPONENT}"
           for arch in x86_64 arm64; do
-            tarcount=$(ls ./staging/${arch}/*.tar 2>/dev/null | wc -l || echo 0)
+            tarcount=$(find "./staging/${arch}" -maxdepth 1 -name '*.tar' 2>/dev/null | wc -l)
             [ "$tarcount" -eq 1 ] || { echo "Expected exactly 1 .tar for ${arch}, found ${tarcount}"; exit 1; }
             tarfile=$(ls ./staging/${arch}/*.tar)
             crane push "$tarfile" "${IMAGE_BASE}:${SERIES}-${arch}" --insecure
@@ -148,13 +154,15 @@ jobs:
           grep -q 'BEGIN PUBLIC KEY' ./static/content/gpg/cosign.pub \
             || { echo "ERROR: cosign.pub is still a placeholder — replace with real key before promoting"; exit 1; }
           IMAGE_BASE="${ZOT_REGISTRY}/lts-${COMPONENT}"
-          cosign verify \
+          if cosign verify \
             --key ./static/content/gpg/cosign.pub \
             --allow-insecure-registry \
             --insecure-ignore-tlog \
-            "${IMAGE_BASE}:${SERIES}" \
-            && echo "SIGNATURE VERIFIED" \
-            || { echo "SIGNATURE VERIFICATION FAILED"; exit 1; }
+            "${IMAGE_BASE}:${SERIES}"; then
+            echo "SIGNATURE VERIFIED"
+          else
+            echo "SIGNATURE VERIFICATION FAILED"; exit 1
+          fi
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/promote-rpm.yml
+++ b/.github/workflows/promote-rpm.yml
@@ -101,12 +101,13 @@ jobs:
           # Avoids __gpg_check_password_cmd true (which bypasses passphrase verification entirely)
           # Passphrase on fd 3; stdin is the (empty) message to sign. Using fd 0
           # for both meant `< /dev/null` replaced the piped passphrase and the
-          # cache step silently did nothing.
+          # cache step silently did nothing. A wrong passphrase must fail here,
+          # with gpg's own message, rather than surface later from rpmsign.
           gpg --batch --yes \
             --pinentry-mode loopback \
             --passphrase-fd 3 \
             -u "${GPG_KEY_ID}" \
-            --sign --output /dev/null - < /dev/null 3< <(printf '%s\n' "${GPG_PASSPHRASE}") 2>/dev/null || true
+            --sign --output /dev/null - < /dev/null 3< <(printf '%s\n' "${GPG_PASSPHRASE}")
           for rpm in ./staging/*.rpm; do
             [ -f "$rpm" ] || { echo "No RPM files found in staging/"; exit 1; }
             rpmsign --addsign \

--- a/.github/workflows/promote-rpm.yml
+++ b/.github/workflows/promote-rpm.yml
@@ -21,11 +21,17 @@ env:
   AWS_DEFAULT_REGION: us-east-1
   RUSTFS_ENDPOINT: http://localhost:9000
 
+permissions:
+  contents: read
+
 jobs:
   promote:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Verify GPG key is not a placeholder
         run: |
@@ -93,11 +99,14 @@ jobs:
         run: |
           # P2: pre-cache passphrase in gpg-agent via loopback pinentry, then sign with rpmsign
           # Avoids __gpg_check_password_cmd true (which bypasses passphrase verification entirely)
-          echo "${GPG_PASSPHRASE}" | gpg --batch --yes \
+          # Passphrase on fd 3; stdin is the (empty) message to sign. Using fd 0
+          # for both meant `< /dev/null` replaced the piped passphrase and the
+          # cache step silently did nothing.
+          gpg --batch --yes \
             --pinentry-mode loopback \
-            --passphrase-fd 0 \
+            --passphrase-fd 3 \
             -u "${GPG_KEY_ID}" \
-            --sign --output /dev/null - < /dev/null 2>/dev/null || true
+            --sign --output /dev/null - < /dev/null 3< <(printf '%s\n' "${GPG_PASSPHRASE}") 2>/dev/null || true
           for rpm in ./staging/*.rpm; do
             [ -f "$rpm" ] || { echo "No RPM files found in staging/"; exit 1; }
             rpmsign --addsign \
@@ -119,6 +128,7 @@ jobs:
           SERIES: ${{ inputs.series }}
           OS: ${{ inputs.os }}
         run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
             set -euo pipefail
             for f in /tmp/rpm-stage/*.rpm; do

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,142 @@
+name: Quality gates
+
+# Defined once, called by CI (PRs and main) and by Release via `uses:`.
+# Adding a gate or bumping a pin here applies everywhere at once.
+
+on:
+  workflow_call:
+    inputs:
+      all:
+        description: Run every gate regardless of which paths changed (used by releases)
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      auth: ${{ inputs.all || steps.filter.outputs.auth == 'true' }}
+      rpm:  ${{ inputs.all || steps.filter.outputs.rpm == 'true' }}
+      docs: ${{ inputs.all || steps.filter.outputs.docs == 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        id: filter
+        if: ${{ !inputs.all }}
+        with:
+          filters: |
+            auth:
+              - 'auth/**'
+              - 'Makefile'
+            rpm:
+              - 'rpm/**'
+            docs:
+              - 'docs/**'
+              - 'docusaurus.config.ts'
+              - 'sidebars.ts'
+              - 'src/**'
+              - 'static/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.nvmrc'
+              - 'tsconfig.json'
+              - 'Makefile'
+
+  lint-auth:
+    name: Auth lint
+    needs: changes
+    if: needs.changes.outputs.auth == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: auth/go.mod
+          cache-dependency-path: auth/go.sum
+      - run: make lint
+
+  test-auth:
+    name: Auth unit tests
+    needs: changes
+    if: needs.changes.outputs.auth == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: auth/go.mod
+          cache-dependency-path: auth/go.sum
+      - run: make test
+
+  build-docs:
+    name: Build docs
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: make docs-install
+      - run: make docs-build
+
+  build-images:
+    name: Build Docker images
+    needs: [changes, test-auth]
+    if: |
+      always() &&
+      (needs.changes.outputs.auth == 'true' || needs.changes.outputs.rpm == 'true') &&
+      (needs.test-auth.result == 'success' || needs.test-auth.result == 'skipped')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Build auth image
+        if: needs.changes.outputs.auth == 'true'
+        run: make build-image-auth
+      - name: Build rpm image
+        if: needs.changes.outputs.rpm == 'true'
+        run: make build-image-rpm
+
+  workflows:
+    # Lints the workflows themselves: unpinned actions, script injection,
+    # credential persistence, schema errors.
+    name: Workflow lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      # docker:// refs pin by image digest rather than commit SHA.
+      - uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667  # v1.7.12
+        with:
+          args: -color
+      - uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99  # v0.6.3
+        with:
+          # Fail the job on findings instead of uploading SARIF (needs no extra permissions).
+          advanced-security: false
+          annotations: true

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ UNAME_S := $(shell uname -s)
 
 .PHONY: help docs-install docs-serve docs-build docs-clean check-node \
         admin-ui admin-ui-install admin-ui-dev admin-ui-clean \
-        build build-clean
+        build build-clean test lint build-image-auth build-image-rpm build-images
 
 ## help: Show this help
 help:
@@ -86,3 +86,23 @@ build: admin-ui
 ## build-clean: Remove built binaries
 build-clean:
 	rm -rf bin/
+
+## test: Run the auth service unit tests
+test:
+	cd auth && $(GO) test ./...
+
+## lint: Check gofmt formatting and run go vet on the auth service
+lint:
+	@cd auth && unformatted="$$(gofmt -l .)" && { test -z "$$unformatted" || { echo "gofmt: files need formatting:"; echo "$$unformatted"; exit 1; }; }
+	cd auth && $(GO) vet ./...
+
+## build-image-auth: Build the auth container image locally (no push)
+build-image-auth:
+	docker build ./auth
+
+## build-image-rpm: Build the rpm container image locally (no push)
+build-image-rpm:
+	docker build ./rpm
+
+## build-images: Build all locally built container images (no push)
+build-images: build-image-auth build-image-rpm


### PR DESCRIPTION
Audit batch 2 of 4 (workflow hygiene). Repo settings were applied via API separately; community files landed in #156.

**Reusable gates.** `quality-gates.yml` is a `workflow_call` workflow used by `ci.yml` and, next, by the release workflow. It keeps the existing path filtering and adds an `all` input for releases. Gates call `make lint`, `make test`, `make docs-build`, `make build-image-auth` and `make build-image-rpm`. A new "Workflow lint" gate runs actionlint and zizmor.

**Hygiene across all 11 workflows.** Pinned `ubuntu-24.04` runners, top-level `contents: read`, concurrency groups, `timeout-minutes` on every job, `persist-credentials: false` on every checkout. zizmor now reports zero findings; actionlint is clean.

**docs.yml.** Dropped the `workflow_run` trigger. It waited for a workflow named `Release` that does not exist, so the post-release rebuild never ran. The release workflow will dispatch `docs.yml` instead (batch 3).

**Bug fix in promote-rpm.yml.** The gpg passphrase pre-cache piped the passphrase into fd 0 and then redirected fd 0 from `/dev/null`. gpg never saw the passphrase and the step silently did nothing behind `|| true`. The passphrase now arrives on fd 3. Please sanity-check this against how the last RPM promotion actually behaved.

**Check names change.** Because gates now run through a reusable workflow, check names become `gates / Auth unit tests` etc. The main ruleset's required checks will be updated to the new names right before this merges.

Closes no issue; part of the maintainer audit.