### PR TITLE
chore(deps): fix Dependabot docker coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       - dependencies
       - github-actions
 
-  # Docker base images — service Dockerfiles only (auth, rpm, backup).
+  # Docker base images — service Dockerfiles only (auth, rpm, backup, aptly, static).
   # Images declared in compose.yml are not scanned by Dependabot's docker ecosystem,
   # and the repository root has no Dockerfile.
   - package-ecosystem: docker
@@ -49,6 +49,26 @@ updates:
 
   - package-ecosystem: docker
     directory: /backup
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    labels:
+      - dependencies
+      - docker
+
+  - package-ecosystem: docker
+    directory: /aptly
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    labels:
+      - dependencies
+      - docker
+
+  - package-ecosystem: docker
+    directory: /static
     schedule:
       interval: weekly
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,18 +24,9 @@ updates:
       - dependencies
       - github-actions
 
-  # Docker base images — service Dockerfiles only
-  # Note: images declared in compose.yml are not scanned by Dependabot's docker ecosystem
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    labels:
-      - dependencies
-      - docker
-
+  # Docker base images — service Dockerfiles only (auth, rpm, backup).
+  # Images declared in compose.yml are not scanned by Dependabot's docker ecosystem,
+  # and the repository root has no Dockerfile.
   - package-ecosystem: docker
     directory: /auth
     schedule:


### PR DESCRIPTION
Two fixes to the Dependabot `docker` ecosystem entries.

Removes the entry for `/`. Every scheduled run failed with "No Dockerfiles nor Kubernetes YAML found in /" because the repository root has no Dockerfile. Images in `compose.yml` are outside Dependabot's docker ecosystem regardless.

Adds entries for `aptly/` and `static/`, which have Dockerfiles but were not watched.