### PR TITLE
ci(release): create dist before the SBOM step and move latest last

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,10 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.IMAGE }}
-          # latest=auto moves `latest` only for stable semver tags, so
-          # v1.2.0-rc1 publishes 1.2.0-rc1 without touching latest.
-          flavor: latest=auto
+          # `latest` is NOT written here. It moves in the release job, after
+          # every image, SBOM and the draft release exist, so a failure later
+          # in the pipeline cannot leave `latest` pointing at an unreleased build.
+          flavor: latest=false
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -100,7 +101,9 @@ jobs:
           push-to-registry: true
 
       - name: SBOM
-        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26  # v0.24.2
+        # sbom-action does not create the output directory.
+        run: mkdir -p dist
+      - uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26  # v0.24.2
         with:
           image: ${{ env.IMAGE }}@${{ steps.push.outputs.digest }}
           format: spdx-json
@@ -122,6 +125,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write   # create release + upload assets
+      packages: write   # move `latest` to the released images
       id-token: write   # cosign sign-blob
       attestations: write
       actions: write    # dispatch the docs rebuild
@@ -161,6 +165,30 @@ jobs:
             gh release create "$GITHUB_REF_NAME" --draft --verify-tag \
               --title "$GITHUB_REF_NAME" --notes "Release notes pending." $PRE
           find dist -type f -exec gh release upload "$GITHUB_REF_NAME" --clobber {} +
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Move `latest` to the released images (stable tags only)
+        # Runs last so `latest` only ever points at a version whose images,
+        # signatures, SBOMs and draft release all exist. Prereleases never
+        # move it. Retagging the manifest list keeps the digests, so the
+        # cosign signatures and provenance published above still apply.
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          case "$GITHUB_REF_NAME" in *-*) echo "prerelease: latest unchanged"; exit 0 ;; esac
+          ver="${GITHUB_REF_NAME#v}"
+          for svc in auth rpm static; do
+            docker buildx imagetools create \
+              -t "ghcr.io/${OWNER}/packyard-${svc}:latest" \
+              "ghcr.io/${OWNER}/packyard-${svc}:${ver}"
+            echo "latest -> packyard-${svc}:${ver}"
+          done
 
       - name: Rebuild docs so the landing page shows the new version
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,7 +33,9 @@ Pushing the tag triggers the `Release` workflow (`.github/workflows/release.yml`
 2. Builds and pushes the three images for `linux/amd64` and `linux/arm64`.
 3. Signs each image with cosign keyless and attaches SLSA build provenance to the registry.
 4. Generates an SPDX SBOM per image.
-5. Creates a **draft** GitHub Release with the SBOMs, a `checksums.txt` and its cosign signature attached, and dispatches `docs.yml` so the landing page shows the new version.
+5. Creates a **draft** GitHub Release with the SBOMs, a `checksums.txt` and its cosign signature attached.
+6. Only then moves `latest` to the released images and dispatches `docs.yml` so the landing page shows the new version.
+   `latest` is written last on purpose: a failure anywhere earlier leaves `latest` on the previous release rather than on a half-published build.
 
 | Image | Tags written for `v1.2.3` |
 |-------|---------------------------|


### PR DESCRIPTION
Fixes the two defects the first live run of `release.yml` (tag v0.3.1, run 33996824742) exposed.

**Missing directory.** `anchore/sbom-action` writes `dist/…` but nothing created `dist/`; all three image jobs failed at the SBOM step with ENOENT. Fixed with `mkdir -p dist` before the step.

**`latest` moved too early.** The image jobs pushed `X.Y.Z`, `X.Y` and `latest` before the SBOM step, so the failed run left `latest` on all three images pointing at a build that never became a release and whose binary reports `0.3.1-rc`. The image jobs now publish only `X.Y.Z` and `X.Y` (`flavor: latest=false`); the final release job retags the manifest lists to `latest` after the SBOMs and the draft release exist, stable tags only. Retagging keeps the digests, so the cosign signatures and provenance already attached still apply. RELEASING.md documents the order.

The stray `v0.3.1` git tag has been deleted; the stray `0.3.1`/`0.3` GHCR versions will be pruned after the next release has moved `latest`.