### PR TITLE
fix(backup): bump sqlite to the version Alpine 3.24 ships

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-ARG SQLITE_VERSION=3.48.0-r4
+ARG SQLITE_VERSION=3.53.4-r0
 
 RUN apk add --no-cache sqlite=${SQLITE_VERSION}
 


### PR DESCRIPTION
Split out of #194 per review, so the publish happens before the reference.

`backup/Dockerfile` pinned `sqlite=3.48.0-r4`, which Alpine 3.24 no longer ships (only `3.53.4-r0`). `build-backup.yml` has failed on every run since 2026-04-13; the published image is frozen at its April build. This bumps only the pin. When it merges, `build-backup.yml` publishes `packyard-backup:3.53.4`; `compose.yml` keeps pointing at `3.48.0` until #194 lands.

**Merge order:** this PR first, wait for the `Build and publish backup image` run on main to succeed, then #194.

Part of #193.