### PR TITLE
docs: drop redundant Getting Started sidebar category

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -3,16 +3,9 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 // Three independent sidebars, one per top-level section. The navbar items in
 // docusaurus.config.ts select which sidebar to render via `sidebarId`.
 const sidebars: SidebarsConfig = {
-  gettingStarted: [
-    {
-      type: 'category',
-      label: 'Getting Started',
-      collapsed: false,
-      items: [
-        'getting-started/quick-start',
-      ],
-    },
-  ],
+  // Single page, so no category wrapper: the navbar item already carries the
+  // "Getting Started" label and a category would repeat it in the mobile menu.
+  gettingStarted: ['getting-started/quick-start'],
 
   operations: [
     {


### PR DESCRIPTION
## Summary
The getting-started sidebar wrapped its single page in a category also labelled "Getting Started". The navbar item already carries that label, so the mobile menu showed "Getting Started" twice, stacked. The sidebar now lists the bare page id.

Closes #202

## Verification
`make docs-build` passes. The built quick-start page contains no collapsible category and a single sidebar link.

## Not included
Operations and Reference follow the same wrapper pattern and repeat their navbar label in the mobile menu. Left as is because flattening them removes the desktop sidebar heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)