### PR TITLE
fix(compose): forward operator and OAuth variables to the auth container; document the cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,33 @@
 ACME_EMAIL=ops@example.org
 PKG_DOMAIN=pkg.example.org
 
+# Admin UI hostname — required. Traefik routes Host(ADMIN_DOMAIN) to the auth
+# service and the CSRF guard derives PACKYARD_ADMIN_HOST=https://${ADMIN_DOMAIN}.
+# Hostname only, no scheme.
+ADMIN_DOMAIN=admin.pkg.example.org
+
+# First operator — inserted as an active admin when the operators table is
+# empty; ignored once any operator exists. See docs/ops/operator-onboarding.md.
+PACKYARD_BOOTSTRAP_OPERATOR_EMAIL=ops@example.org
+
+# OAuth providers for the admin UI — configure at least one. Every variable in
+# a provider's group must be set together; a partial group fails the auth
+# service at startup. Setup steps: docs/ops/operator-onboarding.md §1.
+#PACKYARD_GITHUB_CLIENT_ID=
+#PACKYARD_GITHUB_CLIENT_SECRET=
+#PACKYARD_GITHUB_REDIRECT_URI=https://admin.pkg.example.org/api/v1/auth/callback/github
+#PACKYARD_GITHUB_ORG=
+#PACKYARD_MICROSOFT_CLIENT_ID=
+#PACKYARD_MICROSOFT_CLIENT_SECRET=
+#PACKYARD_MICROSOFT_REDIRECT_URI=https://admin.pkg.example.org/api/v1/auth/callback/microsoft
+#PACKYARD_MICROSOFT_TENANT_ID=
+
+# Forward-auth public-component cache (issue #84). How long a component's
+# "public" visibility is served from memory. Go duration syntax; 0 disables;
+# max 1h. Also the bound on how long a public→private change can lag on an
+# instance other than the one that handled it. Default 30s when unset.
+#PACKYARD_PUBLIC_COMPONENT_CACHE_TTL=30s
+
 # RustFS S3 credentials — used by GHA promotion pipeline (Story 4.1)
 RUSTFS_ACCESS_KEY=change-me-access-key
 RUSTFS_SECRET_KEY=change-me-secret-key

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
+# Copy to .env and edit. This file will hold OAuth client secrets and storage
+# credentials: keep it out of git (it is ignored) and restrict it (chmod 600).
+# Compose interpolates values, so write a literal `$` inside a value as `$$`.
+# Applying a changed value needs `docker compose up -d <service>` to recreate
+# the container; `docker compose restart` keeps the old environment.
+
 # ACME/TLS — required for production certificate issuance
 ACME_EMAIL=ops@example.org
 PKG_DOMAIN=pkg.example.org
@@ -7,26 +13,34 @@ PKG_DOMAIN=pkg.example.org
 # Hostname only, no scheme.
 ADMIN_DOMAIN=admin.pkg.example.org
 
-# First operator — inserted as an active admin when the operators table is
-# empty; ignored once any operator exists. See docs/ops/operator-onboarding.md.
-PACKYARD_BOOTSTRAP_OPERATOR_EMAIL=ops@example.org
+# First operator — set ONCE on a fresh deployment. The address is inserted as
+# the permanent first admin when the operators table is empty and is ignored
+# afterwards, so only set a real address you control. An address that does not
+# parse as an email stops the service from starting.
+# See docs/ops/operator-onboarding.md §2.
+#PACKYARD_BOOTSTRAP_OPERATOR_EMAIL=you@example.org
 
-# OAuth providers for the admin UI — configure at least one. Every variable in
-# a provider's group must be set together; a partial group fails the auth
-# service at startup. Setup steps: docs/ops/operator-onboarding.md §1.
+# OAuth providers for the admin UI — configure at least one, or nobody can log
+# in (the service still starts; this is not validated). Every variable in a
+# provider's group must be set together; a partial group stops the service at
+# startup. The redirect URI host MUST equal ADMIN_DOMAIN above and match the
+# URI registered at the provider. Setup steps: docs/ops/operator-onboarding.md §1.
 #PACKYARD_GITHUB_CLIENT_ID=
 #PACKYARD_GITHUB_CLIENT_SECRET=
-#PACKYARD_GITHUB_REDIRECT_URI=https://admin.pkg.example.org/api/v1/auth/callback/github
+#PACKYARD_GITHUB_REDIRECT_URI=https://<ADMIN_DOMAIN>/api/v1/auth/callback/github
 #PACKYARD_GITHUB_ORG=
 #PACKYARD_MICROSOFT_CLIENT_ID=
 #PACKYARD_MICROSOFT_CLIENT_SECRET=
-#PACKYARD_MICROSOFT_REDIRECT_URI=https://admin.pkg.example.org/api/v1/auth/callback/microsoft
+#PACKYARD_MICROSOFT_REDIRECT_URI=https://<ADMIN_DOMAIN>/api/v1/auth/callback/microsoft
 #PACKYARD_MICROSOFT_TENANT_ID=
 
-# Forward-auth public-component cache (issue #84). How long a component's
-# "public" visibility is served from memory. Go duration syntax; 0 disables;
-# max 1h. Also the bound on how long a public→private change can lag on an
-# instance other than the one that handled it. Default 30s when unset.
+# Forward-auth public-component cache. How long a component's "public"
+# visibility is served from memory without a database read. Go duration syntax
+# such as 30s or 2m (a bare number is invalid); 0 disables the cache; values
+# above 1h are rejected. An invalid value stops the service from starting.
+# Unset or empty means the 30s default. This is also the bound on how long a
+# public→private change can lag for readers that did not go through this
+# instance's API. See docs/reference/configuration.md.
 #PACKYARD_PUBLIC_COMPONENT_CACHE_TTL=30s
 
 # RustFS S3 credentials — used by GHA promotion pipeline (Story 4.1)

--- a/compose.yml
+++ b/compose.yml
@@ -49,8 +49,9 @@ services:
       - PACKYARD_ADMIN_HOST=https://${ADMIN_DOMAIN:?ADMIN_DOMAIN must be set in .env}
       # Operator bootstrap and OAuth providers — values come from .env. Compose
       # only uses .env for interpolation, so each variable must be forwarded
-      # explicitly here to reach the container. `${VAR:-}` leaves an unset
-      # variable empty, which the auth service treats as "not configured".
+      # explicitly here to reach the container. `${VAR:-}` forwards an unset
+      # variable as empty; the auth service treats an empty provider group or
+      # bootstrap email as "not configured".
       - PACKYARD_BOOTSTRAP_OPERATOR_EMAIL=${PACKYARD_BOOTSTRAP_OPERATOR_EMAIL:-}
       - PACKYARD_GITHUB_CLIENT_ID=${PACKYARD_GITHUB_CLIENT_ID:-}
       - PACKYARD_GITHUB_CLIENT_SECRET=${PACKYARD_GITHUB_CLIENT_SECRET:-}
@@ -60,7 +61,8 @@ services:
       - PACKYARD_MICROSOFT_CLIENT_SECRET=${PACKYARD_MICROSOFT_CLIENT_SECRET:-}
       - PACKYARD_MICROSOFT_REDIRECT_URI=${PACKYARD_MICROSOFT_REDIRECT_URI:-}
       - PACKYARD_MICROSOFT_TENANT_ID=${PACKYARD_MICROSOFT_TENANT_ID:-}
-      # Public-component cache TTL for forward-auth (issue #84). Empty = 30s default.
+      # Public-component cache TTL for forward-auth. Unset or empty = 30s
+      # default; "0" disables. See docs/reference/configuration.md.
       - PACKYARD_PUBLIC_COMPONENT_CACHE_TTL=${PACKYARD_PUBLIC_COMPONENT_CACHE_TTL:-}
     volumes:
       - auth-db:/data/db

--- a/compose.yml
+++ b/compose.yml
@@ -47,6 +47,21 @@ services:
       # guard to enforce same-origin on /api/v1/* mutations. Derived from
       # ADMIN_DOMAIN so prod stays a single source of truth.
       - PACKYARD_ADMIN_HOST=https://${ADMIN_DOMAIN:?ADMIN_DOMAIN must be set in .env}
+      # Operator bootstrap and OAuth providers — values come from .env. Compose
+      # only uses .env for interpolation, so each variable must be forwarded
+      # explicitly here to reach the container. `${VAR:-}` leaves an unset
+      # variable empty, which the auth service treats as "not configured".
+      - PACKYARD_BOOTSTRAP_OPERATOR_EMAIL=${PACKYARD_BOOTSTRAP_OPERATOR_EMAIL:-}
+      - PACKYARD_GITHUB_CLIENT_ID=${PACKYARD_GITHUB_CLIENT_ID:-}
+      - PACKYARD_GITHUB_CLIENT_SECRET=${PACKYARD_GITHUB_CLIENT_SECRET:-}
+      - PACKYARD_GITHUB_REDIRECT_URI=${PACKYARD_GITHUB_REDIRECT_URI:-}
+      - PACKYARD_GITHUB_ORG=${PACKYARD_GITHUB_ORG:-}
+      - PACKYARD_MICROSOFT_CLIENT_ID=${PACKYARD_MICROSOFT_CLIENT_ID:-}
+      - PACKYARD_MICROSOFT_CLIENT_SECRET=${PACKYARD_MICROSOFT_CLIENT_SECRET:-}
+      - PACKYARD_MICROSOFT_REDIRECT_URI=${PACKYARD_MICROSOFT_REDIRECT_URI:-}
+      - PACKYARD_MICROSOFT_TENANT_ID=${PACKYARD_MICROSOFT_TENANT_ID:-}
+      # Public-component cache TTL for forward-auth (issue #84). Empty = 30s default.
+      - PACKYARD_PUBLIC_COMPONENT_CACHE_TTL=${PACKYARD_PUBLIC_COMPONENT_CACHE_TTL:-}
     volumes:
       - auth-db:/data/db
       - auth-backup:/data/backup

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -82,7 +82,7 @@ curl -s -X POST http://localhost:8080/api/v1/keys \
 ```
 
 :::note
-`component_visibility` is derived from a startup-loaded snapshot. Because `core` was provisioned after the service started, the snapshot does not include it and the field shows `"private"` (the fallback). This is expected — the field is informational only. Forward-auth reads visibility live from the database on every request, so `core` is publicly accessible immediately without a restart.
+`component_visibility` is derived from a startup-loaded snapshot. Because `core` was provisioned after the service started, the snapshot does not include it and the field shows `"private"` (the fallback). This is expected — the field is informational only. Forward-auth checks visibility against the database on the first request and then caches a `public` result for `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` (30s by default), so `core` is publicly accessible immediately without a restart.
 :::
 
 ## 4. Make an authenticated request

--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -98,6 +98,10 @@ PACKYARD_MICROSOFT_CLIENT_SECRET=<from Entra app registration>
 PACKYARD_MICROSOFT_REDIRECT_URI=https://admin.pkg.example.org/api/v1/auth/callback/microsoft
 PACKYARD_MICROSOFT_TENANT_ID=<from Entra directory>
 
+# Forward-auth public-component cache TTL (optional; unset = 30s, 0 disables,
+# max 1h). See docs/reference/configuration.md.
+#PACKYARD_PUBLIC_COMPONENT_CACHE_TTL=30s
+
 # RustFS staging storage (generate with: openssl rand -hex 20)
 RUSTFS_ACCESS_KEY=<generate>
 RUSTFS_SECRET_KEY=<generate>

--- a/docs/ops/release-runbook.md
+++ b/docs/ops/release-runbook.md
@@ -115,13 +115,13 @@ gh run list --workflow=promote-oci.yml
 
 ### Changing component visibility
 
-Forward-auth caches `public` visibility for `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` (default 30s). Changing a component from private to public takes effect on the next request. Changing it from public to private takes effect immediately on the auth instance that handled the change, but another instance can keep serving it as public for up to one TTL. Before promoting content that must not be public into a component you have just made private:
+Forward-auth caches `public` visibility for `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` (30s unless set in `.env`). Changing a component from private to public takes effect on the next request. Changing it from public to private through `PATCH /api/v1/components/{name}` takes effect immediately on the auth instance that handled the request, which on the shipped single-instance Compose stack is the only instance. The cache can still serve the old answer for up to one TTL when the change did not go through that API: a second auth instance, a direct edit of the SQLite database, or a restore of the `auth-db` volume while the service is running. Before promoting content that must not be public into a component you have just made private:
 
 1. Change the visibility: `PATCH /api/v1/components/{name}` with `{"visibility": "private"}`.
-2. Wait one TTL (30s by default; check `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` in `.env`).
+2. Wait one TTL. This is a no-op safety margin on a single instance and required in the cases above.
 3. Promote.
 
-To take the cache out of the picture entirely, set `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL=0` in `.env` and restart the auth service; no image change or redeploy is needed.
+To take the cache out of the picture entirely, set `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL=0` in `.env` and recreate the container with `docker compose up -d auth`. A plain `docker compose restart` keeps the old environment and will not apply the change. No image change is needed.
 
 ---
 

--- a/docs/ops/release-runbook.md
+++ b/docs/ops/release-runbook.md
@@ -113,6 +113,16 @@ gh run list --workflow=promote-deb.yml
 gh run list --workflow=promote-oci.yml
 ```
 
+### Changing component visibility
+
+Forward-auth caches `public` visibility for `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` (default 30s). Changing a component from private to public takes effect on the next request. Changing it from public to private takes effect immediately on the auth instance that handled the change, but another instance can keep serving it as public for up to one TTL. Before promoting content that must not be public into a component you have just made private:
+
+1. Change the visibility: `PATCH /api/v1/components/{name}` with `{"visibility": "private"}`.
+2. Wait one TTL (30s by default; check `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` in `.env`).
+3. Promote.
+
+To take the cache out of the picture entirely, set `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL=0` in `.env` and restart the auth service; no image change or redeploy is needed.
+
 ---
 
 ## 4. Verify

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -118,9 +118,12 @@ curl -s "https://admin.pkg.example.org/api/v1/keys?account=${ACCOUNT_ID}" \
 
 If a component has `visibility: public` (set via `POST /api/v1/components` or
 updated via `PATCH /api/v1/components/{name}`), the auth service allows
-requests to its paths without inspecting credentials. Forward-auth reads
-visibility from the database on every request — changes take effect
-immediately without a restart. If a subscriber reports getting `401` on a
+requests to its paths without inspecting credentials. A change to `public`
+takes effect on the next request. A change to `private` made through the
+admin API takes effect immediately on the instance that handled it; a
+cached `public` answer can persist for up to `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL`
+(30s by default) only if the change bypassed that API, such as a direct
+database edit or a volume restore. If a subscriber reports getting `401` on a
 public component path, confirm the component's current visibility:
 
 ```bash
@@ -130,7 +133,7 @@ curl -s "https://admin.pkg.example.org/api/v1/components/core" \
 
 **Restart semantics — when a restart is and is not required:**
 
-- **Key creation** (`POST /api/v1/keys`) and **forward-auth decisions** both query the database on every request — a restart is **not** needed for new components, deleted components, or visibility changes to take effect.
+- **Key creation** (`POST /api/v1/keys`) and **forward-auth decisions** query the database (forward-auth serves recently confirmed `public` components from a short in-memory cache, evicted on API changes) — a restart is **not** needed for new components, deleted components, or visibility changes to take effect.
 - **Key list filter** (`GET /api/v1/keys?component=<name>`) validates the component name against an in-memory map loaded at startup — it returns `400 INVALID_COMPONENT` for a newly provisioned component until the service is restarted.
 - **`component_visibility` in key responses** is also derived from the startup-loaded map — it may show a stale value after a `PATCH /api/v1/components/{name}` visibility change until the service is restarted. This is cosmetic only; forward-auth always uses the live value.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -192,8 +192,9 @@ endpoints below remain useful for queries; routine issuance goes through
 ## Components
 
 Components are provisioned via the admin API and stored in the SQLite
-database. Forward-auth resolves component visibility via a live database
-lookup on every request; the `GET /api/v1/keys?component=` filter and
+database. Forward-auth resolves component visibility from the database,
+caching `public` results for `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` (30s by
+default) and evicting on `PATCH`/`DELETE`; the `GET /api/v1/keys?component=` filter and
 `component_visibility` field in key responses use a snapshot loaded at
 startup (restart required to pick up new components in those paths).
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -53,7 +53,9 @@ A subscription key is a 64-character hex secret bound to a single
 - enforces the key's component against the request path
   (`/rpm/{component}/…` etc.) — a `core` key cannot fetch `minion`;
 - fails closed: if the auth service is unreachable, Traefik returns 503
-  rather than admitting the request.
+  rather than admitting the request; if the auth service cannot reach its
+  database, it returns 503 for everything except public components it has
+  confirmed within the cache TTL described below.
 
 Forward-auth queries the database live on every request for private
 components — key revocation and account suspension take effect on the next
@@ -61,9 +63,11 @@ subscriber request with no service restart needed.
 
 Public components take a fast path.
 The auth service keeps an in-memory, positive-only cache of components whose visibility is `public`, each entry valid for `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` (default 30s).
-A request for a cached public component is allowed without touching the database, so public package traffic survives database outages shorter than the TTL.
+A request for a cached public component is allowed without touching the database, so a public component that was confirmed public shortly before a database outage keeps being served for the remainder of its entry's TTL.
+Entries expire one TTL after they were written, not after the outage began, and a component that was not already cached fails closed like everything else.
 Nothing else is ever cached: a `private` result, an unknown component, or a database error always goes back to the database and fails closed with 503 when the database is unavailable.
-Changing a component's visibility or deleting it evicts its entry immediately on the instance that handled the change; on any other instance the old answer can persist for at most one TTL.
+Changing a component's visibility or deleting it through the admin API evicts its entry immediately on the instance that handled the change.
+Any change that did not go through that instance's API, for example a second auth instance, a direct database edit, or a restore of the `auth-db` volume, becomes visible within one TTL.
 That TTL is therefore the revocation bound for public-to-private changes, and the release runbook asks operators to wait one TTL after such a change before promoting content that must not be public.
 Setting the TTL to `0` disables the cache and restores the live-lookup behaviour for every request.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -55,9 +55,17 @@ A subscription key is a 64-character hex secret bound to a single
 - fails closed: if the auth service is unreachable, Traefik returns 503
   rather than admitting the request.
 
-Forward-auth queries the database live on every request — component
-visibility, key revocation, and account suspension take effect on the next
+Forward-auth queries the database live on every request for private
+components — key revocation and account suspension take effect on the next
 subscriber request with no service restart needed.
+
+Public components take a fast path.
+The auth service keeps an in-memory, positive-only cache of components whose visibility is `public`, each entry valid for `PACKYARD_PUBLIC_COMPONENT_CACHE_TTL` (default 30s).
+A request for a cached public component is allowed without touching the database, so public package traffic survives database outages shorter than the TTL.
+Nothing else is ever cached: a `private` result, an unknown component, or a database error always goes back to the database and fails closed with 503 when the database is unavailable.
+Changing a component's visibility or deleting it evicts its entry immediately on the instance that handled the change; on any other instance the old answer can persist for at most one TTL.
+That TTL is therefore the revocation bound for public-to-private changes, and the release runbook asks operators to wait one TTL after such a change before promoting content that must not be public.
+Setting the TTL to `0` disables the cache and restores the live-lookup behaviour for every request.
 
 ### Operator trust
 


### PR DESCRIPTION
Closes #188. Follow-up to #84 / #187.

**A real bug found while scoping.** `compose.yml` forwarded only `RPM_DATA_ROOT` and `PACKYARD_ADMIN_HOST` into the auth container. Compose uses `.env` purely for interpolation, so `PACKYARD_BOOTSTRAP_OPERATOR_EMAIL` and the GitHub and Microsoft OAuth groups, which `docs/ops/production-deployment.md` and the onboarding guide tell operators to place in `.env`, never reached the service. On a fresh deployment following the docs, admin login could not work. Confirmed with `docker compose --env-file <populated> config` on unmodified main (only two `PACKYARD_*`/`RPM_*` entries). Fixed by forwarding each variable with `${VAR:-}`; the auth service treats empty as "not configured" for every affected variable, verified in `main.go` and `BootstrapOperatorFromEnv`.

**Docs.** `architecture.md` describes the public-component cache under Subscriber trust: positive-only, hard TTL, eviction on change or delete, fail-closed otherwise, TTL as the cross-instance revocation bound. `release-runbook.md` gains a "Changing component visibility" subsection with flip, wait one TTL, promote, and the `=0` off switch.

**`.env.example`.** Adds `ADMIN_DOMAIN` (required by compose since v0.3.0 but missing from the example), the bootstrap operator, both OAuth groups commented with pointers to the onboarding guide, and the cache TTL.

**Verified.** `docker compose config` with a populated env file resolves all ten `PACKYARD_*` variables; with `.env.example` verbatim the commented ones resolve to empty. `make docs-build` passes.