### PR TITLE
ci: build the images under test in the integration stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,13 @@ ci-guard:
 	  echo "refusing: COMPOSE_FILE must include compose.override.ci.yml (got '$${COMPOSE_FILE:-}')"; exit 1 ;; esac
 	@test -n "$${COMPOSE_PROJECT_NAME:-}" || { echo "refusing: COMPOSE_PROJECT_NAME must be set (e.g. packyard-ci)"; exit 1; }
 
-## ci-stack-up: Start the CI compose stack, wait for every service, Traefik routing and auth health
+# Commit under test; stamped into every locally built image as
+# org.opencontainers.image.revision and asserted by ci-verify-env.
+export CI_REVISION ?= $(shell git rev-parse HEAD)
+
+## ci-stack-up: Build the images under test, start the CI compose stack, wait for routing and health
 ci-stack-up: ci-guard
+	docker compose build
 	docker compose up -d
 	bash scripts/ci/wait-for-stack.sh
 

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-ARG SQLITE_VERSION=3.48.0-r4
+ARG SQLITE_VERSION=3.53.4-r0
 
 RUN apk add --no-cache sqlite=${SQLITE_VERSION}
 

--- a/compose.override.ci.yml
+++ b/compose.override.ci.yml
@@ -1,7 +1,10 @@
 # compose.override.ci.yml — CI-only overrides (Option A)
 #
-# Swaps Traefik to plaintext HTTP (no TLS/ACME) and publishes auth ports
-# to the host so the CI workflow can seed keys and read metrics.
+# Swaps Traefik to plaintext HTTP (no TLS/ACME), publishes auth ports to the
+# host so the CI workflow can seed keys and read metrics, and builds every
+# image this repository publishes from the working tree instead of pulling the
+# published tag, so the suite exercises the commit under test. Each built image
+# is labelled with the commit (CI_REVISION) and `make ci-verify-env` asserts it.
 #
 # Usage:
 #   docker compose -f compose.yml -f compose.override.ci.yml up -d
@@ -20,6 +23,40 @@ services:
       - ./traefik/dynamic-ci:/etc/traefik/dynamic-ci:ro
 
   auth:
+    build:
+      context: ./auth
+      labels:
+        org.opencontainers.image.revision: ${CI_REVISION:?CI_REVISION must be set (git rev-parse HEAD)}
+    pull_policy: build
     ports:
       - "127.0.0.1:8080:8080"   # admin API — key seeding from CI runner
       - "127.0.0.1:9090:9090"   # Prometheus metrics — observability.sh AC1
+
+  rpm:
+    build:
+      context: ./rpm
+      labels:
+        org.opencontainers.image.revision: ${CI_REVISION:?CI_REVISION must be set (git rev-parse HEAD)}
+    pull_policy: build
+
+  static:
+    build:
+      context: ./static
+      labels:
+        org.opencontainers.image.revision: ${CI_REVISION:?CI_REVISION must be set (git rev-parse HEAD)}
+    pull_policy: build
+
+  backup:
+    build:
+      context: .
+      dockerfile: backup/Dockerfile
+      labels:
+        org.opencontainers.image.revision: ${CI_REVISION:?CI_REVISION must be set (git rev-parse HEAD)}
+    pull_policy: build
+
+  aptly:
+    build:
+      context: ./aptly
+      labels:
+        org.opencontainers.image.revision: ${CI_REVISION:?CI_REVISION must be set (git rev-parse HEAD)}
+    pull_policy: build

--- a/compose.yml
+++ b/compose.yml
@@ -204,7 +204,7 @@ services:
       - backend
 
   backup:
-    image: ghcr.io/no42-org/packyard-backup:3.48.0
+    image: ghcr.io/no42-org/packyard-backup:3.53.4
     restart: unless-stopped
     depends_on:
       auth:

--- a/scripts/ci/verify-env.sh
+++ b/scripts/ci/verify-env.sh
@@ -2,10 +2,13 @@
 # Copyright 2026 Ronny Trommer <ronny@no42.org>
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# verify-env.sh — prove two things about the running CI stack:
+# verify-env.sh — prove three things about the running CI stack:
 #   1. every PACKYARD_* variable compose.yml forwards reaches the auth
 #      container, and the two that carry values in CI carry the right ones;
-#   2. compose refuses to start without ADMIN_DOMAIN (the `${VAR:?}` guard).
+#   2. compose refuses to start without ADMIN_DOMAIN (the `${VAR:?}` guard);
+#   3. every service this repository builds is running an image built from
+#      the commit under test (org.opencontainers.image.revision == CI_REVISION),
+#      not a pulled published tag.
 # Used by `make ci-verify-env`.
 set -euo pipefail
 # shellcheck source=scripts/ci/lib.sh
@@ -47,3 +50,13 @@ if env -u ADMIN_DOMAIN docker compose --env-file "${TMP}" config > /dev/null 2> 
 fi
 grep -q 'ADMIN_DOMAIN' "${TMP}.err" || { echo "ERROR: compose failed for another reason:" >&2; cat "${TMP}.err" >&2; exit 1; }
 echo "compose refuses to start without ADMIN_DOMAIN, as intended"
+
+# --- 3. images under test ------------------------------------------------
+: "${CI_REVISION:?CI_REVISION is required (the commit the images were built from)}"
+for svc in auth rpm static backup aptly; do
+  cid=$(docker compose ps -q --status running "${svc}")
+  [ "$(printf '%s\n' "${cid}" | grep -c .)" = "1" ] || { echo "ERROR: expected exactly one running ${svc} container, got: '${cid}'" >&2; exit 1; }
+  rev=$(docker inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "${cid}")
+  [ "${rev}" = "${CI_REVISION}" ] || { echo "ERROR: ${svc} runs an image with revision '${rev}', want '${CI_REVISION}' (was it pulled instead of built?)" >&2; exit 1; }
+done
+echo "auth, rpm, static, backup and aptly run images built from ${CI_REVISION:0:12}"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -190,8 +190,9 @@ These tests are integration tests, not unit tests. They require:
 - Network access to `BASE_URL`
 
 **CI approach (`.github/workflows/integration.yml`):** the workflow drives the stack through Makefile targets.
-`make ci-stack-up` starts the CI compose stack and waits for routing and health.
+`make ci-stack-up` builds auth, rpm, static, backup and aptly from the working tree (labelled with the commit via `CI_REVISION`), starts the CI compose stack and waits for routing and health.
 `make ci-verify-env` proves the forwarded `PACKYARD_*` variables reach the auth container and that compose rejects a missing `ADMIN_DOMAIN`.
+It also asserts every built service runs an image carrying the current revision label, so a pulled image cannot pass silently.
 `make ci-seed` gives CI an operator session without OAuth: `scripts/ci/seed-integration.sh` inserts one session row for the bootstrap operator into the auth database (via a one-off `sqlite3` sidecar on the `auth-db` volume), verifies it with `GET /api/v1/auth/whoami`, then provisions components, a per-run subscriber account and a key through the real API with the session cookie and an `Origin` header derived from `ADMIN_DOMAIN`.
 `make e2e-observability` runs this suite with the seeded key.
 To reproduce locally: export `COMPOSE_PROJECT_NAME=packyard-ci` and `COMPOSE_FILE=compose.yml:compose.override.ci.yml` (add `:compose.override.arm64.yml` on Apple silicon), point `COMPOSE_ENV_FILES` at a copy of the workflow's `.env`, and run the same targets.


### PR DESCRIPTION
Closes #193. Deferred from the review of #191, where all three review layers noted the suite ran the published `0.3.1-rc` images rather than the pushed source.

**What changes.** `compose.override.ci.yml` declares `build:` for auth, rpm, static, backup and aptly with the same contexts and Dockerfiles the `build-*.yml` publish workflows use, plus `pull_policy: build`. Each image is labelled `org.opencontainers.image.revision=${CI_REVISION}`; the Makefile exports `CI_REVISION` as `git rev-parse HEAD` and `make ci-stack-up` builds before starting. `scripts/ci/verify-env.sh` asserts every built service runs a container carrying the current revision, so a silent fall-back to a pulled image fails the run.

**A pre-existing breakage fixed along the way.** `backup/Dockerfile` pinned `sqlite=3.48.0-r4`, which Alpine 3.24 no longer ships (only `3.53.4-r0`). `build-backup.yml` has failed on every run since 2026-04-13, so the published backup image has been frozen at its April build. The pin is bumped in its own commit; because the publish workflow derives the tag from the ARG, `compose.yml` now references `packyard-backup:3.53.4`, which `build-backup.yml` publishes when this merges. Anyone deploying `main` before that publish completes would need the build to have finished first; the workflow runs on the merge push.

**Verified locally** (arm64, warm cache): all five images build, stack up, `verify-env` passes including the revision check, seed and `ALL TESTS PASSED`, teardown clean; 42 seconds total. `CI_REVISION=deadbeef make ci-verify-env` fails naming the mismatching service. The pull_request Integration run on this PR is the cold-cache measurement.