### PR TITLE
ci(release): sign the checksums file as a Sigstore bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,9 @@ jobs:
           cd dist
           find . -type f | sort | xargs sha256sum > ../checksums.txt
           mv ../checksums.txt checksums.txt
-          cosign sign-blob --yes --output-signature checksums.txt.sig \
-            --output-certificate checksums.txt.pem checksums.txt
+          # cosign v3 writes a Sigstore bundle (signature, certificate and
+          # transparency-log entry in one file) and requires --bundle.
+          cosign sign-blob --yes --bundle checksums.txt.sigstore.json checksums.txt
 
       - name: Attest build provenance (release assets)
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,7 +33,7 @@ Pushing the tag triggers the `Release` workflow (`.github/workflows/release.yml`
 2. Builds and pushes the three images for `linux/amd64` and `linux/arm64`.
 3. Signs each image with cosign keyless and attaches SLSA build provenance to the registry.
 4. Generates an SPDX SBOM per image.
-5. Creates a **draft** GitHub Release with the SBOMs, a `checksums.txt` and its cosign signature attached.
+5. Creates a **draft** GitHub Release with the SBOMs, a `checksums.txt` and its Sigstore bundle (`checksums.txt.sigstore.json`) attached.
 6. Only then moves `latest` to the released images and dispatches `docs.yml` so the landing page shows the new version.
    `latest` is written last on purpose: a failure anywhere earlier leaves `latest` on the previous release rather than on a half-published build.
 
@@ -110,7 +110,7 @@ Verify the release checksums file:
 
 ```bash
 cosign verify-blob checksums.txt \
-  --signature checksums.txt.sig --certificate checksums.txt.pem \
+  --bundle checksums.txt.sigstore.json \
   --certificate-identity-regexp 'https://github.com/no42-org/packyard/\.github/workflows/release\.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 sha256sum -c checksums.txt


### PR DESCRIPTION
The v0.4.0 release run (34106240385) got past the SBOM fix from #197: all three images built, pushed as `0.4.0`/`0.4` and signed, SBOM artifacts uploaded, and `latest` correctly did not move. The release job then failed at the checksums signature: cosign v3 requires `--bundle` for `sign-blob` and errors with "create bundle file: open : no such file or directory" when only the legacy `--output-signature`/`--output-certificate` flags are given.

This emits `checksums.txt.sigstore.json` and documents `cosign verify-blob --bundle` in RELEASING.md. After merge the `v0.4.0` tag is re-created on the merge commit so the tag-triggered run uses the fixed workflow.