### PR TITLE
ci: restore the Integration workflow with a seeded operator session

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,27 @@
 name: Integration
 
+# Full-stack end-to-end run: brings the compose stack up with the CI override
+# (plain HTTP, ports published to the runner), seeds an operator session and
+# test data through the real admin API, and runs the e2e observability suite.
+# All steps call Makefile targets so the same commands work locally.
+
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'compose.yml'
+      - 'compose.override.ci.yml'
+      - 'traefik/**'
+      - 'auth/**'
+      - 'rpm/**'
+      - 'static/**'
+      - 'backup/**'
+      - 'tests/e2e/**'
+      - 'scripts/ci/**'
+      - 'Makefile'
+      - '.github/workflows/integration.yml'
+  schedule:
+    - cron: '17 4 * * 1'   # weekly, so a broken stack is noticed even without stack changes
   workflow_dispatch:
 
 permissions:
@@ -10,104 +31,55 @@ concurrency:
   group: integration-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  COMPOSE_PROJECT_NAME: packyard-ci
+  COMPOSE_FILE: compose.yml:compose.override.ci.yml
+
 jobs:
 
   integration:
     name: Full stack + observability
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
-      - name: Create .env
+      - name: Create CI .env
+        # Every ${VAR:?} guard in compose.yml must be satisfied. Hostnames are
+        # placeholders: the CI Traefik config routes by path, not by host, and
+        # ADMIN_DOMAIN only needs to match the Origin header the seed script sends.
         run: |
           cat > .env <<'EOF'
           ACME_EMAIL=ci@example.com
+          PKG_DOMAIN=pkg.ci.local
+          ADMIN_DOMAIN=admin.ci.local
           RUSTFS_ACCESS_KEY=ci-access-key
           RUSTFS_SECRET_KEY=ci-secret-key-value
+          PACKYARD_BOOTSTRAP_OPERATOR_EMAIL=ci-operator@example.org
           EOF
 
-      - name: Start stack (CI override — HTTP, no TLS)
-        run: |
-          docker compose \
-            -f compose.yml \
-            -f compose.override.ci.yml \
-            up -d
+      - name: Start stack
+        run: make ci-stack-up
 
-      - name: Wait for Traefik to be ready
-        run: |
-          echo "Waiting for Traefik..."
-          timeout 30 bash -c \
-            'until curl -s -o /dev/null -w "%{http_code}" http://localhost/gpg/lts.asc | grep -qE "^(200|404)$"; do sleep 1; done'
-          echo "Traefik is ready."
+      - name: Verify environment passthrough and compose guards
+        run: make ci-verify-env
 
-      - name: Wait for auth to be healthy
-        run: |
-          echo "Waiting for auth service..."
-          timeout 60 bash -c \
-            'until curl -sf http://localhost:8080/health > /dev/null; do sleep 2; done'
-          echo "Auth is healthy."
-
-      - name: Seed CI components
-        run: |
-          # Provision the CI component set (mixed visibility — exercises both auth code paths):
-          #   core:   public  — unauthenticated access allowed
-          #   minion: private — credentials required
-          # Treat 409 (already exists) as success so re-runs are idempotent.
-          for payload in \
-            '{"name":"core","visibility":"public","rpm_series":["2025"],"rpm_os_families":["el9"],"rpm_architectures":["x86_64"]}' \
-            '{"name":"minion","visibility":"private","rpm_series":["2025"],"rpm_os_families":["el9"],"rpm_architectures":["x86_64"]}'; do
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:8080/api/v1/components \
-              -H 'Content-Type: application/json' \
-              -d "${payload}")
-            if [ "${HTTP_CODE}" != "201" ] && [ "${HTTP_CODE}" != "409" ]; then
-              echo "ERROR: unexpected HTTP ${HTTP_CODE} seeding component" >&2
-              exit 1
-            fi
-          done
-          echo "Components provisioned."
-          # Restart auth so it reloads component sets from the database.
-          docker compose -f compose.yml -f compose.override.ci.yml restart auth \
-            || { echo "ERROR: docker compose restart auth failed" >&2; exit 1; }
-          timeout 60 bash -c \
-            'until curl -sf http://localhost:8080/health > /dev/null; do sleep 2; done'
-          echo "Auth reloaded with new components."
-
-      - name: Seed CI subscription key
-        run: |
-          RESPONSE=$(curl -sf http://localhost:8080/api/v1/keys \
-            -H 'Content-Type: application/json' \
-            -d '{"component":"core","label":"ci-integration-test"}')
-          echo "Create key response: ${RESPONSE}"
-          KEY_ID=$(echo "${RESPONSE}" | jq -r '.id')
-          if [ -z "${KEY_ID}" ] || [ "${KEY_ID}" = "null" ]; then
-            echo "ERROR: failed to extract key ID from response" >&2
-            exit 1
-          fi
-          echo "VALID_KEY=${KEY_ID}" >> "${GITHUB_ENV}"
-          echo "Seeded subscription key: ${KEY_ID}"
+      - name: Seed operator session, components and key
+        env:
+          ADMIN_ORIGIN: https://admin.ci.local
+          BOOTSTRAP_EMAIL: ci-operator@example.org
+        run: make ci-seed
 
       - name: Run observability tests (AC1–AC4)
-        env:
-          BASE_URL: http://localhost
-          METRICS_URL: http://localhost:9090/metrics
-        run: bash tests/e2e/observability.sh
+        run: make e2e-observability
 
       - name: Dump service logs on failure
         if: failure()
-        run: |
-          docker compose \
-            -f compose.yml \
-            -f compose.override.ci.yml \
-            logs --no-color
+        run: make ci-stack-logs
 
       - name: Tear down stack
         if: always()
-        run: |
-          docker compose \
-            -f compose.yml \
-            -f compose.override.ci.yml \
-            down -v
+        run: make ci-stack-down

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,24 @@ name: Integration
 # All steps call Makefile targets so the same commands work locally.
 
 on:
+  pull_request:
+    paths:
+      - 'compose.yml'
+      - 'compose.override.ci.yml'
+      - 'traefik/**'
+      - 'auth/**'
+      - 'rpm/**'
+      - 'static/**'
+      - 'backup/**'
+      - 'aptly/**'
+      - 'deb/**'
+      - 'zot/**'
+      - 'rustfs/**'
+      - 'scripts/backup-keystore.sh'
+      - 'tests/e2e/**'
+      - 'scripts/ci/**'
+      - 'Makefile'
+      - '.github/workflows/integration.yml'
   push:
     branches: [main]
     paths:
@@ -16,6 +34,11 @@ on:
       - 'rpm/**'
       - 'static/**'
       - 'backup/**'
+      - 'aptly/**'
+      - 'deb/**'
+      - 'zot/**'
+      - 'rustfs/**'
+      - 'scripts/backup-keystore.sh'
       - 'tests/e2e/**'
       - 'scripts/ci/**'
       - 'Makefile'
@@ -27,9 +50,11 @@ on:
 permissions:
   contents: read
 
+# One run per event and ref. Never cancel: a post-merge run that is cancelled
+# by the next merge leaves that commit without a verdict and skips the log dump.
 concurrency:
-  group: integration-${{ github.ref }}
-  cancel-in-progress: true
+  group: integration-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   COMPOSE_PROJECT_NAME: packyard-ci
@@ -49,8 +74,8 @@ jobs:
 
       - name: Create CI .env
         # Every ${VAR:?} guard in compose.yml must be satisfied. Hostnames are
-        # placeholders: the CI Traefik config routes by path, not by host, and
-        # ADMIN_DOMAIN only needs to match the Origin header the seed script sends.
+        # placeholders: the CI Traefik config routes by path, not by host. The
+        # seed script derives its Origin header from ADMIN_DOMAIN via compose.
         run: |
           cat > .env <<'EOF'
           ACME_EMAIL=ci@example.com
@@ -67,10 +92,9 @@ jobs:
       - name: Verify environment passthrough and compose guards
         run: make ci-verify-env
 
-      - name: Seed operator session, components and key
-        env:
-          ADMIN_ORIGIN: https://admin.ci.local
-          BOOTSTRAP_EMAIL: ci-operator@example.org
+      - name: Seed operator session, components, account and key
+        # Admin host and bootstrap email are read from `docker compose config`,
+        # so they always match what the auth container was started with.
         run: make ci-seed
 
       - name: Run observability tests (AC1–AC4)

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ site/
 # Build artefacts
 bin/
 auth/server
+
+# Integration run artefact (subscription key seeded by scripts/ci/seed-integration.sh)
+.ci-valid-key

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ UNAME_S := $(shell uname -s)
 .PHONY: help docs-install docs-serve docs-build docs-clean check-node \
         admin-ui admin-ui-install admin-ui-dev admin-ui-clean \
         build build-clean test lint lint-workflows build-image-auth build-image-rpm build-images \
-        ci-stack-up ci-stack-down ci-stack-logs ci-seed ci-verify-env e2e-observability
+        ci-guard ci-stack-up ci-stack-down ci-stack-logs ci-seed ci-verify-env e2e-observability
 
 ## help: Show this help
 help:
@@ -113,41 +113,41 @@ build-image-rpm:
 build-images: build-image-auth build-image-rpm
 
 # ---------------------------------------------------------------------------
-# Integration stack (CI). Callers set COMPOSE_PROJECT_NAME and COMPOSE_FILE
-# (compose.yml:compose.override.ci.yml) in the environment; a .env with the
-# required hostnames and credentials must exist in the working directory.
+# Integration stack (CI). Every ci-* target refuses to run unless COMPOSE_FILE
+# names compose.override.ci.yml and COMPOSE_PROJECT_NAME is set, so a stray
+# `make ci-stack-down` can never remove a developer's real stack. A .env (or
+# COMPOSE_ENV_FILES) with the required hostnames and credentials must exist.
 # ---------------------------------------------------------------------------
 
-## ci-stack-up: Start the compose stack and wait for Traefik and auth to be ready
-ci-stack-up:
+ci-guard:
+	@case "$${COMPOSE_FILE:-}" in *compose.override.ci.yml*) ;; *) \
+	  echo "refusing: COMPOSE_FILE must include compose.override.ci.yml (got '$${COMPOSE_FILE:-}')"; exit 1 ;; esac
+	@test -n "$${COMPOSE_PROJECT_NAME:-}" || { echo "refusing: COMPOSE_PROJECT_NAME must be set (e.g. packyard-ci)"; exit 1; }
+
+## ci-stack-up: Start the CI compose stack, wait for every service, Traefik routing and auth health
+ci-stack-up: ci-guard
 	docker compose up -d
 	bash scripts/ci/wait-for-stack.sh
 
-## ci-stack-down: Stop the compose stack and remove its volumes
-ci-stack-down:
+## ci-stack-down: Stop the CI compose stack and remove its volumes
+ci-stack-down: ci-guard
 	docker compose down -v
+	rm -f .ci-valid-key
 
-## ci-stack-logs: Dump all service logs (used on failure)
-ci-stack-logs:
+## ci-stack-logs: Dump all CI stack service logs (used on failure)
+ci-stack-logs: ci-guard
 	docker compose logs --no-color
 
-## ci-seed: Seed an operator session, CI components and a subscription key via the admin API
-ci-seed:
+## ci-seed: Seed an operator session, CI components, an account and a subscription key via the admin API
+ci-seed: ci-guard
 	bash scripts/ci/seed-integration.sh
 
-## ci-verify-env: Assert PACKYARD_* variables reach the auth container and the ADMIN_DOMAIN guard fires when missing
-ci-verify-env:
-	@cid=$$(docker compose ps -q auth); test -n "$$cid" || { echo "auth container not running"; exit 1; }; \
-	for v in PACKYARD_ADMIN_HOST PACKYARD_BOOTSTRAP_OPERATOR_EMAIL PACKYARD_PUBLIC_COMPONENT_CACHE_TTL PACKYARD_GITHUB_CLIENT_ID; do \
-	  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$$cid" | grep -q "^$$v=" \
-	    || { echo "missing $$v in auth container environment"; exit 1; }; \
-	done; echo "auth container receives the forwarded PACKYARD_* variables"
-	@tmp=$$(mktemp); grep -v '^ADMIN_DOMAIN=' "$${COMPOSE_ENV_FILES:-.env}" > "$$tmp"; \
-	if docker compose --env-file "$$tmp" config > /dev/null 2> "$$tmp.err"; then \
-	  echo "expected compose to reject a missing ADMIN_DOMAIN"; rm -f "$$tmp" "$$tmp.err"; exit 1; fi; \
-	grep -q 'ADMIN_DOMAIN must be set' "$$tmp.err" || { echo "unexpected error:"; cat "$$tmp.err"; rm -f "$$tmp" "$$tmp.err"; exit 1; }; \
-	rm -f "$$tmp" "$$tmp.err"; echo "compose guard rejects a missing ADMIN_DOMAIN as expected"
+## ci-verify-env: Assert PACKYARD_* variables reach the auth container with the expected values, and that compose rejects a missing ADMIN_DOMAIN
+ci-verify-env: ci-guard
+	bash scripts/ci/verify-env.sh
 
-## e2e-observability: Run the observability end-to-end tests against the running stack (needs VALID_KEY)
-e2e-observability:
-	BASE_URL=$${BASE_URL:-http://localhost} METRICS_URL=$${METRICS_URL:-http://localhost:9090/metrics} bash tests/e2e/observability.sh
+## e2e-observability: Run the observability end-to-end tests (VALID_KEY from the environment or .ci-valid-key)
+e2e-observability: ci-guard
+	VALID_KEY="$${VALID_KEY:-$$(cat .ci-valid-key 2>/dev/null)}" \
+	BASE_URL="$${BASE_URL:-http://localhost}" METRICS_URL="$${METRICS_URL:-http://localhost:9090/metrics}" \
+	bash tests/e2e/observability.sh

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ UNAME_S := $(shell uname -s)
 
 .PHONY: help docs-install docs-serve docs-build docs-clean check-node \
         admin-ui admin-ui-install admin-ui-dev admin-ui-clean \
-        build build-clean test lint lint-workflows build-image-auth build-image-rpm build-images
+        build build-clean test lint lint-workflows build-image-auth build-image-rpm build-images \
+        ci-stack-up ci-stack-down ci-stack-logs ci-seed ci-verify-env e2e-observability
 
 ## help: Show this help
 help:
@@ -110,3 +111,43 @@ build-image-rpm:
 
 ## build-images: Build all locally built container images (no push)
 build-images: build-image-auth build-image-rpm
+
+# ---------------------------------------------------------------------------
+# Integration stack (CI). Callers set COMPOSE_PROJECT_NAME and COMPOSE_FILE
+# (compose.yml:compose.override.ci.yml) in the environment; a .env with the
+# required hostnames and credentials must exist in the working directory.
+# ---------------------------------------------------------------------------
+
+## ci-stack-up: Start the compose stack and wait for Traefik and auth to be ready
+ci-stack-up:
+	docker compose up -d
+	bash scripts/ci/wait-for-stack.sh
+
+## ci-stack-down: Stop the compose stack and remove its volumes
+ci-stack-down:
+	docker compose down -v
+
+## ci-stack-logs: Dump all service logs (used on failure)
+ci-stack-logs:
+	docker compose logs --no-color
+
+## ci-seed: Seed an operator session, CI components and a subscription key via the admin API
+ci-seed:
+	bash scripts/ci/seed-integration.sh
+
+## ci-verify-env: Assert PACKYARD_* variables reach the auth container and the ADMIN_DOMAIN guard fires when missing
+ci-verify-env:
+	@cid=$$(docker compose ps -q auth); test -n "$$cid" || { echo "auth container not running"; exit 1; }; \
+	for v in PACKYARD_ADMIN_HOST PACKYARD_BOOTSTRAP_OPERATOR_EMAIL PACKYARD_PUBLIC_COMPONENT_CACHE_TTL PACKYARD_GITHUB_CLIENT_ID; do \
+	  docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$$cid" | grep -q "^$$v=" \
+	    || { echo "missing $$v in auth container environment"; exit 1; }; \
+	done; echo "auth container receives the forwarded PACKYARD_* variables"
+	@tmp=$$(mktemp); grep -v '^ADMIN_DOMAIN=' "$${COMPOSE_ENV_FILES:-.env}" > "$$tmp"; \
+	if docker compose --env-file "$$tmp" config > /dev/null 2> "$$tmp.err"; then \
+	  echo "expected compose to reject a missing ADMIN_DOMAIN"; rm -f "$$tmp" "$$tmp.err"; exit 1; fi; \
+	grep -q 'ADMIN_DOMAIN must be set' "$$tmp.err" || { echo "unexpected error:"; cat "$$tmp.err"; rm -f "$$tmp" "$$tmp.err"; exit 1; }; \
+	rm -f "$$tmp" "$$tmp.err"; echo "compose guard rejects a missing ADMIN_DOMAIN as expected"
+
+## e2e-observability: Run the observability end-to-end tests against the running stack (needs VALID_KEY)
+e2e-observability:
+	BASE_URL=$${BASE_URL:-http://localhost} METRICS_URL=$${METRICS_URL:-http://localhost:9090/metrics} bash tests/e2e/observability.sh

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# lib.sh — helpers shared by the CI stack scripts. Source it; do not execute.
+
+# require_cmds NAME... — fail early with one clear message per missing tool.
+require_cmds() {
+  local missing=0 c
+  for c in "$@"; do
+    command -v "$c" > /dev/null 2>&1 || { echo "ERROR: required command not found: $c" >&2; missing=1; }
+  done
+  [ "$missing" -eq 0 ]
+}
+
+# wait_until SECONDS COMMAND... — poll COMMAND every 2s until it succeeds or the
+# deadline passes. Portable (no GNU timeout, which macOS lacks). COMMAND must
+# bound its own runtime (e.g. curl --max-time), otherwise the deadline is only
+# checked between attempts.
+wait_until() {
+  local deadline=$(( $(date +%s) + $1 )); shift
+  until "$@" > /dev/null 2>&1; do
+    [ "$(date +%s)" -lt "${deadline}" ] || { echo "ERROR: timed out waiting for: $*" >&2; return 1; }
+    sleep 2
+  done
+}
+
+# compose_auth_env NAME — the resolved value of an auth service environment
+# variable from `docker compose config`, so scripts read the same values the
+# container gets instead of duplicating literals.
+compose_auth_env() {
+  docker compose config --format json | jq -r --arg k "$1" '.services.auth.environment[$k] // empty'
+}

--- a/scripts/ci/seed-integration.sh
+++ b/scripts/ci/seed-integration.sh
@@ -14,47 +14,52 @@
 #   2. verifies the session with GET /api/v1/auth/whoami;
 #   3. provisions the CI components (core public, minion private);
 #   4. restarts auth so the keys handler reloads its component set;
-#   5. creates a CI subscriber account and a subscription key for core,
-#      exported as VALID_KEY.
+#   5. creates a per-run CI subscriber account and a subscription key for core,
+#      exported as VALID_KEY (masked in Actions logs) and written to a key file
+#      for `make e2e-observability`.
 #
-# Required environment:
-#   COMPOSE_PROJECT_NAME  compose project (volume is <project>_auth-db)
-#   ADMIN_ORIGIN          value for the Origin header, must equal PACKYARD_ADMIN_HOST
-#   BOOTSTRAP_EMAIL       the PACKYARD_BOOTSTRAP_OPERATOR_EMAIL the stack started with
-# Optional:
-#   AUTH_URL   (default http://localhost:8080)
-#   GITHUB_ENV if set, VALID_KEY is appended for later workflow steps
+# Reads the admin host and bootstrap email from `docker compose config`, so the
+# values always match what the auth container was started with. Requires
+# COMPOSE_PROJECT_NAME (the volume is <project>_auth-db). Optional:
+#   AUTH_URL        default http://localhost:8080
+#   VALID_KEY_FILE  default .ci-valid-key (git-ignored)
+#   GITHUB_ENV      if set, VALID_KEY is exported for later workflow steps
 set -euo pipefail
+# shellcheck source=scripts/ci/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+require_cmds docker jq curl openssl
 
 : "${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required}"
-: "${ADMIN_ORIGIN:?ADMIN_ORIGIN is required (e.g. https://admin.ci.local)}"
-: "${BOOTSTRAP_EMAIL:?BOOTSTRAP_EMAIL is required}"
 AUTH_URL="${AUTH_URL:-http://localhost:8080}"
+VALID_KEY_FILE="${VALID_KEY_FILE:-.ci-valid-key}"
 VOLUME="${COMPOSE_PROJECT_NAME}_auth-db"
 
-# wait_until SECONDS COMMAND... — poll COMMAND every 2s until it succeeds or the
-# deadline passes. Portable (no GNU timeout, which macOS lacks).
-wait_until() {
-  local deadline=$(( $(date +%s) + $1 )); shift
-  until "$@" > /dev/null 2>&1; do
-    [ "$(date +%s)" -lt "${deadline}" ] || { echo "ERROR: timed out waiting for: $*" >&2; return 1; }
-    sleep 2
-  done
-}
+ADMIN_ORIGIN=$(compose_auth_env PACKYARD_ADMIN_HOST)
+BOOTSTRAP_EMAIL=$(compose_auth_env PACKYARD_BOOTSTRAP_OPERATOR_EMAIL)
+[ -n "${ADMIN_ORIGIN}" ] || { echo "ERROR: PACKYARD_ADMIN_HOST is not set for the auth service" >&2; exit 1; }
+[ -n "${BOOTSTRAP_EMAIL}" ] || { echo "ERROR: PACKYARD_BOOTSTRAP_OPERATOR_EMAIL is empty; the stack must start with a bootstrap operator" >&2; exit 1; }
+# The email is interpolated into SQL below; only allow the characters an
+# address legitimately contains, which excludes quotes and semicolons.
+[[ "${BOOTSTRAP_EMAIL}" =~ ^[A-Za-z0-9._%+@-]+$ ]] || { echo "ERROR: bootstrap email contains characters outside [A-Za-z0-9._%+@-]" >&2; exit 1; }
+
+docker volume inspect "${VOLUME}" > /dev/null 2>&1 \
+  || { echo "ERROR: volume ${VOLUME} does not exist; is the stack up under COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}?" >&2; exit 1; }
 
 # The backup service image carries sqlite3; reuse it rather than pinning a
-# second image here. compose resolves the pinned tag from compose.yml.
-SIDECAR_IMAGE=$(docker compose config --format json | jq -r '.services.backup.image')
-[ -n "${SIDECAR_IMAGE}" ] && [ "${SIDECAR_IMAGE}" != "null" ] \
-  || { echo "ERROR: could not resolve the backup image from compose config" >&2; exit 1; }
+# second image here.
+SIDECAR_IMAGE=$(docker compose config --format json | jq -r '.services.backup.image // empty')
+[ -n "${SIDECAR_IMAGE}" ] || { echo "ERROR: could not resolve the backup image from compose config" >&2; exit 1; }
 
 sql() {
-  docker run --rm -v "${VOLUME}:/data/db" --entrypoint sqlite3 "${SIDECAR_IMAGE}" /data/db/auth.db "$1"
+  # .timeout: auth holds the database open (WAL); wait up to 5s for its writes.
+  # Set via -cmd so it produces no output that would pollute query results.
+  docker run --rm -v "${VOLUME}:/data/db" --entrypoint sqlite3 "${SIDECAR_IMAGE}" \
+    -cmd ".timeout 5000" /data/db/auth.db "$1"
 }
 
-# 1. Seed a session for the bootstrap operator. Timestamps use the same
-#    RFC 3339 layout the Go store writes. One hour is plenty for a CI run and
-#    well under the service's 8h idle / 24h absolute limits.
+# 1. Seed a session for the bootstrap operator. Timestamps use the RFC 3339
+#    layout the Go store writes. One hour covers a CI run and is well under the
+#    service's 8h idle / 24h absolute limits.
 SESSION_ID=$(openssl rand -hex 32)
 ROWS=$(sql "INSERT INTO sessions (id, operator_id, created_at, last_seen_at, expires_at, ip, user_agent)
   SELECT '${SESSION_ID}', id,
@@ -65,63 +70,60 @@ ROWS=$(sql "INSERT INTO sessions (id, operator_id, created_at, last_seen_at, exp
   FROM operators WHERE email = lower('${BOOTSTRAP_EMAIL}') AND status = 'active';
   SELECT changes();")
 if [ "${ROWS}" != "1" ]; then
-  echo "ERROR: expected to seed 1 session row for ${BOOTSTRAP_EMAIL}, got '${ROWS}'." >&2
-  echo "       Is PACKYARD_BOOTSTRAP_OPERATOR_EMAIL set and forwarded to the auth container?" >&2
-  sql "SELECT id, email, role, status FROM operators;" >&2 || true
+  echo "ERROR: expected to seed 1 session row for the bootstrap operator, got '${ROWS}'." >&2
+  sql "SELECT id, role, status FROM operators;" >&2 || true
   exit 1
 fi
-echo "Seeded operator session for ${BOOTSTRAP_EMAIL}."
+echo "Seeded an operator session."
 
+BODY=$(mktemp); trap 'rm -f "${BODY}"' EXIT
 COOKIE="packyard_session=${SESSION_ID}"
-api() { # method path [json-body]
-  local method="$1" path="$2" body="${3:-}"
+api() { # method path [json-body] -> prints HTTP code, 000 on transport failure
+  local method="$1" path="$2" body="${3:-}" code
   if [ -n "${body}" ]; then
-    curl -s -o /tmp/api-body -w '%{http_code}' -X "${method}" "${AUTH_URL}${path}" \
-      -H "Cookie: ${COOKIE}" -H "Origin: ${ADMIN_ORIGIN}" -H 'Content-Type: application/json' -d "${body}"
+    code=$(curl -s --max-time 20 -o "${BODY}" -w '%{http_code}' -X "${method}" "${AUTH_URL}${path}" \
+      -H "Cookie: ${COOKIE}" -H "Origin: ${ADMIN_ORIGIN}" -H 'Content-Type: application/json' -d "${body}") || code=000
   else
-    curl -s -o /tmp/api-body -w '%{http_code}' -X "${method}" "${AUTH_URL}${path}" \
-      -H "Cookie: ${COOKIE}" -H "Origin: ${ADMIN_ORIGIN}"
+    code=$(curl -s --max-time 20 -o "${BODY}" -w '%{http_code}' -X "${method}" "${AUTH_URL}${path}" \
+      -H "Cookie: ${COOKIE}" -H "Origin: ${ADMIN_ORIGIN}") || code=000
   fi
+  printf '%s' "${code}"
 }
+fail_api() { echo "ERROR: $1 returned HTTP $2: $(cat "${BODY}" 2>/dev/null)" >&2; exit 1; }
 
 # 2. The session must be accepted by the real middleware chain.
-CODE=$(api GET /api/v1/auth/whoami)
-[ "${CODE}" = "200" ] || { echo "ERROR: whoami returned ${CODE}: $(cat /tmp/api-body)" >&2; exit 1; }
-echo "whoami OK: $(jq -c '{email, role}' /tmp/api-body)"
+CODE=$(api GET /api/v1/auth/whoami); [ "${CODE}" = "200" ] || fail_api whoami "${CODE}"
+ROLE=$(jq -er '.role' "${BODY}") || { echo "ERROR: whoami body is not the expected JSON" >&2; exit 1; }
+echo "whoami OK (role ${ROLE})."
 
 # 3. Components: core public, minion private. 409 means a re-run; fine.
 for payload in \
   '{"name":"core","visibility":"public","rpm_series":["2025"],"rpm_os_families":["el9"],"rpm_architectures":["x86_64"]}' \
   '{"name":"minion","visibility":"private","rpm_series":["2025"],"rpm_os_families":["el9"],"rpm_architectures":["x86_64"]}'; do
   CODE=$(api POST /api/v1/components "${payload}")
-  case "${CODE}" in 201|409) ;; *) echo "ERROR: component seed returned ${CODE}: $(cat /tmp/api-body)" >&2; exit 1 ;; esac
+  case "${CODE}" in 201|409) ;; *) fail_api "component seed" "${CODE}" ;; esac
 done
 echo "Components provisioned."
 
 # 4. The keys handler validates component names against a set loaded at
-#    startup, so restart auth before creating a key.
+#    startup, so restart auth before creating a key. `docker compose restart`
+#    is synchronous; the poll then covers listener start-up.
 docker compose restart auth
-wait_until 90 curl -sf "${AUTH_URL}/health"
+wait_until 90 curl -sf --max-time 5 "${AUTH_URL}/health"
 echo "Auth reloaded with new components."
 
-# 5. Keys belong to accounts. Create (or reuse, on 409) the CI account, then
-#    issue a key for the public test component.
-CODE=$(api POST /api/v1/accounts '{"email":"ci-subscriber@example.org","org_name":"packyard CI"}')
-case "${CODE}" in
-  201) ACCOUNT_ID=$(jq -r '.id' /tmp/api-body) ;;
-  409) CODE=$(api GET '/api/v1/accounts?limit=100')
-       [ "${CODE}" = "200" ] || { echo "ERROR: listing accounts returned ${CODE}: $(cat /tmp/api-body)" >&2; exit 1; }
-       ACCOUNT_ID=$(jq -r 'if type == "array" then . else .accounts end | map(select(.email == "ci-subscriber@example.org")) | .[0].id' /tmp/api-body) ;;
-  *)   echo "ERROR: account creation returned ${CODE}: $(cat /tmp/api-body)" >&2; exit 1 ;;
-esac
-[ -n "${ACCOUNT_ID}" ] && [ "${ACCOUNT_ID}" != "null" ] || { echo "ERROR: could not determine CI account id" >&2; exit 1; }
-echo "CI subscriber account ${ACCOUNT_ID:0:8}…"
+# 5. A fresh account per run avoids any collision with soft-deleted or
+#    suspended accounts from earlier runs against a persisted database.
+ACCOUNT_EMAIL="ci-subscriber-${SESSION_ID:0:8}@example.org"
+CODE=$(api POST /api/v1/accounts "{\"email\":\"${ACCOUNT_EMAIL}\",\"org_name\":\"packyard CI\"}")
+[ "${CODE}" = "201" ] || fail_api "account creation" "${CODE}"
+ACCOUNT_ID=$(jq -er '.id' "${BODY}")
 
 CODE=$(api POST /api/v1/keys "{\"account_id\":\"${ACCOUNT_ID}\",\"component\":\"core\",\"label\":\"ci-integration-test\"}")
-[ "${CODE}" = "201" ] || { echo "ERROR: key creation returned ${CODE}: $(cat /tmp/api-body)" >&2; exit 1; }
-VALID_KEY=$(jq -r '.id' /tmp/api-body)
-[ -n "${VALID_KEY}" ] && [ "${VALID_KEY}" != "null" ] || { echo "ERROR: no key id in response" >&2; exit 1; }
-if [ -n "${GITHUB_ENV:-}" ]; then
-  echo "VALID_KEY=${VALID_KEY}" >> "${GITHUB_ENV}"
-fi
-echo "Seeded subscription key ${VALID_KEY:0:8}… for component core."
+[ "${CODE}" = "201" ] || fail_api "key creation" "${CODE}"
+VALID_KEY=$(jq -er '.id' "${BODY}")
+
+if [ -n "${GITHUB_ACTIONS:-}" ]; then echo "::add-mask::${VALID_KEY}"; fi
+if [ -n "${GITHUB_ENV:-}" ]; then printf 'VALID_KEY<<EOF\n%s\nEOF\n' "${VALID_KEY}" >> "${GITHUB_ENV}"; fi
+umask 077; printf '%s\n' "${VALID_KEY}" > "${VALID_KEY_FILE}"
+echo "Seeded subscription key for component core (written to ${VALID_KEY_FILE})."

--- a/scripts/ci/seed-integration.sh
+++ b/scripts/ci/seed-integration.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# seed-integration.sh — give CI an operator session and seed test data through
+# the real admin API.
+#
+# The admin API sits behind OAuth: /api/v1/* requires a session cookie, a
+# matching Origin header (CSRF guard) and an active operator. CI cannot log in
+# through GitHub or Microsoft, so this script:
+#   1. inserts one session row for the bootstrap operator directly into the
+#      auth SQLite database, using the backup image as a one-off sqlite3
+#      sidecar on the auth-db volume (the auth image is distroless);
+#   2. verifies the session with GET /api/v1/auth/whoami;
+#   3. provisions the CI components (core public, minion private);
+#   4. restarts auth so the keys handler reloads its component set;
+#   5. creates a CI subscriber account and a subscription key for core,
+#      exported as VALID_KEY.
+#
+# Required environment:
+#   COMPOSE_PROJECT_NAME  compose project (volume is <project>_auth-db)
+#   ADMIN_ORIGIN          value for the Origin header, must equal PACKYARD_ADMIN_HOST
+#   BOOTSTRAP_EMAIL       the PACKYARD_BOOTSTRAP_OPERATOR_EMAIL the stack started with
+# Optional:
+#   AUTH_URL   (default http://localhost:8080)
+#   GITHUB_ENV if set, VALID_KEY is appended for later workflow steps
+set -euo pipefail
+
+: "${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required}"
+: "${ADMIN_ORIGIN:?ADMIN_ORIGIN is required (e.g. https://admin.ci.local)}"
+: "${BOOTSTRAP_EMAIL:?BOOTSTRAP_EMAIL is required}"
+AUTH_URL="${AUTH_URL:-http://localhost:8080}"
+VOLUME="${COMPOSE_PROJECT_NAME}_auth-db"
+
+# wait_until SECONDS COMMAND... — poll COMMAND every 2s until it succeeds or the
+# deadline passes. Portable (no GNU timeout, which macOS lacks).
+wait_until() {
+  local deadline=$(( $(date +%s) + $1 )); shift
+  until "$@" > /dev/null 2>&1; do
+    [ "$(date +%s)" -lt "${deadline}" ] || { echo "ERROR: timed out waiting for: $*" >&2; return 1; }
+    sleep 2
+  done
+}
+
+# The backup service image carries sqlite3; reuse it rather than pinning a
+# second image here. compose resolves the pinned tag from compose.yml.
+SIDECAR_IMAGE=$(docker compose config --format json | jq -r '.services.backup.image')
+[ -n "${SIDECAR_IMAGE}" ] && [ "${SIDECAR_IMAGE}" != "null" ] \
+  || { echo "ERROR: could not resolve the backup image from compose config" >&2; exit 1; }
+
+sql() {
+  docker run --rm -v "${VOLUME}:/data/db" --entrypoint sqlite3 "${SIDECAR_IMAGE}" /data/db/auth.db "$1"
+}
+
+# 1. Seed a session for the bootstrap operator. Timestamps use the same
+#    RFC 3339 layout the Go store writes. One hour is plenty for a CI run and
+#    well under the service's 8h idle / 24h absolute limits.
+SESSION_ID=$(openssl rand -hex 32)
+ROWS=$(sql "INSERT INTO sessions (id, operator_id, created_at, last_seen_at, expires_at, ip, user_agent)
+  SELECT '${SESSION_ID}', id,
+         strftime('%Y-%m-%dT%H:%M:%SZ','now'),
+         strftime('%Y-%m-%dT%H:%M:%SZ','now'),
+         strftime('%Y-%m-%dT%H:%M:%SZ','now','+1 hour'),
+         '127.0.0.1', 'packyard-ci'
+  FROM operators WHERE email = lower('${BOOTSTRAP_EMAIL}') AND status = 'active';
+  SELECT changes();")
+if [ "${ROWS}" != "1" ]; then
+  echo "ERROR: expected to seed 1 session row for ${BOOTSTRAP_EMAIL}, got '${ROWS}'." >&2
+  echo "       Is PACKYARD_BOOTSTRAP_OPERATOR_EMAIL set and forwarded to the auth container?" >&2
+  sql "SELECT id, email, role, status FROM operators;" >&2 || true
+  exit 1
+fi
+echo "Seeded operator session for ${BOOTSTRAP_EMAIL}."
+
+COOKIE="packyard_session=${SESSION_ID}"
+api() { # method path [json-body]
+  local method="$1" path="$2" body="${3:-}"
+  if [ -n "${body}" ]; then
+    curl -s -o /tmp/api-body -w '%{http_code}' -X "${method}" "${AUTH_URL}${path}" \
+      -H "Cookie: ${COOKIE}" -H "Origin: ${ADMIN_ORIGIN}" -H 'Content-Type: application/json' -d "${body}"
+  else
+    curl -s -o /tmp/api-body -w '%{http_code}' -X "${method}" "${AUTH_URL}${path}" \
+      -H "Cookie: ${COOKIE}" -H "Origin: ${ADMIN_ORIGIN}"
+  fi
+}
+
+# 2. The session must be accepted by the real middleware chain.
+CODE=$(api GET /api/v1/auth/whoami)
+[ "${CODE}" = "200" ] || { echo "ERROR: whoami returned ${CODE}: $(cat /tmp/api-body)" >&2; exit 1; }
+echo "whoami OK: $(jq -c '{email, role}' /tmp/api-body)"
+
+# 3. Components: core public, minion private. 409 means a re-run; fine.
+for payload in \
+  '{"name":"core","visibility":"public","rpm_series":["2025"],"rpm_os_families":["el9"],"rpm_architectures":["x86_64"]}' \
+  '{"name":"minion","visibility":"private","rpm_series":["2025"],"rpm_os_families":["el9"],"rpm_architectures":["x86_64"]}'; do
+  CODE=$(api POST /api/v1/components "${payload}")
+  case "${CODE}" in 201|409) ;; *) echo "ERROR: component seed returned ${CODE}: $(cat /tmp/api-body)" >&2; exit 1 ;; esac
+done
+echo "Components provisioned."
+
+# 4. The keys handler validates component names against a set loaded at
+#    startup, so restart auth before creating a key.
+docker compose restart auth
+wait_until 90 curl -sf "${AUTH_URL}/health"
+echo "Auth reloaded with new components."
+
+# 5. Keys belong to accounts. Create (or reuse, on 409) the CI account, then
+#    issue a key for the public test component.
+CODE=$(api POST /api/v1/accounts '{"email":"ci-subscriber@example.org","org_name":"packyard CI"}')
+case "${CODE}" in
+  201) ACCOUNT_ID=$(jq -r '.id' /tmp/api-body) ;;
+  409) CODE=$(api GET '/api/v1/accounts?limit=100')
+       [ "${CODE}" = "200" ] || { echo "ERROR: listing accounts returned ${CODE}: $(cat /tmp/api-body)" >&2; exit 1; }
+       ACCOUNT_ID=$(jq -r 'if type == "array" then . else .accounts end | map(select(.email == "ci-subscriber@example.org")) | .[0].id' /tmp/api-body) ;;
+  *)   echo "ERROR: account creation returned ${CODE}: $(cat /tmp/api-body)" >&2; exit 1 ;;
+esac
+[ -n "${ACCOUNT_ID}" ] && [ "${ACCOUNT_ID}" != "null" ] || { echo "ERROR: could not determine CI account id" >&2; exit 1; }
+echo "CI subscriber account ${ACCOUNT_ID:0:8}…"
+
+CODE=$(api POST /api/v1/keys "{\"account_id\":\"${ACCOUNT_ID}\",\"component\":\"core\",\"label\":\"ci-integration-test\"}")
+[ "${CODE}" = "201" ] || { echo "ERROR: key creation returned ${CODE}: $(cat /tmp/api-body)" >&2; exit 1; }
+VALID_KEY=$(jq -r '.id' /tmp/api-body)
+[ -n "${VALID_KEY}" ] && [ "${VALID_KEY}" != "null" ] || { echo "ERROR: no key id in response" >&2; exit 1; }
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "VALID_KEY=${VALID_KEY}" >> "${GITHUB_ENV}"
+fi
+echo "Seeded subscription key ${VALID_KEY:0:8}… for component core."

--- a/scripts/ci/verify-env.sh
+++ b/scripts/ci/verify-env.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# verify-env.sh — prove two things about the running CI stack:
+#   1. every PACKYARD_* variable compose.yml forwards reaches the auth
+#      container, and the two that carry values in CI carry the right ones;
+#   2. compose refuses to start without ADMIN_DOMAIN (the `${VAR:?}` guard).
+# Used by `make ci-verify-env`.
+set -euo pipefail
+# shellcheck source=scripts/ci/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+require_cmds docker jq grep
+
+ENV_FILE="${COMPOSE_ENV_FILES:-.env}"
+case "${ENV_FILE}" in *,*) echo "ERROR: COMPOSE_ENV_FILES must name a single file for this check (got '${ENV_FILE}')" >&2; exit 1 ;; esac
+[ -r "${ENV_FILE}" ] || { echo "ERROR: env file not readable: ${ENV_FILE}" >&2; exit 1; }
+env_value() { sed -n "s/^$1=//p" "${ENV_FILE}" | tail -1; }
+
+WANT_ADMIN_DOMAIN=$(env_value ADMIN_DOMAIN)
+WANT_BOOTSTRAP=$(env_value PACKYARD_BOOTSTRAP_OPERATOR_EMAIL)
+[ -n "${WANT_ADMIN_DOMAIN}" ] || { echo "ERROR: ${ENV_FILE} does not set ADMIN_DOMAIN; the guard check would be meaningless" >&2; exit 1; }
+[ -n "${WANT_BOOTSTRAP}" ] || { echo "ERROR: ${ENV_FILE} does not set PACKYARD_BOOTSTRAP_OPERATOR_EMAIL" >&2; exit 1; }
+
+# --- 1. container environment --------------------------------------------
+CIDS=$(docker compose ps -q --status running auth)
+[ "$(printf '%s\n' "${CIDS}" | grep -c .)" = "1" ] || { echo "ERROR: expected exactly one running auth container, got: '${CIDS}'" >&2; exit 1; }
+ENV_DUMP=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "${CIDS}")
+
+for v in PACKYARD_ADMIN_HOST PACKYARD_BOOTSTRAP_OPERATOR_EMAIL PACKYARD_PUBLIC_COMPONENT_CACHE_TTL \
+         PACKYARD_GITHUB_CLIENT_ID PACKYARD_GITHUB_CLIENT_SECRET PACKYARD_GITHUB_REDIRECT_URI PACKYARD_GITHUB_ORG \
+         PACKYARD_MICROSOFT_CLIENT_ID PACKYARD_MICROSOFT_CLIENT_SECRET PACKYARD_MICROSOFT_REDIRECT_URI PACKYARD_MICROSOFT_TENANT_ID; do
+  printf '%s\n' "${ENV_DUMP}" | grep -q "^${v}=" || { echo "ERROR: ${v} is not forwarded into the auth container" >&2; exit 1; }
+done
+got_host=$(printf '%s\n' "${ENV_DUMP}" | sed -n 's/^PACKYARD_ADMIN_HOST=//p')
+got_boot=$(printf '%s\n' "${ENV_DUMP}" | sed -n 's/^PACKYARD_BOOTSTRAP_OPERATOR_EMAIL=//p')
+[ "${got_host}" = "https://${WANT_ADMIN_DOMAIN}" ] || { echo "ERROR: PACKYARD_ADMIN_HOST='${got_host}', want 'https://${WANT_ADMIN_DOMAIN}'" >&2; exit 1; }
+[ "${got_boot}" = "${WANT_BOOTSTRAP}" ] || { echo "ERROR: PACKYARD_BOOTSTRAP_OPERATOR_EMAIL='${got_boot}', want '${WANT_BOOTSTRAP}'" >&2; exit 1; }
+echo "auth container receives all forwarded PACKYARD_* variables; admin host and bootstrap email carry the expected values"
+
+# --- 2. compose guard ----------------------------------------------------
+TMP=$(mktemp); trap 'rm -f "${TMP}" "${TMP}.err"' EXIT
+grep -v '^ADMIN_DOMAIN=' "${ENV_FILE}" > "${TMP}"
+# Unset it in the process environment too: compose prefers the shell over --env-file.
+if env -u ADMIN_DOMAIN docker compose --env-file "${TMP}" config > /dev/null 2> "${TMP}.err"; then
+  echo "ERROR: expected compose to reject a configuration without ADMIN_DOMAIN" >&2; exit 1
+fi
+grep -q 'ADMIN_DOMAIN' "${TMP}.err" || { echo "ERROR: compose failed for another reason:" >&2; cat "${TMP}.err" >&2; exit 1; }
+echo "compose refuses to start without ADMIN_DOMAIN, as intended"

--- a/scripts/ci/wait-for-stack.sh
+++ b/scripts/ci/wait-for-stack.sh
@@ -2,32 +2,46 @@
 # Copyright 2026 Ronny Trommer <ronny@no42.org>
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# wait-for-stack.sh — block until Traefik answers on the public entrypoint and
-# the auth service reports healthy. Used by `make ci-stack-up`.
+# wait-for-stack.sh — block until every long-running compose service is running
+# (and healthy where it declares a healthcheck), Traefik routes the public GPG
+# key (200, so the file provider has loaded its routers) and the auth service
+# is healthy. One-shot services that exited 0 (rustfs-init) are accepted;
+# `docker compose up --wait` would treat them as failures.
+# Used by `make ci-stack-up`.
 #
 #   BASE_URL  public base URL through Traefik   (default http://localhost)
 #   AUTH_URL  auth admin API published to host  (default http://localhost:8080)
 set -euo pipefail
+# shellcheck source=scripts/ci/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+require_cmds curl docker jq
 
 BASE_URL="${BASE_URL:-http://localhost}"
 AUTH_URL="${AUTH_URL:-http://localhost:8080}"
 
-# wait_until SECONDS COMMAND... — poll COMMAND every 2s until it succeeds or the
-# deadline passes. Portable (no GNU timeout, which macOS lacks).
-wait_until() {
-  local deadline=$(( $(date +%s) + $1 )); shift
-  until "$@" > /dev/null 2>&1; do
-    [ "$(date +%s)" -lt "${deadline}" ] || { echo "ERROR: timed out waiting for: $*" >&2; return 1; }
-    sleep 2
-  done
+stack_settled() {
+  # Every container: exited 0 (one-shot) or running and not unhealthy/starting.
+  docker compose ps -a --format json | jq -e -s '
+    map(if type == "array" then .[] else . end)
+    | all(
+        (.State == "exited" and .ExitCode == 0)
+        or (.State == "running" and ((.Health // "") == "" or .Health == "healthy"))
+      )' > /dev/null
 }
 
-traefik_up() { curl -s -o /dev/null -w '%{http_code}' "${BASE_URL}/gpg/lts.asc" | grep -qE '^(200|404)$'; }
+traefik_routes() {
+  # 200 only: a 404 is also what Traefik returns before any router is loaded.
+  [ "$(curl -s --max-time 5 -o /dev/null -w '%{http_code}' "${BASE_URL}/gpg/lts.asc")" = "200" ]
+}
 
-echo "Waiting for Traefik at ${BASE_URL} ..."
-wait_until 60 traefik_up
-echo "Traefik is ready."
+echo "Waiting for all services to be running or cleanly exited ..."
+wait_until 180 stack_settled
+echo "Services settled."
+
+echo "Waiting for Traefik to route ${BASE_URL}/gpg/lts.asc ..."
+wait_until 60 traefik_routes
+echo "Traefik is routing."
 
 echo "Waiting for auth at ${AUTH_URL}/health ..."
-wait_until 90 curl -sf "${AUTH_URL}/health"
+wait_until 90 curl -sf --max-time 5 "${AUTH_URL}/health"
 echo "Auth is healthy."

--- a/scripts/ci/wait-for-stack.sh
+++ b/scripts/ci/wait-for-stack.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# wait-for-stack.sh — block until Traefik answers on the public entrypoint and
+# the auth service reports healthy. Used by `make ci-stack-up`.
+#
+#   BASE_URL  public base URL through Traefik   (default http://localhost)
+#   AUTH_URL  auth admin API published to host  (default http://localhost:8080)
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost}"
+AUTH_URL="${AUTH_URL:-http://localhost:8080}"
+
+# wait_until SECONDS COMMAND... — poll COMMAND every 2s until it succeeds or the
+# deadline passes. Portable (no GNU timeout, which macOS lacks).
+wait_until() {
+  local deadline=$(( $(date +%s) + $1 )); shift
+  until "$@" > /dev/null 2>&1; do
+    [ "$(date +%s)" -lt "${deadline}" ] || { echo "ERROR: timed out waiting for: $*" >&2; return 1; }
+    sleep 2
+  done
+}
+
+traefik_up() { curl -s -o /dev/null -w '%{http_code}' "${BASE_URL}/gpg/lts.asc" | grep -qE '^(200|404)$'; }
+
+echo "Waiting for Traefik at ${BASE_URL} ..."
+wait_until 60 traefik_up
+echo "Traefik is ready."
+
+echo "Waiting for auth at ${AUTH_URL}/health ..."
+wait_until 90 curl -sf "${AUTH_URL}/health"
+echo "Auth is healthy."

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -189,7 +189,7 @@ These tests are integration tests, not unit tests. They require:
 - Format-specific clients (`dnf` for RPM, `apt-get` for DEB, `docker`/`podman` for OCI)
 - Network access to `BASE_URL`
 
-**Recommended CI approach:** Run in a dedicated integration test job that spins up the full stack via `docker compose up -d`, waits for health checks, seeds test data, then runs the e2e scripts.
+**CI approach (`.github/workflows/integration.yml`):** the workflow starts the stack with `make ci-stack-up`, then runs `make ci-seed`. Because the admin API sits behind OAuth, the seed script (`scripts/ci/seed-integration.sh`) inserts one session row for the bootstrap operator into the auth database using the backup image as a one-off `sqlite3` sidecar on the `auth-db` volume, verifies it with `GET /api/v1/auth/whoami`, and then provisions components and a key through the real API with the session cookie and an `Origin` header matching `PACKYARD_ADMIN_HOST`. The suite then runs via `make e2e-observability`. To reproduce locally, export `COMPOSE_PROJECT_NAME`, `COMPOSE_FILE=compose.yml:compose.override.ci.yml`, write a `.env` like the workflow's, and run the same targets.
 
 ---
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -189,7 +189,13 @@ These tests are integration tests, not unit tests. They require:
 - Format-specific clients (`dnf` for RPM, `apt-get` for DEB, `docker`/`podman` for OCI)
 - Network access to `BASE_URL`
 
-**CI approach (`.github/workflows/integration.yml`):** the workflow starts the stack with `make ci-stack-up`, then runs `make ci-seed`. Because the admin API sits behind OAuth, the seed script (`scripts/ci/seed-integration.sh`) inserts one session row for the bootstrap operator into the auth database using the backup image as a one-off `sqlite3` sidecar on the `auth-db` volume, verifies it with `GET /api/v1/auth/whoami`, and then provisions components and a key through the real API with the session cookie and an `Origin` header matching `PACKYARD_ADMIN_HOST`. The suite then runs via `make e2e-observability`. To reproduce locally, export `COMPOSE_PROJECT_NAME`, `COMPOSE_FILE=compose.yml:compose.override.ci.yml`, write a `.env` like the workflow's, and run the same targets.
+**CI approach (`.github/workflows/integration.yml`):** the workflow drives the stack through Makefile targets.
+`make ci-stack-up` starts the CI compose stack and waits for routing and health.
+`make ci-verify-env` proves the forwarded `PACKYARD_*` variables reach the auth container and that compose rejects a missing `ADMIN_DOMAIN`.
+`make ci-seed` gives CI an operator session without OAuth: `scripts/ci/seed-integration.sh` inserts one session row for the bootstrap operator into the auth database (via a one-off `sqlite3` sidecar on the `auth-db` volume), verifies it with `GET /api/v1/auth/whoami`, then provisions components, a per-run subscriber account and a key through the real API with the session cookie and an `Origin` header derived from `ADMIN_DOMAIN`.
+`make e2e-observability` runs this suite with the seeded key.
+To reproduce locally: export `COMPOSE_PROJECT_NAME=packyard-ci` and `COMPOSE_FILE=compose.yml:compose.override.ci.yml` (add `:compose.override.arm64.yml` on Apple silicon), point `COMPOSE_ENV_FILES` at a copy of the workflow's `.env`, and run the same targets.
+The `ci-*` targets refuse to run without those two exports, so they cannot touch a developer's real stack.
 
 ---
 


### PR DESCRIPTION
Closes #190.

**Why it was broken.** Two independent defects. The generated `.env` lacked `PKG_DOMAIN` and `ADMIN_DOMAIN`, so `docker compose up` aborted on the `:?` guards added in v0.3.0. And the seeding steps called `/api/v1/*` with plain `curl`, which has returned 401 since #101 put the admin API behind OAuth sessions. Keys additionally require an `account_id` now.

**How CI acts as an operator.** `scripts/ci/seed-integration.sh` inserts one session row for the `PACKYARD_BOOTSTRAP_OPERATOR_EMAIL` operator directly into the auth SQLite database, using the already-pinned backup image as a one-off `sqlite3` sidecar on the `auth-db` volume (the auth image is distroless). It verifies the session with `GET /api/v1/auth/whoami`, so the real CSRF, session and role middleware are exercised, then provisions components, a CI subscriber account and a key through the API. No product change.

**Makefile targets.** `ci-stack-up`, `ci-verify-env`, `ci-seed`, `e2e-observability`, `ci-stack-logs`, `ci-stack-down`; the workflow calls only these. `ci-verify-env` asserts the `PACKYARD_*` passthrough from #189 reaches the container and that a missing `ADMIN_DOMAIN` is rejected with the guard message.

**Triggers.** Push to `main` for stack-affecting paths, weekly cron, manual dispatch.

**Verified locally** on arm64 with `COMPOSE_ENV_FILES` pointing at a scratch env: stack up, passthrough and guard checks pass, seed runs twice (fresh and 409 paths), `tests/e2e/observability.sh` reports ALL TESTS PASSED, teardown leaves no volumes. A workflow_dispatch run against this branch is linked in a comment below.

**Follow-up noted.** `docs/ops/manual-test-plan.md` still shows unauthenticated `curl` calls to `/api/v1/keys`.