### PR TITLE
ci: validate paths-filter YAML in the workflow lint gate

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -139,3 +139,6 @@ jobs:
           # Fail the job on findings instead of uploading SARIF (needs no extra permissions).
           advanced-security: false
           annotations: true
+      # paths-filter takes its filters as a YAML string; neither linter above
+      # parses it, and a bad indent there skips every gate at run time.
+      - run: make lint-workflows

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ UNAME_S := $(shell uname -s)
 
 .PHONY: help docs-install docs-serve docs-build docs-clean check-node \
         admin-ui admin-ui-install admin-ui-dev admin-ui-clean \
-        build build-clean test lint build-image-auth build-image-rpm build-images
+        build build-clean test lint lint-workflows build-image-auth build-image-rpm build-images
 
 ## help: Show this help
 help:
@@ -95,6 +95,10 @@ test:
 lint:
 	@cd auth && unformatted="$$(gofmt -l .)" && { test -z "$$unformatted" || { echo "gofmt: files need formatting:"; echo "$$unformatted"; exit 1; }; }
 	cd auth && $(GO) vet ./...
+
+## lint-workflows: Validate YAML embedded in workflow action inputs (paths-filter)
+lint-workflows:
+	python3 scripts/lint-workflow-filters.py
 
 ## build-image-auth: Build the auth container image locally (no push)
 build-image-auth:

--- a/scripts/lint-workflow-filters.py
+++ b/scripts/lint-workflow-filters.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Validate embedded YAML that workflow linters cannot see.
+
+dorny/paths-filter takes its `filters` input as a YAML *string*, so a bad
+indentation inside it passes actionlint and zizmor and only fails at run
+time, skipping every gate. This script parses each workflow, finds
+paths-filter steps and checks that `filters` is valid YAML mapping names
+to lists of glob strings.
+"""
+import glob
+import sys
+
+import yaml
+
+
+def check(path: str) -> list[str]:
+    errors: list[str] = []
+    with open(path, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    for job_name, job in (doc.get("jobs") or {}).items():
+        for idx, step in enumerate(job.get("steps") or []):
+            uses = str(step.get("uses", ""))
+            if not uses.startswith("dorny/paths-filter@"):
+                continue
+            where = f"{path}: job {job_name!r} step {idx + 1}"
+            raw = (step.get("with") or {}).get("filters")
+            if not isinstance(raw, str):
+                errors.append(f"{where}: filters must be a YAML string")
+                continue
+            try:
+                parsed = yaml.safe_load(raw)
+            except yaml.YAMLError as exc:
+                errors.append(f"{where}: filters is not valid YAML: {exc}")
+                continue
+            if not isinstance(parsed, dict) or not parsed:
+                errors.append(f"{where}: filters must map names to glob lists")
+                continue
+            for name, globs in parsed.items():
+                if not isinstance(globs, list) or not all(isinstance(g, str) for g in globs):
+                    errors.append(f"{where}: filter {name!r} must be a list of glob strings")
+    return errors
+
+
+def main() -> int:
+    files = sorted(glob.glob(".github/workflows/*.yml"))
+    errors = [e for f in files for e in check(f)]
+    for e in errors:
+        print(f"error: {e}", file=sys.stderr)
+    print(f"checked {len(files)} workflow files, {len(errors)} error(s)")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the gap seen on #185: the `filters` input of `dorny/paths-filter` is a YAML string that actionlint and zizmor do not parse, so a bad indent there passes the linters and fails at run time, skipping every gate.

`scripts/lint-workflow-filters.py` loads each workflow, finds paths-filter steps and validates the embedded YAML as a mapping of names to glob lists. Exposed as `make lint-workflows` and run in the Workflow lint job. Uses PyYAML, which the ubuntu-24.04 runner image ships.

Verified locally: 0 errors on the current tree; reintroducing the #185 indentation bug in a scratch copy fails with the offending line quoted.