### PR TITLE
build: pin base images by digest and override qs to a patched version

### DIFF
--- a/aptly/Dockerfile
+++ b/aptly/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 ARG APTLY_VERSION=1.6.2
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -6,7 +6,7 @@
 # golang@sha256:…, distroless@sha256:…) before tagging a production release.
 # Mutable tags would otherwise let a compromised upstream image silently land
 # in the next build.
-FROM node:26-alpine AS spa-builder
+FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f1edc3d298a3 AS spa-builder
 WORKDIR /spa
 # Lockfile is committed and authoritative — `npm ci` fails closed when it
 # disagrees with package.json, so the container build can't silently drift.
@@ -19,7 +19,7 @@ COPY internal/admin-ui/ ./
 RUN npm run build
 
 # Stage 2: Go build — embeds the freshly-built SPA bundle.
-FROM golang:1.27.1-alpine AS builder
+FROM golang:1.27.1-alpine@sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125 AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
@@ -30,6 +30,6 @@ COPY . .
 COPY --from=spa-builder /spa/dist/ ./internal/adminui/dist/
 RUN CGO_ENABLED=0 GOOS=linux go build -o /auth ./cmd/server
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12@sha256:d75cdd72874d4790092fcb1b058493ecf6bb5bf2b2b897045b00ff01d91843f2
 COPY --from=builder /auth /auth
 ENTRYPOINT ["/auth"]

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.24
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 ARG SQLITE_VERSION=3.48.0-r4
 
 RUN apk add --no-cache sqlite=${SQLITE_VERSION}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,22 +8199,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/bonjour-service": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
@@ -18139,12 +18123,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "node": ">=20.0"
   },
   "overrides": {
+    "qs": ">=6.16.0",
     "serialize-javascript": "^7.0.5",
     "uuid": "^14.0.0"
   }

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.31-alpine@sha256:72ba65eb42c10344912a84ff42408db7d34f2feb642204570ab8fc5ffd29f1d3
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY scripts/init-rpm-tree.sh /docker-entrypoint.d/10-init-rpm-tree.sh
 RUN chmod +x /docker-entrypoint.d/10-init-rpm-tree.sh \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:alpine
+FROM nginx:1.31-alpine@sha256:72ba65eb42c10344912a84ff42408db7d34f2feb642204570ab8fc5ffd29f1d3
 COPY config/nginx.conf /etc/nginx/nginx.conf
 COPY content/ /usr/share/nginx/html/


### PR DESCRIPTION
Addresses the Scorecard Pinned-Dependencies findings (7 alerts) and the three qs Dependabot alerts.

**Dockerfiles.** Every `FROM` in `auth/`, `rpm/`, `static/`, `backup/` and `aptly/` is now pinned as `image:tag@sha256:…`. Dependabot's docker entries update both tag and digest. nginx moves from the floating `alpine` tag to `1.31-alpine`; the digest is what `alpine` resolved to today, so the image is unchanged.

**qs.** npm `overrides` forces `qs >= 6.16.0`. It is a transitive dependency via `@docusaurus/core → webpack-dev-server → express → body-parser`, and no upstream bump has reached us. `npm ls qs` now shows a single 6.16.0. `make docs-build` passes.

The remaining Dependabot alerts (two `image-size` DoS advisories) have no patched version. They are dismissed as tolerable risk with a comment: image-size runs only at docs build time on images committed to this repo.