### PR TITLE
ci: add tag-triggered release workflow with signing, SBOM and provenance

### DIFF
--- a/.github/workflows/build-auth.yml
+++ b/.github/workflows/build-auth.yml
@@ -1,9 +1,11 @@
-name: Build and publish auth image
+name: Preview auth image
+
+# Pushes to main publish a mutable preview tag (the -rc version from the
+# source tree) that is overwritten on every build. Release tags are handled
+# by release.yml, which alone writes X.Y.Z, X.Y and latest.
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
     branches: [main]
     paths:
       - auth/**
@@ -22,13 +24,18 @@ concurrency:
 
 jobs:
 
+  gates:
+    uses: ./.github/workflows/quality-gates.yml # zizmor: ignore[self-repository]
+
   build-and-push:
-    name: Build multi-arch and push to ghcr.io
+    name: Build multi-arch and push preview to ghcr.io
+    needs: gates
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
       packages: write
+      id-token: write  # cosign keyless
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -38,13 +45,10 @@ jobs:
       - name: Determine image version
         id: version
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            ver="${GITHUB_REF_NAME#v}"
-            printf 'tags<<EOF\n%s:%s\n%s:latest\nEOF\n' "${IMAGE}" "${ver}" "${IMAGE}" >> "${GITHUB_OUTPUT}"
-          else
-            ver=$(grep -oP '(?<=const version = ")[^"]+' auth/cmd/server/version.go)
-            printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
-          fi
+          ver=$(grep -oP '(?<=const version = ")[^"]+' auth/cmd/server/version.go)
+          printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Set up QEMU (cross-platform builds)
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a  # v4.3.0
@@ -60,6 +64,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./auth
@@ -68,3 +73,8 @@ jobs:
           tags: ${{ steps.version.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Sign image (cosign keyless)
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -1,9 +1,11 @@
-name: Build and publish rpm image
+name: Preview rpm image
+
+# Pushes to main publish a mutable preview tag (the -rc version from the
+# source tree) that is overwritten on every build. Release tags are handled
+# by release.yml, which alone writes X.Y.Z, X.Y and latest.
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
     branches: [main]
     paths:
       - rpm/**
@@ -22,13 +24,18 @@ concurrency:
 
 jobs:
 
+  gates:
+    uses: ./.github/workflows/quality-gates.yml # zizmor: ignore[self-repository]
+
   build-and-push:
-    name: Build multi-arch and push to ghcr.io
+    name: Build multi-arch and push preview to ghcr.io
+    needs: gates
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
       packages: write
+      id-token: write  # cosign keyless
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -38,13 +45,10 @@ jobs:
       - name: Determine image version
         id: version
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            ver="${GITHUB_REF_NAME#v}"
-            printf 'tags<<EOF\n%s:%s\n%s:latest\nEOF\n' "${IMAGE}" "${ver}" "${IMAGE}" >> "${GITHUB_OUTPUT}"
-          else
-            ver=$(cat rpm/VERSION)
-            printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
-          fi
+          ver=$(cat rpm/VERSION)
+          printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Set up QEMU (cross-platform builds)
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a  # v4.3.0
@@ -60,6 +64,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./rpm
@@ -68,3 +73,8 @@ jobs:
           tags: ${{ steps.version.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Sign image (cosign keyless)
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -1,9 +1,11 @@
-name: Build and publish static image
+name: Preview static image
+
+# Pushes to main publish a mutable preview tag (the -rc version from the
+# source tree) that is overwritten on every build. Release tags are handled
+# by release.yml, which alone writes X.Y.Z, X.Y and latest.
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
     branches: [main]
     paths:
       - static/**
@@ -22,13 +24,18 @@ concurrency:
 
 jobs:
 
+  gates:
+    uses: ./.github/workflows/quality-gates.yml # zizmor: ignore[self-repository]
+
   build-and-push:
-    name: Build multi-arch and push to ghcr.io
+    name: Build multi-arch and push preview to ghcr.io
+    needs: gates
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
       packages: write
+      id-token: write  # cosign keyless
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -38,13 +45,10 @@ jobs:
       - name: Determine image version
         id: version
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            ver="${GITHUB_REF_NAME#v}"
-            printf 'tags<<EOF\n%s:%s\n%s:latest\nEOF\n' "${IMAGE}" "${ver}" "${IMAGE}" >> "${GITHUB_OUTPUT}"
-          else
-            ver=$(cat static/VERSION)
-            printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
-          fi
+          ver=$(cat static/VERSION)
+          printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Set up QEMU (cross-platform builds)
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a  # v4.3.0
@@ -60,6 +64,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./static
@@ -68,3 +73,8 @@ jobs:
           tags: ${{ steps.version.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Sign image (cosign keyless)
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,168 @@
+name: Release
+
+# Triggered only by version tags. Runs every quality gate, builds and pushes
+# the auth, rpm and static images with cosign signatures, SBOMs and SLSA
+# provenance, then creates a DRAFT GitHub Release with the SBOMs attached.
+# The maintainer adds curated notes and publishes (see RELEASING.md).
+
+on:
+  push:
+    tags: ['v*.*.*']
+
+permissions:
+  contents: read
+
+# Serialize releases and never cancel one: a cancelled release can leave a
+# pushed image without a signature or a draft with partial assets.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+
+  gates:
+    uses: ./.github/workflows/quality-gates.yml # zizmor: ignore[self-repository]
+    with:
+      all: true
+
+  images:
+    name: Build, push and sign ${{ matrix.service }} image
+    needs: gates
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write      # push to GHCR
+      id-token: write      # cosign keyless + provenance
+      attestations: write  # SLSA build provenance
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [auth, rpm, static]
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/packyard-${{ matrix.service }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Set up QEMU (cross-platform builds)
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a  # v4.3.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
+        with:
+          images: ${{ env.IMAGE }}
+          # latest=auto moves `latest` only for stable semver tags, so
+          # v1.2.0-rc1 publishes 1.2.0-rc1 without touching latest.
+          flavor: latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: ./${{ matrix.service }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+
+      - name: Sign image (cosign keyless)
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Attest build provenance (image)
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26  # v0.24.2
+        with:
+          image: ${{ env.IMAGE }}@${{ steps.push.outputs.digest }}
+          format: spdx-json
+          output-file: dist/packyard-${{ matrix.service }}-${{ github.ref_name }}.sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: sbom-${{ matrix.service }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Create draft release
+    needs: images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write   # create release + upload assets
+      id-token: write   # cosign sign-blob
+      attestations: write
+      actions: write    # dispatch the docs rebuild
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: sbom-*
+          path: dist
+          merge-multiple: true
+
+      - name: Checksums and signature
+        run: |
+          cd dist
+          find . -type f | sort | xargs sha256sum > ../checksums.txt
+          mv ../checksums.txt checksums.txt
+          cosign sign-blob --yes --output-signature checksums.txt.sig \
+            --output-certificate checksums.txt.pem checksums.txt
+
+      - name: Attest build provenance (release assets)
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+        with:
+          subject-path: dist/*
+
+      - name: Create draft release and upload assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Prerelease tags (v1.2.3-rc1) are marked as such.
+          case "$GITHUB_REF_NAME" in *-*) PRE=--prerelease ;; *) PRE= ;; esac
+          gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || \
+            gh release create "$GITHUB_REF_NAME" --draft --verify-tag \
+              --title "$GITHUB_REF_NAME" --notes "Release notes pending." $PRE
+          find dist -type f -exec gh release upload "$GITHUB_REF_NAME" --clobber {} +
+
+      - name: Rebuild docs so the landing page shows the new version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run docs.yml --ref main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ When adding or updating documentation:
 - Edit the relevant file under `docs/` — do not create Wiki pages
 - New pages must be added to the appropriate sidebar in `sidebars.ts`
 - Run `make docs-serve` locally to preview before committing (requires Node 20 via `.nvmrc`)
-- Docs are published automatically on each push to `main` via `docs.yml`, and rebuilt after each Release workflow completes (so the landing-page version eyebrow picks up new tags)
+- Docs are published automatically on each push to `main` via `docs.yml`. The Release workflow dispatches `docs.yml` after publishing images so the landing-page version eyebrow picks up new tags
 
 ## Docker Compose
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,79 +1,115 @@
 # Releasing Packyard
 
-This covers cutting a new version of the Packyard infrastructure itself — the auth service, RPM service, and static service images, plus the versioned docs.
+This covers cutting a new version of the Packyard infrastructure itself: the auth, rpm and static service images plus the versioned docs.
+Versions follow [SemVer](https://semver.org/) and are derived from the Conventional Commit types since the last tag.
+A `feat` commit means a minor bump, a `fix` or `chore` a patch, and a `BREAKING CHANGE` footer or `!` a major bump.
 
 ## 1. Bump version numbers
 
-Three places must match the intended release tag (without the `v` prefix):
+Four places must match the intended release tag (without the `v` prefix):
 
 ```bash
-sed -i "s/const version = .*/const version = \"1.2.3\"/" auth/cmd/server/version.go
-echo "1.2.3" > rpm/VERSION
-echo "1.2.3" > static/VERSION
-
-sed -i "s|packyard-auth:[^ ]*|packyard-auth:1.2.3|" compose.yml
-sed -i "s|packyard-rpm:[^ ]*|packyard-rpm:1.2.3|" compose.yml
-sed -i "s|packyard-static:[^ ]*|packyard-static:1.2.3|" compose.yml
+VERSION=1.2.3
+sed -i "s/const version = .*/const version = \"${VERSION}\"/" auth/cmd/server/version.go
+echo "${VERSION}" > rpm/VERSION
+echo "${VERSION}" > static/VERSION
+sed -i -E "s|(packyard-(auth\|rpm\|static)):[^ ]*|\1:${VERSION}|" compose.yml
 ```
 
-Open a PR and merge to `main` before tagging.
+Commit as `chore(release): vX.Y.Z`, open a PR and merge it.
+`main` is protected, so the bump always lands through a PR.
 
 ## 2. Tag and push
 
 ```bash
 git checkout main && git pull
-
-git tag v1.2.3
+git tag -a v1.2.3 -m "v1.2.3"
 git push origin v1.2.3
 ```
 
-Pushing the tag immediately triggers three image build workflows:
+Pushing the tag triggers the `Release` workflow (`.github/workflows/release.yml`). It:
 
-| Workflow | Image pushed |
-|----------|-------------|
-| `build-auth.yml` | `ghcr.io/no42-org/packyard-auth:1.2.3` + `latest` |
-| `build-rpm.yml` | `ghcr.io/no42-org/packyard-rpm:1.2.3` + `latest` |
-| `build-static.yml` | `ghcr.io/no42-org/packyard-static:1.2.3` + `latest` |
+1. Runs every quality gate (`quality-gates.yml` with `all: true`). Nothing publishes on red.
+2. Builds and pushes the three images for `linux/amd64` and `linux/arm64`.
+3. Signs each image with cosign keyless and attaches SLSA build provenance to the registry.
+4. Generates an SPDX SBOM per image.
+5. Creates a **draft** GitHub Release with the SBOMs, a `checksums.txt` and its cosign signature attached, and dispatches `docs.yml` so the landing page shows the new version.
 
-Monitor them:
+| Image | Tags written for `v1.2.3` |
+|-------|---------------------------|
+| `ghcr.io/no42-org/packyard-auth` | `1.2.3`, `1.2`, `latest` |
+| `ghcr.io/no42-org/packyard-rpm` | `1.2.3`, `1.2`, `latest` |
+| `ghcr.io/no42-org/packyard-static` | `1.2.3`, `1.2`, `latest` |
 
-```bash
-gh run list --workflow=build-auth.yml
-gh run list --workflow=build-rpm.yml
-gh run list --workflow=build-static.yml
-```
+`latest` always equals the newest stable release.
+Prerelease tags such as `v1.2.3-rc1` publish `1.2.3-rc1`, are marked as prereleases and never move `latest`.
 
-All three must succeed before creating the GitHub release.
-
-## 3. Create the GitHub release
-
-```bash
-gh release create v1.2.3 \
-  --title "v1.2.3" \
-  --generate-notes
-```
-
-Publishing the release triggers a rebuild of `docs.yml` via the `workflow_run` hook, so the landing-page version eyebrow (resolved from `git describe --tags` in `docusaurus.config.ts`) picks up the new tag. Docs themselves publish on every push to `main`, not on release — so by the time you cut the release, the page text is already live. Confirm at `https://no42-org.github.io/packyard/`.
-
-## 4. Bump to next development version
-
-After the release is tagged, bump `main` to the next version with a `-rc` suffix so builds on `main` are never mistaken for a release:
+Monitor the run:
 
 ```bash
-git checkout -b chore/bump-1.2.4-rc
-
-sed -i "s/const version = .*/const version = \"1.2.4-rc\"/" auth/cmd/server/version.go
-echo "1.2.4-rc" > rpm/VERSION
-echo "1.2.4-rc" > static/VERSION
-
-sed -i "s|packyard-auth:[^ ]*|packyard-auth:1.2.4-rc|" compose.yml
-sed -i "s|packyard-rpm:[^ ]*|packyard-rpm:1.2.4-rc|" compose.yml
-sed -i "s|packyard-static:[^ ]*|packyard-static:1.2.4-rc|" compose.yml
-
-git add auth/cmd/server/version.go rpm/VERSION compose.yml
-git commit -m "chore: bump versions to 1.2.4-rc post v1.2.3 release"
-git push -u origin chore/bump-1.2.4-rc
-gh pr create --title "chore: bump versions to 1.2.4-rc post v1.2.3" --fill
+gh run list --workflow=release.yml
+gh run watch
 ```
 
-Builds on `main` will tag images with the `-rc` version until the next release cycle begins.
+## 3. Publish the release
+
+Write curated notes, never a raw commit dump: a `## Highlights` section with user-facing impact, `## Breaking changes` with the migration path if any, `## Fixes` one line each, and one line summarizing dependency updates.
+Then publish the draft:
+
+```bash
+gh release edit v1.2.3 --notes-file notes.md --draft=false
+```
+
+Confirm the landing page at https://no42-org.github.io/packyard/ shows the new version.
+
+## 4. Bump to the next development version
+
+Bump `main` to the next patch version with an `-rc` suffix so preview builds are never mistaken for a release:
+
+```bash
+NEXT=1.2.4-rc
+git checkout -b chore/bump-${NEXT}
+sed -i "s/const version = .*/const version = \"${NEXT}\"/" auth/cmd/server/version.go
+echo "${NEXT}" > rpm/VERSION
+echo "${NEXT}" > static/VERSION
+sed -i -E "s|(packyard-(auth\|rpm\|static)):[^ ]*|\1:${NEXT}|" compose.yml
+git add auth/cmd/server/version.go rpm/VERSION static/VERSION compose.yml
+git commit -s -m "chore: bump versions to ${NEXT} post v1.2.3 release"
+git push -u origin chore/bump-${NEXT}
+gh pr create --fill
+```
+
+## Preview images from main
+
+Every push to `main` that touches a service runs the quality gates and then pushes a single mutable preview tag named after the `-rc` version in the source tree, for example `ghcr.io/no42-org/packyard-auth:1.2.4-rc`.
+Each build overwrites the previous one.
+Preview images are signed with cosign but never receive `X.Y.Z`, `X.Y` or `latest` tags.
+
+## Verifying signatures and provenance
+
+Images are signed keylessly by the `Release` workflow. Verify against the workflow identity:
+
+```bash
+cosign verify ghcr.io/no42-org/packyard-auth:1.2.3 \
+  --certificate-identity-regexp 'https://github.com/no42-org/packyard/\.github/workflows/release\.yml@refs/tags/v.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Preview images are signed by the `Preview <service> image` workflows; use `build-auth\.yml@refs/heads/main` (or `build-rpm`, `build-static`) as the identity instead.
+
+Verify SLSA build provenance for an image or a downloaded release asset:
+
+```bash
+gh attestation verify oci://ghcr.io/no42-org/packyard-auth:1.2.3 --owner no42-org
+gh attestation verify checksums.txt --owner no42-org
+```
+
+Verify the release checksums file:
+
+```bash
+cosign verify-blob checksums.txt \
+  --signature checksums.txt.sig --certificate checksums.txt.pem \
+  --certificate-identity-regexp 'https://github.com/no42-org/packyard/\.github/workflows/release\.yml@refs/tags/v.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+sha256sum -c checksums.txt
+```


### PR DESCRIPTION
Audit batch 3 of 4 (release pipeline). Stacked on #163; GitHub retargets this to `main` when #163 merges.

**release.yml.** Runs on `v*.*.*` tags only. Reuses `quality-gates.yml` with `all: true` so nothing publishes on red. A matrix job builds auth, rpm and static for amd64 and arm64, signs each image with cosign keyless, pushes SLSA provenance to the registry, and produces an SPDX SBOM. A final job attaches the SBOMs and a cosign-signed `checksums.txt` to a **draft** release, then dispatches `docs.yml` so the landing page eyebrow updates. `docker/metadata-action` with `latest=auto` writes `X.Y.Z`, `X.Y` and `latest`, and never moves `latest` for prerelease tags. That closes the gap where `v1.0.0-rc1` would have become `latest`.

**Preview builds.** `build-auth.yml`, `build-rpm.yml` and `build-static.yml` drop their tag trigger, gate on `quality-gates.yml`, and sign the preview image. They keep pushing the single mutable `-rc` tag from the source tree.

**Docs.** RELEASING.md rewritten: SemVer from Conventional Commits, the four version locations including compose.yml, the tag scheme, prerelease behaviour, and `cosign verify` / `gh attestation verify` commands with the workflow identity. CLAUDE.md's docs note now describes the dispatch.

**Not exercised yet.** The release path only runs on a real tag. The next release is the first end-to-end test; the draft-release step means a failure leaves nothing published.

Part of the maintainer audit.