### PR TITLE
feat(auth): cache public-component visibility in forward-auth

### DIFF
--- a/auth/cmd/server/config.go
+++ b/auth/cmd/server/config.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// envDuration reads a Go duration from the environment variable key.
+//
+// Unset or empty returns def. The value must parse with time.ParseDuration,
+// so a bare number such as "30" is rejected: operators must write "30s".
+// Negative values and values above max are rejected. Zero is allowed so a
+// caller can use it to mean "disabled".
+func envDuration(key string, def, max time.Duration) (time.Duration, error) {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s=%q is not a valid duration; use Go duration syntax such as \"30s\" or \"1m\"", key, raw)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("%s=%q must not be negative", key, raw)
+	}
+	if d > max {
+		return 0, fmt.Errorf("%s=%q exceeds the maximum of %s", key, raw, max)
+	}
+	return d, nil
+}

--- a/auth/cmd/server/config_test.go
+++ b/auth/cmd/server/config_test.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// These tests mutate process environment via t.Setenv and must not run in parallel.
+func TestEnvDuration(t *testing.T) {
+	const key = "PACKYARD_TEST_DURATION"
+	def, max := 30*time.Second, time.Hour
+
+	cases := []struct {
+		name    string
+		set     bool
+		value   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "unset returns default", set: false, want: def},
+		{name: "valid duration", set: true, value: "45s", want: 45 * time.Second},
+		{name: "zero allowed", set: true, value: "0", want: 0},
+		{name: "zero with unit allowed", set: true, value: "0s", want: 0},
+		{name: "bare number rejected", set: true, value: "30", wantErr: true},
+		{name: "garbage rejected", set: true, value: "soon", wantErr: true},
+		{name: "negative rejected", set: true, value: "-1s", wantErr: true},
+		{name: "above max rejected", set: true, value: "2h", wantErr: true},
+		{name: "exactly max allowed", set: true, value: "1h", want: time.Hour},
+		{name: "empty string treated as unset", set: true, value: "", want: def},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(key, tc.value)
+			}
+			got, err := envDuration(key, def, max)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("envDuration(%q) = %v, want error", tc.value, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("envDuration(%q) unexpected error: %v", tc.value, err)
+			}
+			if got != tc.want {
+				t.Fatalf("envDuration(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/auth/cmd/server/main.go
+++ b/auth/cmd/server/main.go
@@ -121,6 +121,19 @@ func main() {
 	defer serverCancel()
 	stateStore := auth.NewMemStateStore(serverCtx, 5*time.Minute)
 
+	// Public-component cache for forward-auth (issue #84). Public lookups are
+	// served from memory for up to this long, so public traffic survives
+	// short store outages; private traffic still fails closed. The TTL is
+	// also the bound on how long a public→private change can lag on an
+	// instance that did not handle the request. 0 disables the cache.
+	cacheTTL, err := envDuration("PACKYARD_PUBLIC_COMPONENT_CACHE_TTL", 30*time.Second, time.Hour)
+	if err != nil {
+		logger.Error("invalid public-component cache configuration", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	comps := store.NewCachedComponentStore(serverCtx, st, cacheTTL)
+	logger.Info("public-component cache configured", slog.Duration("ttl", cacheTTL), slog.Bool("enabled", cacheTTL > 0))
+
 	// Auditor: the SQLiteStore implements audit.Auditor via its Write method,
 	// so all audit calls now persist to the audit_log table. The store
 	// internally logs persistence failures (fire-and-forget per the Auditor
@@ -165,7 +178,7 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	forwardAuth := handler.NewForwardAuthHandler(st, st, st, logger)
+	forwardAuth := handler.NewForwardAuthHandler(st, comps, st, logger)
 	r.Get("/auth", forwardAuth.ServeHTTP)
 
 	authH := handler.NewAuthHandler(st, auditor, logger)
@@ -175,7 +188,7 @@ func main() {
 
 	keys := handler.NewKeysHandler(st, st, st, auditor, logger, validComponents, componentList, compVisibility)
 	rpmDataRoot := os.Getenv("RPM_DATA_ROOT")
-	components := handler.NewComponentsHandler(st, logger, rpmDataRoot)
+	components := handler.NewComponentsHandler(comps, logger, rpmDataRoot)
 	accounts := handler.NewAccountsHandler(st, st, auditor, logger, compVisibility)
 	auditH := handler.NewAuditHandler(st, logger)
 	operators := handler.NewOperatorsHandler(st, st, auditor, logger)

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/go-chi/chi/v5 v5.3.2
 	github.com/prometheus/client_golang v1.24.1
+	golang.org/x/sync v0.22.0
 	modernc.org/sqlite v1.58.0
 )
 
@@ -13,6 +14,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/auth/internal/handler/forward_auth_test.go
+++ b/auth/internal/handler/forward_auth_test.go
@@ -518,3 +518,61 @@ func FuzzExtractComponent(f *testing.F) {
 		}
 	})
 }
+
+// toggleErrComponentStore wraps a stubComponentStore and, once failing is set,
+// returns an error from GetComponent for every name. It simulates a database
+// outage that begins after the cache has been warmed.
+type toggleErrComponentStore struct {
+	*stubComponentStore
+	failing bool
+}
+
+func (s *toggleErrComponentStore) GetComponent(ctx context.Context, name string) (*store.Component, error) {
+	if s.failing {
+		return nil, errors.New("database is locked")
+	}
+	return s.stubComponentStore.GetComponent(ctx, name)
+}
+
+// TestForwardAuth_PublicComponentCache_SurvivesOutage covers issue #84 AC1 at
+// the handler level: with the CachedComponentStore in front of a store that
+// starts failing, a recently seen public component keeps returning 200 while an
+// unseen component fails closed with 503. With the cache disabled the same
+// sequence returns 503 for both, which is today's behaviour.
+func TestForwardAuth_PublicComponentCache_SurvivesOutage(t *testing.T) {
+	run := func(t *testing.T, ttl time.Duration, wantCached int) {
+		cs := newStubComponentStore()
+		cs.comps["core"] = &store.Component{Name: "core", Visibility: "public"}
+		cs.comps["minion"] = &store.Component{Name: "minion", Visibility: "private"}
+		toggle := &toggleErrComponentStore{stubComponentStore: cs}
+		h := &ForwardAuthHandler{
+			Store:          &mockStore{},
+			ComponentStore: store.NewCachedComponentStore(context.Background(), toggle, ttl),
+			Logger:         slog.Default(),
+		}
+		get := func(uri string) int {
+			req := httptest.NewRequest("GET", "/auth", nil)
+			req.Header.Set("X-Forwarded-Uri", uri)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			return w.Code
+		}
+
+		if code := get("/rpm/core/2025/el9-x86_64/"); code != http.StatusOK {
+			t.Fatalf("warm-up: expected 200, got %d", code)
+		}
+		toggle.failing = true
+		if code := get("/rpm/core/2025/el9-x86_64/"); code != wantCached {
+			t.Fatalf("cached public component during outage: expected %d, got %d", wantCached, code)
+		}
+		if code := get("/rpm/minion/2025/el9-x86_64/"); code != http.StatusServiceUnavailable {
+			t.Fatalf("uncached component during outage: expected 503, got %d", code)
+		}
+	}
+	t.Run("cache enabled serves public from cache", func(t *testing.T) {
+		run(t, 30*time.Second, http.StatusOK)
+	})
+	t.Run("cache disabled fails closed", func(t *testing.T) {
+		run(t, 0, http.StatusServiceUnavailable)
+	})
+}

--- a/auth/internal/handler/forward_auth_test.go
+++ b/auth/internal/handler/forward_auth_test.go
@@ -561,6 +561,11 @@ func TestForwardAuth_PublicComponentCache_SurvivesOutage(t *testing.T) {
 		if code := get("/rpm/core/2025/el9-x86_64/"); code != http.StatusOK {
 			t.Fatalf("warm-up: expected 200, got %d", code)
 		}
+		// Warm the private component too: it must be looked up and denied, and
+		// must NOT be cached, so it fails closed once the store is down.
+		if code := get("/rpm/minion/2025/el9-x86_64/"); code != http.StatusUnauthorized {
+			t.Fatalf("warm-up private without creds: expected 401, got %d", code)
+		}
 		toggle.failing = true
 		if code := get("/rpm/core/2025/el9-x86_64/"); code != wantCached {
 			t.Fatalf("cached public component during outage: expected %d, got %d", wantCached, code)

--- a/auth/internal/metrics/metrics.go
+++ b/auth/internal/metrics/metrics.go
@@ -27,8 +27,38 @@ var (
 			Buckets: prometheus.DefBuckets,
 		},
 	)
+
+	// ComponentCacheRequests counts every component lookup that passed through
+	// the public-component cache, hit or miss. Hit ratio is
+	// ComponentCacheHits / ComponentCacheRequests.
+	ComponentCacheRequests = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "packyard_auth_component_cache_requests_total",
+			Help: "Total number of component lookups through the public-component cache.",
+		},
+	)
+
+	// ComponentCacheHits counts component lookups answered from the cache
+	// without a store call.
+	ComponentCacheHits = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "packyard_auth_component_cache_hits_total",
+			Help: "Total number of component lookups served from the public-component cache.",
+		},
+	)
+
+	// ComponentCacheEntries is the number of components currently cached as
+	// public. It should track the number of public components; growth beyond
+	// that indicates a bug.
+	ComponentCacheEntries = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "packyard_auth_component_cache_entries",
+			Help: "Number of components currently held in the public-component cache.",
+		},
+	)
 )
 
 func init() {
-	prometheus.MustRegister(RequestsTotal, RequestDuration)
+	prometheus.MustRegister(RequestsTotal, RequestDuration,
+		ComponentCacheRequests, ComponentCacheHits, ComponentCacheEntries)
 }

--- a/auth/internal/metrics/metrics_test.go
+++ b/auth/internal/metrics/metrics_test.go
@@ -34,3 +34,24 @@ func TestMetricsEndpoint(t *testing.T) {
 		t.Error("packyard_auth_duration_seconds not found in /metrics output")
 	}
 }
+
+func TestComponentCacheMetricsRegistered(t *testing.T) {
+	// Touch each metric so it appears in Gather output even at zero.
+	ComponentCacheRequests.Add(0)
+	ComponentCacheHits.Add(0)
+	ComponentCacheEntries.Set(0)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	promhttp.Handler().ServeHTTP(w, req)
+	body := w.Body.String()
+	for _, name := range []string{
+		"packyard_auth_component_cache_requests_total",
+		"packyard_auth_component_cache_hits_total",
+		"packyard_auth_component_cache_entries",
+	} {
+		if !strings.Contains(body, name) {
+			t.Errorf("%s not found in /metrics output", name)
+		}
+	}
+}

--- a/auth/internal/store/cached_components.go
+++ b/auth/internal/store/cached_components.go
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package store
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/no42-org/packyard-auth/internal/metrics"
+)
+
+// lookupTimeout bounds the shared store call behind a cache miss. It matches
+// the SQLite busy_timeout so a hung database cannot pin waiters for longer
+// than the store itself would.
+const lookupTimeout = 5 * time.Second
+
+// CachedComponentStore decorates a ComponentStore with a positive-only,
+// hard-TTL cache of components whose visibility is "public".
+//
+// Design (issue #84):
+//   - Only "public" results are cached. "private", ErrComponentNotFound and
+//     store errors are never cached, so the set is bounded by the number of
+//     public components and a database outage never widens access.
+//   - Entries expire after ttl and are removed lazily on the next lookup.
+//     There is no stale-while-revalidate: once expired, an entry is gone and
+//     a lookup during an outage fails closed exactly as it did before #84.
+//   - Mutating calls (visibility update, delete) pass through and evict the
+//     name on success only, so a public→private change is immediate on this
+//     instance and bounded by ttl on any other.
+//   - Concurrent misses for one name are collapsed by singleflight into a
+//     single store call that runs on a service-owned context, not on the
+//     first caller's request context.
+//
+// A ttl <= 0 disables the cache: every method passes straight through.
+type CachedComponentStore struct {
+	ComponentStore
+
+	base context.Context
+	ttl  time.Duration
+
+	mu      sync.RWMutex
+	entries map[string]cachedComponent
+	sf      singleflight.Group
+}
+
+type cachedComponent struct {
+	comp      Component
+	expiresAt time.Time
+}
+
+// NewCachedComponentStore wraps inner. base is the service lifetime context
+// used for shared store lookups; it should be cancelled on shutdown.
+func NewCachedComponentStore(base context.Context, inner ComponentStore, ttl time.Duration) *CachedComponentStore {
+	return &CachedComponentStore{
+		ComponentStore: inner,
+		base:           base,
+		ttl:            ttl,
+		entries:        map[string]cachedComponent{},
+	}
+}
+
+// Len returns the number of cached entries, expired or not. Intended for tests
+// and metrics; the gauge is updated on insert and evict.
+func (c *CachedComponentStore) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
+func (c *CachedComponentStore) enabled() bool { return c.ttl > 0 }
+
+// GetComponent returns a copy of the cached component on a fresh hit, and
+// otherwise performs one shared lookup against the inner store.
+func (c *CachedComponentStore) GetComponent(ctx context.Context, name string) (*Component, error) {
+	if !c.enabled() {
+		return c.ComponentStore.GetComponent(ctx, name)
+	}
+	metrics.ComponentCacheRequests.Inc()
+
+	if comp, ok := c.lookup(name); ok {
+		metrics.ComponentCacheHits.Inc()
+		return &comp, nil
+	}
+
+	v, err, _ := c.sf.Do(name, func() (any, error) {
+		lctx, cancel := context.WithTimeout(c.base, lookupTimeout)
+		defer cancel()
+		comp, err := c.ComponentStore.GetComponent(lctx, name)
+		if err != nil {
+			return nil, err
+		}
+		if comp.Visibility == "public" {
+			c.insert(name, *comp)
+		}
+		return comp, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Return a copy so callers cannot mutate the shared value.
+	cp := *v.(*Component)
+	return &cp, nil
+}
+
+// lookup returns a copy of a non-expired entry. Expired entries are removed.
+func (c *CachedComponentStore) lookup(name string) (Component, bool) {
+	c.mu.RLock()
+	e, ok := c.entries[name]
+	c.mu.RUnlock()
+	if !ok {
+		return Component{}, false
+	}
+	if time.Now().Before(e.expiresAt) {
+		return e.comp, true
+	}
+	c.evict(name)
+	return Component{}, false
+}
+
+func (c *CachedComponentStore) insert(name string, comp Component) {
+	c.mu.Lock()
+	c.entries[name] = cachedComponent{comp: comp, expiresAt: time.Now().Add(c.ttl)}
+	n := len(c.entries)
+	c.mu.Unlock()
+	metrics.ComponentCacheEntries.Set(float64(n))
+}
+
+func (c *CachedComponentStore) evict(name string) {
+	c.mu.Lock()
+	delete(c.entries, name)
+	n := len(c.entries)
+	c.mu.Unlock()
+	metrics.ComponentCacheEntries.Set(float64(n))
+}
+
+// UpdateComponentVisibility passes through and evicts the name on success.
+func (c *CachedComponentStore) UpdateComponentVisibility(ctx context.Context, name, visibility string) (*Component, error) {
+	comp, err := c.ComponentStore.UpdateComponentVisibility(ctx, name, visibility)
+	if err == nil && c.enabled() {
+		c.evict(name)
+	}
+	return comp, err
+}
+
+// DeleteComponent passes through and evicts the name on success.
+func (c *CachedComponentStore) DeleteComponent(ctx context.Context, name string) error {
+	err := c.ComponentStore.DeleteComponent(ctx, name)
+	if err == nil && c.enabled() {
+		c.evict(name)
+	}
+	return err
+}
+
+// DeleteComponentWithRevoke passes through and evicts the name on success.
+func (c *CachedComponentStore) DeleteComponentWithRevoke(ctx context.Context, name string) (int64, error) {
+	n, err := c.ComponentStore.DeleteComponentWithRevoke(ctx, name)
+	if err == nil && c.enabled() {
+		c.evict(name)
+	}
+	return n, err
+}

--- a/auth/internal/store/cached_components.go
+++ b/auth/internal/store/cached_components.go
@@ -7,6 +7,7 @@ package store
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"time"
 
@@ -32,7 +33,9 @@ const lookupTimeout = 5 * time.Second
 //     a lookup during an outage fails closed exactly as it did before #84.
 //   - Mutating calls (visibility update, delete) pass through and evict the
 //     name on success only, so a public→private change is immediate on this
-//     instance and bounded by ttl on any other.
+//     instance and bounded by ttl on any other. Eviction also bumps a
+//     per-name generation so a lookup that was already in flight when the
+//     write landed cannot re-insert the pre-write value.
 //   - Concurrent misses for one name are collapsed by singleflight into a
 //     single store call that runs on a service-owned context, not on the
 //     first caller's request context.
@@ -46,6 +49,7 @@ type CachedComponentStore struct {
 
 	mu      sync.RWMutex
 	entries map[string]cachedComponent
+	gen     map[string]uint64 // bumped on every eviction caused by a write
 	sf      singleflight.Group
 }
 
@@ -62,6 +66,7 @@ func NewCachedComponentStore(base context.Context, inner ComponentStore, ttl tim
 		base:           base,
 		ttl:            ttl,
 		entries:        map[string]cachedComponent{},
+		gen:            map[string]uint64{},
 	}
 }
 
@@ -75,13 +80,22 @@ func (c *CachedComponentStore) Len() int {
 
 func (c *CachedComponentStore) enabled() bool { return c.ttl > 0 }
 
+// cloneComponent returns a deep copy so callers can never reach the cached
+// slices through a returned value.
+func cloneComponent(src Component) Component {
+	src.RPMSeries = slices.Clone(src.RPMSeries)
+	src.RPMOSFamilies = slices.Clone(src.RPMOSFamilies)
+	src.RPMArchitectures = slices.Clone(src.RPMArchitectures)
+	return src
+}
+
 // GetComponent returns a copy of the cached component on a fresh hit, and
 // otherwise performs one shared lookup against the inner store.
 func (c *CachedComponentStore) GetComponent(ctx context.Context, name string) (*Component, error) {
+	metrics.ComponentCacheRequests.Inc()
 	if !c.enabled() {
 		return c.ComponentStore.GetComponent(ctx, name)
 	}
-	metrics.ComponentCacheRequests.Inc()
 
 	if comp, ok := c.lookup(name); ok {
 		metrics.ComponentCacheHits.Inc()
@@ -89,6 +103,10 @@ func (c *CachedComponentStore) GetComponent(ctx context.Context, name string) (*
 	}
 
 	v, err, _ := c.sf.Do(name, func() (any, error) {
+		// Capture the generation before the read. If a write evicts this name
+		// while the read is in flight, the generation moves on and the stale
+		// result is not inserted.
+		gen := c.generation(name)
 		lctx, cancel := context.WithTimeout(c.base, lookupTimeout)
 		defer cancel()
 		comp, err := c.ComponentStore.GetComponent(lctx, name)
@@ -96,19 +114,26 @@ func (c *CachedComponentStore) GetComponent(ctx context.Context, name string) (*
 			return nil, err
 		}
 		if comp.Visibility == "public" {
-			c.insert(name, *comp)
+			c.insert(name, *comp, gen)
 		}
 		return comp, nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	// Return a copy so callers cannot mutate the shared value.
-	cp := *v.(*Component)
+	cp := cloneComponent(*v.(*Component))
 	return &cp, nil
 }
 
-// lookup returns a copy of a non-expired entry. Expired entries are removed.
+func (c *CachedComponentStore) generation(name string) uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.gen[name]
+}
+
+// lookup returns a copy of a non-expired entry. An expired entry is removed
+// only if it is still the same entry that was found expired, so a concurrent
+// fresher insert is never discarded.
 func (c *CachedComponentStore) lookup(name string) (Component, bool) {
 	c.mu.RLock()
 	e, ok := c.entries[name]
@@ -117,26 +142,36 @@ func (c *CachedComponentStore) lookup(name string) (Component, bool) {
 		return Component{}, false
 	}
 	if time.Now().Before(e.expiresAt) {
-		return e.comp, true
+		return cloneComponent(e.comp), true
 	}
-	c.evict(name)
+	c.mu.Lock()
+	if cur, ok := c.entries[name]; ok && cur.expiresAt.Equal(e.expiresAt) {
+		delete(c.entries, name)
+		metrics.ComponentCacheEntries.Set(float64(len(c.entries)))
+	}
+	c.mu.Unlock()
 	return Component{}, false
 }
 
-func (c *CachedComponentStore) insert(name string, comp Component) {
+// insert stores comp unless the name's generation changed since gen was read.
+func (c *CachedComponentStore) insert(name string, comp Component, gen uint64) {
 	c.mu.Lock()
-	c.entries[name] = cachedComponent{comp: comp, expiresAt: time.Now().Add(c.ttl)}
-	n := len(c.entries)
-	c.mu.Unlock()
-	metrics.ComponentCacheEntries.Set(float64(n))
+	defer c.mu.Unlock()
+	if c.gen[name] != gen {
+		return
+	}
+	c.entries[name] = cachedComponent{comp: cloneComponent(comp), expiresAt: time.Now().Add(c.ttl)}
+	metrics.ComponentCacheEntries.Set(float64(len(c.entries)))
 }
 
+// evict removes the name and bumps its generation so in-flight lookups that
+// started before the write cannot re-insert their result.
 func (c *CachedComponentStore) evict(name string) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	delete(c.entries, name)
-	n := len(c.entries)
-	c.mu.Unlock()
-	metrics.ComponentCacheEntries.Set(float64(n))
+	c.gen[name]++
+	metrics.ComponentCacheEntries.Set(float64(len(c.entries)))
 }
 
 // UpdateComponentVisibility passes through and evicts the name on success.

--- a/auth/internal/store/cached_components_test.go
+++ b/auth/internal/store/cached_components_test.go
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package store
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/no42-org/packyard-auth/internal/metrics"
+)
+
+// countingComponentStore is an in-memory ComponentStore that counts
+// GetComponent calls, can be switched to return an error, and can block
+// GetComponent on a gate channel so tests can pile up concurrent callers.
+type countingComponentStore struct {
+	mu        sync.Mutex
+	comps     map[string]*Component
+	getCalls  int
+	err       error // returned by GetComponent when non-nil
+	updateErr error // returned by UpdateComponentVisibility when non-nil
+	gate      chan struct{}
+}
+
+func newCountingStore(comps ...*Component) *countingComponentStore {
+	s := &countingComponentStore{comps: map[string]*Component{}}
+	for _, c := range comps {
+		s.comps[c.Name] = c
+	}
+	return s
+}
+
+func (s *countingComponentStore) calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.getCalls
+}
+
+func (s *countingComponentStore) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
+
+func (s *countingComponentStore) GetComponent(_ context.Context, name string) (*Component, error) {
+	s.mu.Lock()
+	s.getCalls++
+	err, gate := s.err, s.gate
+	c, ok := s.comps[name]
+	s.mu.Unlock()
+	if gate != nil {
+		<-gate
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrComponentNotFound
+	}
+	cp := *c
+	return &cp, nil
+}
+
+func (s *countingComponentStore) UpdateComponentVisibility(_ context.Context, name, visibility string) (*Component, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.updateErr != nil {
+		return nil, s.updateErr
+	}
+	c, ok := s.comps[name]
+	if !ok {
+		return nil, ErrComponentNotFound
+	}
+	c.Visibility = visibility
+	cp := *c
+	return &cp, nil
+}
+
+func (s *countingComponentStore) DeleteComponent(_ context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.comps[name]; !ok {
+		return ErrComponentNotFound
+	}
+	delete(s.comps, name)
+	return nil
+}
+
+func (s *countingComponentStore) DeleteComponentWithRevoke(ctx context.Context, name string) (int64, error) {
+	return 0, s.DeleteComponent(ctx, name)
+}
+
+func (s *countingComponentStore) CreateComponent(_ context.Context, c *Component) (*Component, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.comps[c.Name] = c
+	return c, nil
+}
+func (s *countingComponentStore) ListComponents(context.Context, int, int) ([]*Component, error) {
+	return nil, nil
+}
+func (s *countingComponentStore) RevokeComponentKeys(context.Context, string) (int64, error) {
+	return 0, nil
+}
+func (s *countingComponentStore) CountActiveComponentKeys(context.Context, string) (int64, error) {
+	return 0, nil
+}
+
+const testTTL = 30 * time.Second
+
+func public(name string) *Component  { return &Component{Name: name, Visibility: "public"} }
+func private(name string) *Component { return &Component{Name: name, Visibility: "private"} }
+
+func mustGet(t *testing.T, cs ComponentStore, name string) *Component {
+	t.Helper()
+	c, err := cs.GetComponent(context.Background(), name)
+	if err != nil {
+		t.Fatalf("GetComponent(%q): %v", name, err)
+	}
+	return c
+}
+
+func TestCached_HitAvoidsInner(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("core"))
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+		hitsBefore := testutil.ToFloat64(metrics.ComponentCacheHits)
+
+		for i := 0; i < 3; i++ {
+			if c := mustGet(t, cs, "core"); c.Visibility != "public" {
+				t.Fatalf("visibility = %q", c.Visibility)
+			}
+		}
+		if inner.calls() != 1 {
+			t.Fatalf("inner calls = %d, want 1", inner.calls())
+		}
+		if got := testutil.ToFloat64(metrics.ComponentCacheHits) - hitsBefore; got != 2 {
+			t.Fatalf("hits delta = %v, want 2", got)
+		}
+	})
+}
+
+func TestCached_PrivateAndNotFoundNeverCached(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(private("secret"))
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+
+		for i := 0; i < 2; i++ {
+			if c := mustGet(t, cs, "secret"); c.Visibility != "private" {
+				t.Fatalf("visibility = %q", c.Visibility)
+			}
+		}
+		for i := 0; i < 2; i++ {
+			if _, err := cs.GetComponent(context.Background(), "ghost"); !errors.Is(err, ErrComponentNotFound) {
+				t.Fatalf("ghost err = %v, want ErrComponentNotFound", err)
+			}
+		}
+		if inner.calls() != 4 {
+			t.Fatalf("inner calls = %d, want 4 (nothing cached)", inner.calls())
+		}
+		if n := cs.Len(); n != 0 {
+			t.Fatalf("cache entries = %d, want 0", n)
+		}
+	})
+}
+
+func TestCached_TTLExpiry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("core"))
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+
+		mustGet(t, cs, "core")
+		time.Sleep(testTTL - time.Nanosecond)
+		mustGet(t, cs, "core")
+		if inner.calls() != 1 {
+			t.Fatalf("inner calls before expiry = %d, want 1", inner.calls())
+		}
+		time.Sleep(2 * time.Nanosecond)
+		mustGet(t, cs, "core")
+		if inner.calls() != 2 {
+			t.Fatalf("inner calls after expiry = %d, want 2", inner.calls())
+		}
+	})
+}
+
+func TestCached_SurvivesInnerErrorWithinTTL_FailsClosedAfter(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("core"))
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+
+		mustGet(t, cs, "core")
+		inner.setErr(errors.New("database is locked"))
+
+		// Within TTL: served from cache despite the outage.
+		if c := mustGet(t, cs, "core"); c.Visibility != "public" {
+			t.Fatalf("visibility during outage = %q", c.Visibility)
+		}
+		// Unseen component during the outage: error propagates, nothing cached.
+		if _, err := cs.GetComponent(context.Background(), "other"); err == nil {
+			t.Fatal("expected error for uncached component during outage")
+		}
+		// After TTL: fail closed.
+		time.Sleep(testTTL + time.Nanosecond)
+		if _, err := cs.GetComponent(context.Background(), "core"); err == nil {
+			t.Fatal("expected error after TTL during outage")
+		}
+		if n := cs.Len(); n != 0 {
+			t.Fatalf("cache entries after failed refresh = %d, want 0", n)
+		}
+	})
+}
+
+func TestCached_PublicToPrivateEvictsImmediately(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("core"))
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+
+		mustGet(t, cs, "core")
+		if _, err := cs.UpdateComponentVisibility(context.Background(), "core", "private"); err != nil {
+			t.Fatal(err)
+		}
+		c := mustGet(t, cs, "core")
+		if c.Visibility != "private" {
+			t.Fatalf("visibility after flip = %q, want private", c.Visibility)
+		}
+		if inner.calls() != 2 {
+			t.Fatalf("inner calls = %d, want 2 (evicted then re-read)", inner.calls())
+		}
+	})
+}
+
+func TestCached_DeleteEvicts(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("a"), public("b"))
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+		mustGet(t, cs, "a")
+		mustGet(t, cs, "b")
+
+		if err := cs.DeleteComponent(context.Background(), "a"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := cs.DeleteComponentWithRevoke(context.Background(), "b"); err != nil {
+			t.Fatal(err)
+		}
+		if n := cs.Len(); n != 0 {
+			t.Fatalf("entries after deletes = %d, want 0", n)
+		}
+		if _, err := cs.GetComponent(context.Background(), "a"); !errors.Is(err, ErrComponentNotFound) {
+			t.Fatalf("a after delete: %v", err)
+		}
+	})
+}
+
+func TestCached_FailedWriteDoesNotEvict(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("core"))
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+		mustGet(t, cs, "core")
+
+		inner.updateErr = errors.New("disk full")
+		if _, err := cs.UpdateComponentVisibility(context.Background(), "core", "private"); err == nil {
+			t.Fatal("expected write error")
+		}
+		mustGet(t, cs, "core")
+		if inner.calls() != 1 {
+			t.Fatalf("inner calls = %d, want 1 (entry must survive a failed write)", inner.calls())
+		}
+	})
+}
+
+func TestCached_StampedeCollapsesToOneInnerCall(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("core"))
+		inner.gate = make(chan struct{})
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+
+		const n = 25
+		var wg sync.WaitGroup
+		results := make([]error, n)
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				_, results[i] = cs.GetComponent(context.Background(), "core")
+			}(i)
+		}
+		synctest.Wait() // every caller is now blocked behind the single in-flight lookup
+		close(inner.gate)
+		wg.Wait()
+
+		for i, err := range results {
+			if err != nil {
+				t.Fatalf("caller %d: %v", i, err)
+			}
+		}
+		if inner.calls() != 1 {
+			t.Fatalf("inner calls = %d, want 1", inner.calls())
+		}
+	})
+}
+
+func TestCached_ReturnsCopies(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("core"))
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+
+		first := mustGet(t, cs, "core")
+		first.Visibility = "mutated"
+		second := mustGet(t, cs, "core")
+		if second.Visibility != "public" {
+			t.Fatalf("cached entry was mutated through a returned pointer: %q", second.Visibility)
+		}
+	})
+}
+
+func TestCached_DisabledPassesThrough(t *testing.T) {
+	inner := newCountingStore(public("core"))
+	cs := NewCachedComponentStore(context.Background(), inner, 0)
+	for i := 0; i < 3; i++ {
+		mustGet(t, cs, "core")
+	}
+	if inner.calls() != 3 {
+		t.Fatalf("inner calls = %d, want 3 with cache disabled", inner.calls())
+	}
+	if n := cs.Len(); n != 0 {
+		t.Fatalf("entries = %d, want 0 with cache disabled", n)
+	}
+}
+
+func TestCached_InnerCallUsesServiceContextNotCallers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("core"))
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // an already-cancelled request context must not fail the lookup
+		if _, err := cs.GetComponent(ctx, "core"); err != nil {
+			t.Fatalf("lookup with cancelled caller context: %v", err)
+		}
+	})
+}

--- a/auth/internal/store/cached_components_test.go
+++ b/auth/internal/store/cached_components_test.go
@@ -50,14 +50,39 @@ func (s *countingComponentStore) setErr(err error) {
 	s.err = err
 }
 
-func (s *countingComponentStore) GetComponent(_ context.Context, name string) (*Component, error) {
+func (s *countingComponentStore) setUpdateErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.updateErr = err
+}
+
+func (s *countingComponentStore) setGate(g chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gate = g
+}
+
+func (s *countingComponentStore) GetComponent(ctx context.Context, name string) (*Component, error) {
+	// Honour the context like a real driver would, so tests about which
+	// context reaches the store are meaningful.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	s.mu.Lock()
 	s.getCalls++
 	err, gate := s.err, s.gate
 	c, ok := s.comps[name]
+	if ok {
+		cp := *c
+		cp.RPMSeries = append([]string(nil), c.RPMSeries...)
+		c = &cp
+	}
 	s.mu.Unlock()
 	if gate != nil {
 		<-gate
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 	if err != nil {
 		return nil, err
@@ -65,8 +90,7 @@ func (s *countingComponentStore) GetComponent(_ context.Context, name string) (*
 	if !ok {
 		return nil, ErrComponentNotFound
 	}
-	cp := *c
-	return &cp, nil
+	return c, nil
 }
 
 func (s *countingComponentStore) UpdateComponentVisibility(_ context.Context, name, visibility string) (*Component, error) {
@@ -116,7 +140,9 @@ func (s *countingComponentStore) CountActiveComponentKeys(context.Context, strin
 
 const testTTL = 30 * time.Second
 
-func public(name string) *Component  { return &Component{Name: name, Visibility: "public"} }
+func public(name string) *Component {
+	return &Component{Name: name, Visibility: "public", RPMSeries: []string{"2025"}}
+}
 func private(name string) *Component { return &Component{Name: name, Visibility: "private"} }
 
 func mustGet(t *testing.T, cs ComponentStore, name string) *Component {
@@ -150,7 +176,7 @@ func TestCached_HitAvoidsInner(t *testing.T) {
 
 func TestCached_PrivateAndNotFoundNeverCached(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		inner := newCountingStore(private("secret"))
+		inner := newCountingStore(private("secret"), &Component{Name: "odd", Visibility: ""})
 		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
 
 		for i := 0; i < 2; i++ {
@@ -163,8 +189,11 @@ func TestCached_PrivateAndNotFoundNeverCached(t *testing.T) {
 				t.Fatalf("ghost err = %v, want ErrComponentNotFound", err)
 			}
 		}
-		if inner.calls() != 4 {
-			t.Fatalf("inner calls = %d, want 4 (nothing cached)", inner.calls())
+		for i := 0; i < 2; i++ {
+			mustGet(t, cs, "odd") // unknown visibility is treated as not public
+		}
+		if inner.calls() != 6 {
+			t.Fatalf("inner calls = %d, want 6 (nothing cached)", inner.calls())
 		}
 		if n := cs.Len(); n != 0 {
 			t.Fatalf("cache entries = %d, want 0", n)
@@ -183,10 +212,10 @@ func TestCached_TTLExpiry(t *testing.T) {
 		if inner.calls() != 1 {
 			t.Fatalf("inner calls before expiry = %d, want 1", inner.calls())
 		}
-		time.Sleep(2 * time.Nanosecond)
+		time.Sleep(time.Nanosecond) // now == expiresAt exactly: a miss, since lookup uses Before
 		mustGet(t, cs, "core")
 		if inner.calls() != 2 {
-			t.Fatalf("inner calls after expiry = %d, want 2", inner.calls())
+			t.Fatalf("inner calls at exact expiry = %d, want 2", inner.calls())
 		}
 	})
 }
@@ -265,7 +294,7 @@ func TestCached_FailedWriteDoesNotEvict(t *testing.T) {
 		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
 		mustGet(t, cs, "core")
 
-		inner.updateErr = errors.New("disk full")
+		inner.setUpdateErr(errors.New("disk full"))
 		if _, err := cs.UpdateComponentVisibility(context.Background(), "core", "private"); err == nil {
 			t.Fatal("expected write error")
 		}
@@ -279,7 +308,8 @@ func TestCached_FailedWriteDoesNotEvict(t *testing.T) {
 func TestCached_StampedeCollapsesToOneInnerCall(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		inner := newCountingStore(public("core"))
-		inner.gate = make(chan struct{})
+		gate := make(chan struct{})
+		inner.setGate(gate)
 		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
 
 		const n = 25
@@ -293,7 +323,7 @@ func TestCached_StampedeCollapsesToOneInnerCall(t *testing.T) {
 			}(i)
 		}
 		synctest.Wait() // every caller is now blocked behind the single in-flight lookup
-		close(inner.gate)
+		close(gate)
 		wg.Wait()
 
 		for i, err := range results {
@@ -314,9 +344,13 @@ func TestCached_ReturnsCopies(t *testing.T) {
 
 		first := mustGet(t, cs, "core")
 		first.Visibility = "mutated"
+		first.RPMSeries[0] = "mutated"
 		second := mustGet(t, cs, "core")
 		if second.Visibility != "public" {
 			t.Fatalf("cached entry was mutated through a returned pointer: %q", second.Visibility)
+		}
+		if second.RPMSeries[0] != "2025" {
+			t.Fatalf("cached slice was mutated through a returned value: %v", second.RPMSeries)
 		}
 	})
 }
@@ -344,6 +378,76 @@ func TestCached_InnerCallUsesServiceContextNotCallers(t *testing.T) {
 		cancel() // an already-cancelled request context must not fail the lookup
 		if _, err := cs.GetComponent(ctx, "core"); err != nil {
 			t.Fatalf("lookup with cancelled caller context: %v", err)
+		}
+	})
+}
+
+// TestCached_WriteDuringInFlightLookupIsNotResurrected covers the race found
+// in review: a lookup that read "public" before a write landed must not insert
+// that stale value after the write evicted the name.
+func TestCached_WriteDuringInFlightLookupIsNotResurrected(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("core"))
+		gate := make(chan struct{})
+		inner.setGate(gate)
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// The fake snapshots "public" before blocking on the gate.
+			_, _ = cs.GetComponent(context.Background(), "core")
+		}()
+		synctest.Wait() // lookup is in flight, blocked on the gate
+
+		// Operator flips visibility while the read is in flight.
+		inner.setGate(nil)
+		if _, err := cs.UpdateComponentVisibility(context.Background(), "core", "private"); err != nil {
+			t.Fatal(err)
+		}
+		close(gate) // stale "public" result now returns to the decorator
+		<-done
+
+		if n := cs.Len(); n != 0 {
+			t.Fatalf("stale public entry was resurrected after eviction: entries = %d", n)
+		}
+		if c := mustGet(t, cs, "core"); c.Visibility != "private" {
+			t.Fatalf("visibility after flip = %q, want private", c.Visibility)
+		}
+	})
+}
+
+func TestCached_GaugeTracksLen(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inner := newCountingStore(public("a"), public("b"), public("c"))
+		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
+		check := func(step string) {
+			t.Helper()
+			if g, n := testutil.ToFloat64(metrics.ComponentCacheEntries), cs.Len(); int(g) != n {
+				t.Fatalf("%s: gauge = %v, Len = %d", step, g, n)
+			}
+		}
+		mustGet(t, cs, "a")
+		mustGet(t, cs, "b")
+		mustGet(t, cs, "c")
+		check("after three inserts")
+		if err := cs.DeleteComponent(context.Background(), "b"); err != nil {
+			t.Fatal(err)
+		}
+		check("after evict")
+		time.Sleep(testTTL + time.Nanosecond)
+		mustGet(t, cs, "a") // expired entry replaced by a fresh one
+		_, _ = cs.GetComponent(context.Background(), "c")
+		check("after expiry and refresh")
+		if err := cs.DeleteComponent(context.Background(), "a"); err != nil {
+			t.Fatal(err)
+		}
+		if err := cs.DeleteComponent(context.Background(), "c"); err != nil {
+			t.Fatal(err)
+		}
+		check("after all evicted")
+		if cs.Len() != 0 {
+			t.Fatalf("Len = %d, want 0", cs.Len())
 		}
 	})
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -34,7 +34,7 @@ RUSTFS_SECRET_KEY=dev-secret-key-value
 
 ### Advanced (auth service)
 
-These are set via `compose.yml` and only need overriding when deploying with a non-standard volume layout:
+These are set via `compose.yml` or the auth container's environment. `RPM_DATA_ROOT` only needs overriding for a non-standard volume layout; the cache TTL is a tuning knob with a safe default:
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -39,6 +39,7 @@ These are set via `compose.yml` and only need overriding when deploying with a n
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `RPM_DATA_ROOT` | `/data/rpm` | Root directory for RPM tree initialisation inside the auth container. Must match the mount point of the `rpm-data` volume. The auth service creates trees under `{RPM_DATA_ROOT}/rpm/{component}/{series}/{os_family}-{arch}/` — note the extra `rpm/` subdirectory level. |
+| `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` | `30s` | How long forward-auth caches a component's `public` visibility in memory, so public package traffic is served without a database read and survives store outages shorter than this. Go duration syntax (`30s`, `2m`); `0` disables the cache; values above `1h` are rejected at startup. Only `public` results are cached, so private components always fail closed. This is also the revocation bound: a public-to-private change takes effect immediately on the instance that handled it and within one TTL on any other. |
 
 ## Compose Override Files
 

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -8,6 +8,9 @@ Metrics are exposed by the auth service at `http://auth:9090/metrics` (Docker-in
 |--------|------|-------------|
 | `packyard_auth_requests_total{status="allowed\|denied\|error"}` | Counter | forwardAuth request outcomes |
 | `packyard_auth_duration_seconds` | Histogram | forwardAuth latency |
+| `packyard_auth_component_cache_requests_total` | Counter | Component lookups through the public-component cache (forward-auth and admin reads) |
+| `packyard_auth_component_cache_hits_total` | Counter | Lookups answered from the cache without a store call; hit ratio is hits / requests |
+| `packyard_auth_component_cache_entries` | Gauge | Components currently cached as public; should track the number of public components |
 
 Traefik exposes its own metrics on an internal `metrics` entrypoint at
 `http://traefik:8082/metrics` — Docker-internal only, not published to the


### PR DESCRIPTION
Closes #84. Implements the design from the research summary on that issue.

**What changes.** A `CachedComponentStore` decorator in `internal/store` wraps the SQLite store for both the forward-auth handler and the components handler. Only `public` lookups are cached, for `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` (default `30s`, `0` disables, max `1h`, fail-fast on invalid values). Private, not-found and error results are never cached, so private traffic keeps failing closed and the cache is bounded by the number of public components. Concurrent misses collapse through `singleflight` onto one store call on the service context with a 5s timeout. The visibility update and both delete methods evict on success.

**Behaviour.** A public component looked up within the last TTL keeps returning 200 through a store outage; anything else returns 503 as today. A public-to-private change takes effect immediately on the instance that handled it and within one TTL on any other; the configuration reference names the TTL as that bound.

**Observability.** `packyard_auth_component_cache_requests_total`, `packyard_auth_component_cache_hits_total`, `packyard_auth_component_cache_entries`.

**Tests.** Eleven decorator tests with `testing/synctest` (hit, private and not-found never cached, expiry at the nanosecond boundary, survives outage within TTL then fails closed, eviction on update and delete, failed write does not evict, 25-way stampede collapses to one call, copies returned, disabled pass-through, cancelled caller context does not fail the lookup), a handler-level outage test with a disabled-cache subtest, and table tests for the duration parser. `go test ./... -race` and `make lint` clean.

**New dependency.** `golang.org/x/sync` v0.22.0 for `singleflight`.

**Follow-ups, not in this PR.** Architecture doc paragraph, runbook visibility-flip procedure (flip, wait one TTL, then promote private content), `.env.example` entry, and a separate evaluation of a SQLite reader/writer pool split.