### PR TITLE
ci: harden the build-under-test configuration from code review

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# The only image built with the repository root as context is backup/
+# (compose.override.ci.yml and build-backup.yml). Allow-list what it needs so
+# .git, node_modules, .env files and CI artefacts never reach the daemon.
+*
+!backup/
+!scripts/backup-keystore.sh

--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,17 @@ ci-guard:
 	@case "$${COMPOSE_FILE:-}" in *compose.override.ci.yml*) ;; *) \
 	  echo "refusing: COMPOSE_FILE must include compose.override.ci.yml (got '$${COMPOSE_FILE:-}')"; exit 1 ;; esac
 	@test -n "$${COMPOSE_PROJECT_NAME:-}" || { echo "refusing: COMPOSE_PROJECT_NAME must be set (e.g. packyard-ci)"; exit 1; }
+	@test -n "$${CI_REVISION:-}" || { echo "refusing: CI_REVISION is empty (not a git checkout?); export CI_REVISION=<commit> to build under test"; exit 1; }
 
 # Commit under test; stamped into every locally built image as
-# org.opencontainers.image.revision and asserted by ci-verify-env.
-export CI_REVISION ?= $(shell git rev-parse HEAD)
+# org.opencontainers.image.revision and asserted by ci-verify-env. Evaluated
+# once. Suffixed -dirty when tracked files have uncommitted changes, so the
+# label never claims a commit the image was not built from. Empty outside a
+# git checkout; ci-guard then refuses with a clear message.
+ifeq ($(origin CI_REVISION), undefined)
+CI_REVISION := $(shell r=$$(git rev-parse HEAD 2>/dev/null) && { git diff --quiet HEAD -- 2>/dev/null && printf '%s' "$$r" || printf '%s-dirty' "$$r"; })
+endif
+export CI_REVISION
 
 ## ci-stack-up: Build the images under test, start the CI compose stack, wait for routing and health
 ci-stack-up: ci-guard
@@ -134,9 +141,11 @@ ci-stack-up: ci-guard
 	docker compose up -d
 	bash scripts/ci/wait-for-stack.sh
 
-## ci-stack-down: Stop the CI compose stack and remove its volumes
+## ci-stack-down: Stop the CI compose stack, remove its volumes and the locally built images
 ci-stack-down: ci-guard
 	docker compose down -v
+	@docker compose config --format json | jq -r '.services[] | select(.build) | .image' \
+	  | xargs -r docker image rm -f > /dev/null 2>&1 || true
 	rm -f .ci-valid-key
 
 ## ci-stack-logs: Dump all CI stack service logs (used on failure)

--- a/compose.override.ci.yml
+++ b/compose.override.ci.yml
@@ -3,8 +3,11 @@
 # Swaps Traefik to plaintext HTTP (no TLS/ACME), publishes auth ports to the
 # host so the CI workflow can seed keys and read metrics, and builds every
 # image this repository publishes from the working tree instead of pulling the
-# published tag, so the suite exercises the commit under test. Each built image
-# is labelled with the commit (CI_REVISION) and `make ci-verify-env` asserts it.
+# published tag, so the suite exercises the working tree at the commit under
+# test. Each built image is labelled with the commit (CI_REVISION, suffixed
+# `-dirty` when the tree has uncommitted changes) and `make ci-verify-env`
+# asserts it. `make ci-stack-up` runs an explicit build; there is deliberately
+# no `pull_policy: build`, which would rebuild on every `up`.
 #
 # Usage:
 #   docker compose -f compose.yml -f compose.override.ci.yml up -d
@@ -12,6 +15,12 @@
 # The base compose.yml port mapping for Traefik (443) is merged in by
 # Compose but harmless — Traefik only listens on the entryPoints defined in
 # traefik.ci.yml (web:80 and admin:8088).
+
+# Every image built here is stamped with the commit under test. The value is
+# enforced non-empty by `make ci-guard` rather than by a `${VAR:?}` guard, so
+# read-only compose commands (down, logs, ps) keep working when it is unset.
+x-ci-image-labels: &ci-image-labels
+  org.opencontainers.image.revision: ${CI_REVISION:-}
 
 services:
 
@@ -25,9 +34,7 @@ services:
   auth:
     build:
       context: ./auth
-      labels:
-        org.opencontainers.image.revision: ${CI_REVISION:?CI_REVISION must be set (git rev-parse HEAD)}
-    pull_policy: build
+      labels: *ci-image-labels
     ports:
       - "127.0.0.1:8080:8080"   # admin API — key seeding from CI runner
       - "127.0.0.1:9090:9090"   # Prometheus metrics — observability.sh AC1
@@ -35,28 +42,20 @@ services:
   rpm:
     build:
       context: ./rpm
-      labels:
-        org.opencontainers.image.revision: ${CI_REVISION:?CI_REVISION must be set (git rev-parse HEAD)}
-    pull_policy: build
+      labels: *ci-image-labels
 
   static:
     build:
       context: ./static
-      labels:
-        org.opencontainers.image.revision: ${CI_REVISION:?CI_REVISION must be set (git rev-parse HEAD)}
-    pull_policy: build
+      labels: *ci-image-labels
 
   backup:
     build:
       context: .
       dockerfile: backup/Dockerfile
-      labels:
-        org.opencontainers.image.revision: ${CI_REVISION:?CI_REVISION must be set (git rev-parse HEAD)}
-    pull_policy: build
+      labels: *ci-image-labels
 
   aptly:
     build:
       context: ./aptly
-      labels:
-        org.opencontainers.image.revision: ${CI_REVISION:?CI_REVISION must be set (git rev-parse HEAD)}
-    pull_policy: build
+      labels: *ci-image-labels

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -125,7 +125,7 @@ investigation.
 | `aptly` | `ghcr.io/no42-org/packyard-aptly:1.6.2` | DEB repo management and signing (multi-arch: amd64 + arm64) |
 | `rustfs` | `rustfs/rustfs:latest` | S3-compatible staging storage for promotion pipeline |
 | `static` | `nginx:alpine` | Public GPG/cosign key hosting |
-| `backup` | `ghcr.io/no42-org/packyard-backup:3.48.0` | Daily SQLite backup of the key store |
+| `backup` | `ghcr.io/no42-org/packyard-backup:3.53.4` | Daily SQLite backup of the key store |
 
 The auth service binary embeds the React + TypeScript SPA via `go:embed`,
 so the admin UI ships in the same single artifact as the admin API and the

--- a/scripts/ci/verify-env.sh
+++ b/scripts/ci/verify-env.sh
@@ -6,9 +6,10 @@
 #   1. every PACKYARD_* variable compose.yml forwards reaches the auth
 #      container, and the two that carry values in CI carry the right ones;
 #   2. compose refuses to start without ADMIN_DOMAIN (the `${VAR:?}` guard);
-#   3. every service this repository builds is running an image built from
-#      the commit under test (org.opencontainers.image.revision == CI_REVISION),
-#      not a pulled published tag.
+#   3. every service with a build: entry is running an image built from the
+#      commit under test (org.opencontainers.image.revision == CI_REVISION);
+#   4. the backup and aptly image tags in compose.yml match the Dockerfile ARGs
+#      the publish workflows derive them from.
 # Used by `make ci-verify-env`.
 set -euo pipefail
 # shellcheck source=scripts/ci/lib.sh
@@ -53,10 +54,28 @@ echo "compose refuses to start without ADMIN_DOMAIN, as intended"
 
 # --- 3. images under test ------------------------------------------------
 : "${CI_REVISION:?CI_REVISION is required (the commit the images were built from)}"
-for svc in auth rpm static backup aptly; do
-  cid=$(docker compose ps -q --status running "${svc}")
+# Derive the list from compose config so a new build: entry is asserted
+# automatically instead of silently escaping the check.
+BUILT_SERVICES=$(docker compose config --format json | jq -r '.services | to_entries[] | select(.value.build) | .key' | sort)
+[ -n "${BUILT_SERVICES}" ] || { echo "ERROR: no services with a build: entry in the compose configuration" >&2; exit 1; }
+for svc in ${BUILT_SERVICES}; do
+  cid=$(docker compose ps -q --status running "${svc}" 2>/dev/null) || cid=""
   [ "$(printf '%s\n' "${cid}" | grep -c .)" = "1" ] || { echo "ERROR: expected exactly one running ${svc} container, got: '${cid}'" >&2; exit 1; }
   rev=$(docker inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "${cid}")
-  [ "${rev}" = "${CI_REVISION}" ] || { echo "ERROR: ${svc} runs an image with revision '${rev}', want '${CI_REVISION}' (was it pulled instead of built?)" >&2; exit 1; }
+  case "${rev}" in
+    ""|"<no value>") echo "ERROR: ${svc} runs an image with no org.opencontainers.image.revision label (pulled, not built here)" >&2; exit 1 ;;
+  esac
+  [ "${rev}" = "${CI_REVISION}" ] || { echo "ERROR: ${svc} runs an image with revision '${rev}', want '${CI_REVISION}'" >&2; exit 1; }
 done
-echo "auth, rpm, static, backup and aptly run images built from ${CI_REVISION:0:12}"
+# shellcheck disable=SC2086  # word-splitting the service list is intended
+echo "$(printf '%s, ' ${BUILT_SERVICES} | sed 's/, $//') run images built from ${CI_REVISION:0:12}${CI_REVISION#"${CI_REVISION%-dirty}"}"
+
+# --- 4. published tags stay in sync with the Dockerfile ARGs -------------
+# build-backup.yml and build-aptly.yml derive the published tag from these
+# ARGs; compose.yml carries the tag by hand. Catch drift here.
+compose_tag() { docker compose config --format json | jq -r --arg s "$1" '.services[$s].image | split(":")[1]'; }
+sqlite_ver=$(sed -n 's/^ARG SQLITE_VERSION=//p' backup/Dockerfile); sqlite_ver="${sqlite_ver%-r*}"
+aptly_ver=$(sed -n 's/^ARG APTLY_VERSION=//p' aptly/Dockerfile)
+[ "$(compose_tag backup)" = "${sqlite_ver}" ] || { echo "ERROR: compose backup tag '$(compose_tag backup)' != Dockerfile SQLITE_VERSION '${sqlite_ver}'" >&2; exit 1; }
+[ "$(compose_tag aptly)" = "${aptly_ver}" ] || { echo "ERROR: compose aptly tag '$(compose_tag aptly)' != Dockerfile APTLY_VERSION '${aptly_ver}'" >&2; exit 1; }
+echo "backup and aptly compose tags match their Dockerfile ARGs (${sqlite_ver}, ${aptly_ver})"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -192,11 +192,12 @@ These tests are integration tests, not unit tests. They require:
 **CI approach (`.github/workflows/integration.yml`):** the workflow drives the stack through Makefile targets.
 `make ci-stack-up` builds auth, rpm, static, backup and aptly from the working tree (labelled with the commit via `CI_REVISION`), starts the CI compose stack and waits for routing and health.
 `make ci-verify-env` proves the forwarded `PACKYARD_*` variables reach the auth container and that compose rejects a missing `ADMIN_DOMAIN`.
-It also asserts every built service runs an image carrying the current revision label, so a pulled image cannot pass silently.
+It also asserts every built service runs an image whose revision label is the commit under test (`-dirty` if the tree had uncommitted changes), so a stale or pulled image does not pass unnoticed, and that the backup and aptly tags in `compose.yml` match their Dockerfile ARGs.
 `make ci-seed` gives CI an operator session without OAuth: `scripts/ci/seed-integration.sh` inserts one session row for the bootstrap operator into the auth database (via a one-off `sqlite3` sidecar on the `auth-db` volume), verifies it with `GET /api/v1/auth/whoami`, then provisions components, a per-run subscriber account and a key through the real API with the session cookie and an `Origin` header derived from `ADMIN_DOMAIN`.
 `make e2e-observability` runs this suite with the seeded key.
 To reproduce locally: export `COMPOSE_PROJECT_NAME=packyard-ci` and `COMPOSE_FILE=compose.yml:compose.override.ci.yml` (add `:compose.override.arm64.yml` on Apple silicon), point `COMPOSE_ENV_FILES` at a copy of the workflow's `.env`, and run the same targets.
 The `ci-*` targets refuse to run without those two exports, so they cannot touch a developer's real stack.
+Built images are tagged with the names from `compose.yml`, so on a shared daemon a CI run temporarily replaces the published tags; `make ci-stack-down` removes them again.
 
 ---
 


### PR DESCRIPTION
Follow-up to #194, which was merged before the review fixes were pushed. This PR carries exactly those fixes (cherry-picked from the closed branch). Part of #193.

**Fixed.** The `CI_REVISION` guard moves out of the compose file (`${CI_REVISION:-}` behind a YAML anchor) into `make ci-guard`, so `down`/`logs`/`ps` work when the variable is unset. `CI_REVISION` is computed once, carries `-dirty` when the tree has uncommitted changes, and is refused when empty (not a git checkout). `pull_policy: build` is dropped; images were being built twice per run. `verify-env.sh` derives the asserted services from compose config, reports a missing revision label explicitly, and asserts the backup and aptly tags in `compose.yml` match their Dockerfile ARGs. `ci-stack-down` removes the locally built images so a shared daemon does not keep CI builds under the published tag names. A root `.dockerignore` allow-lists what the backup context needs. `architecture.md` gets the current backup tag; README wording states what the label proves.

**Verified locally** against a real stack: build, verify-env (including the `-dirty` label and the tag/ARG check), seed, `ALL TESTS PASSED`, negative revision case fails naming the service, teardown removes the five built images and leaves no volumes.