### PR TITLE
chore: maintainer audit fixes

### DIFF
--- a/.github/workflows/build-aptly.yml
+++ b/.github/workflows/build-aptly.yml
@@ -1,5 +1,8 @@
 name: Build and publish aptly image
 
+# The image is versioned by the upstream tool it wraps, not by Packyard, so
+# it carries only that version tag. `latest` is reserved for release.yml.
+
 on:
   push:
     branches: [main]
@@ -62,6 +65,5 @@ jobs:
             APTLY_VERSION=${{ steps.version.outputs.aptly_version }}
           tags: |
             ${{ env.IMAGE }}:${{ steps.version.outputs.aptly_version }}
-            ${{ env.IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-backup.yml
+++ b/.github/workflows/build-backup.yml
@@ -1,5 +1,8 @@
 name: Build and publish backup image
 
+# The image is versioned by the upstream tool it wraps, not by Packyard, so
+# it carries only that version tag. `latest` is reserved for release.yml.
+
 on:
   push:
     branches: [main]
@@ -62,6 +65,5 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE }}:${{ steps.version.outputs.backup_version }}
-            ${{ env.IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,119 +1,49 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code when working in this repository.
 
-## Project Overview
+## What this is
 
-**Packyard** is a BMad (Build Method Architecture by Design) framework installation — a multi-module AI agent methodology system for structured product development. It is not a compiled project; there are no build, lint, or test commands. All content is Markdown-based workflow definitions, agent personas, and YAML configuration.
+Packyard is a self-hosted, authenticated distribution platform for LTS releases. Traefik terminates TLS and calls the Go `auth` service as forwardAuth for every request. Authenticated subscribers reach RPM (nginx), DEB (nginx in front of Aptly) and OCI (Zot) repositories. Artifacts are promoted from CI into RustFS object storage and signed. The auth service keeps accounts, keys, components, operators and an audit log in SQLite and embeds a React admin UI.
 
-- **BMad version:** 6.2.2
-- **User:** Indigo (intermediate skill level)
-- **Configured IDEs:** Claude Code, Codex
+## Commands
 
-## Module Structure
+Always go through `make`. CI runs the same targets, so they must stay in sync.
 
-The framework lives under `_bmad/` and is organized into six modules:
-
-| Module | Path | Purpose |
-|--------|------|---------|
-| core | `_bmad/core/` | Shared utilities: brainstorming, document review, party-mode, distillation |
-| bmm | `_bmad/bmm/` | Business Method Module — 4-phase product lifecycle (analysis → plan → solution → implement) |
-| bmb | `_bmad/bmb/` | Builder Module — create/edit custom agents and workflow skills |
-| cis | `_bmad/cis/` | Creative Intelligence Suite — storytelling, innovation, design thinking |
-| tea | `_bmad/tea/` | Test Architecture Enterprise — full test lifecycle (ATDD, CI/CD, NFR, coverage) |
-| wds | `_bmad/wds/` | Workflow Design System — UX/product design pipeline (wds-0 through wds-8) |
-
-## Output Locations
-
-- Planning artifacts (briefs, PRDs, specs): `_bmad-output/planning-artifacts/`
-- Implementation artifacts (code, design systems): `_bmad-output/implementation-artifacts/`
-- Test artifacts (plans, automation): `_bmad-output/test-artifacts/`
-- Design workflow outputs (visual/UX): `design-artifacts/A-G/`
-- Project knowledge docs: `docs/`
-
-## Agent Roster
-
-18 named agents, each with a distinct role. Invoke by name or skill ID:
-
-- **Mary** (`bmad-agent-analyst`) — business analysis & requirements
-- **John** (`bmad-agent-pm`) — product management & PRD creation
-- **Sally** (`bmad-agent-ux-designer`) — UX/UI design
-- **Winston** (`bmad-agent-architect`) — systems architecture
-- **Amelia** (`bmad-agent-dev`) — developer / story implementation
-- **Quinn** (`bmad-agent-qa`) — QA & test automation
-- **Barry** (`bmad-agent-quick-flow-solo-dev`) — rapid full-stack development
-- **Bob** (`bmad-agent-sm`) — scrum master & sprint ceremonies
-- **Paige** (`bmad-agent-tech-writer`) — technical documentation
-- **Murat** (`bmad-tea`) — master test architect (TEA module)
-- **Freya** (`wds-agent-freya-ux`) — WDS UX designer
-- **Saga** (`wds-agent-saga-analyst`) — WDS business analyst
-- **Carson / Dr. Quinn / Maya / Victor / Caravaggio / Sophia** — CIS creative agents
-
-## Workflow Execution Pattern
-
-TEA and many BMM workflows use a **step-file architecture**: strict sequential step files prevent AI improvisation. When executing a workflow, follow the numbered steps in order without skipping. Each skill directory contains a `SKILL.md` defining the entry point, modes (Create / Edit / Validate), and execution rules.
-
-## Documentation
-
-All user-facing documentation lives in `docs/` and is published via Docusaurus to https://no42-org.github.io/packyard/. The landing page (`/`) is a custom React route at `src/pages/index.tsx`. The GitHub Wiki is retired and must not be used.
-
-Structure:
-
-| Path | Section |
+| Task | Command |
 |------|---------|
-| `src/pages/index.tsx` | Landing page (custom React hero + Terminal) |
-| `docs/getting-started/` | Quick-start and local development guides |
-| `docs/ops/` | Operational runbooks (production deployment, restore procedures) |
-| `docs/reference/` | Architecture, API, configuration, subscriber usage, promotion pipeline, observability |
+| Build the auth binary with the embedded admin UI | `make build` |
+| Run the auth unit tests | `make test` |
+| Run one test | `cd auth && go test ./internal/handler -run TestName` |
+| gofmt check and go vet | `make lint` |
+| Lint workflow files | `make lint-workflows` |
+| Build the docs site (fails on broken links) | `make docs-build` |
+| Serve docs with live reload | `make docs-serve` |
+| Bring up the CI compose stack locally | `make ci-stack-up` |
 
-When adding or updating documentation:
-- Edit the relevant file under `docs/` — do not create Wiki pages
-- New pages must be added to the appropriate sidebar in `sidebars.ts`
-- Run `make docs-serve` locally to preview before committing (requires Node 20 via `.nvmrc`)
-- Docs are published automatically on each push to `main` via `docs.yml`. The Release workflow dispatches `docs.yml` after publishing images so the landing-page version eyebrow picks up new tags
+`make help` lists everything. Docs need Node 20 via `.nvmrc`.
 
-## Docker Compose
+## Layout
 
-Always use `compose.yml` as the filename, not `docker-compose.yml`. Docker Compose v2 searches for `compose.yml` first — it is the current convention.
+- `auth/` is the Go module. `cmd/server` is the entry point. `internal/` holds `handler`, `middleware`, `store` (SQLite), `audit`, `metrics`, `logsafe` and `adminui`. The React SPA source lives in `internal/admin-ui` and builds into the Go embed directory.
+- `rpm/`, `static/`, `aptly/`, `backup/` each hold one Dockerfile. `auth`, `rpm` and `static` are released by tag; `aptly` and `backup` are versioned by the upstream tool they wrap.
+- `docs/` is the Docusaurus site published to https://no42-org.github.io/packyard/. New pages must be added to `sidebars.ts`. The GitHub Wiki is retired.
+- `scripts/ci/` holds the compose stack helpers the `ci-*` make targets call.
 
-Override files follow the same pattern: `compose.override.ci.yml`, `compose.override.arm64.yml`.
+## Conventions
 
-## Git Workflow
+- Compose files are `compose.yml` and `compose.override.<name>.yml`, never `docker-compose.yml`.
+- Every source file starts with the SPDX header `GPL-3.0-or-later`.
+- Never commit to `main`. Branch as `<type>/<short-description>`, use Conventional Commit messages and open a PR that references an issue with `Closes #N`. PRs are squash-merged, so the PR title becomes the commit subject.
+- Commits carry `Assisted-by: ClaudeCode:<model>` followed by a human `Signed-off-by` (`git commit -s`). See CONTRIBUTING.md.
+- Releases are tag driven. RELEASING.md documents the version bump locations and the tagging scheme. Change it in the same PR as any pipeline change.
 
-- **Never commit story work directly to `main`** — every completed story must be submitted as a pull request.
-- **One PR per story**: when a story reaches `done` status, create a branch, commit the story's implementation files, and open a PR against `main`.
-- Story branch naming: `feat/story-{epic}-{story}-{slug}` (e.g. `feat/story-1-1-docker-compose-platform-scaffold-with-traefik-tls`)
-- Use **Conventional Commits** for all commit messages:
-  - `feat:` — new feature or content
-  - `fix:` — bug fix or correction
-  - `docs:` — documentation changes
-  - `chore:` — maintenance, config, tooling
-  - `refactor:` — restructuring without behaviour change
-- Non-story branches: `<type>/<short-description>` (e.g. `feat/add-prd-template`, `docs/update-agent-roster`)
+## Admin API errors
 
-## API Error Response Guideline
-
-When implementing API error responses in packyard projects, use the **Code + Message** pattern:
+Return a machine-readable `code` in SCREAMING_SNAKE_CASE, a human-readable `message`, and any context fields that make the error self-contained:
 
 ```json
-{
-  "code": "KEY_SCOPE_MISMATCH",
-  "message": "Key 'abc123' is scoped to 'core' but requested path is '/minion/'",
-  "component_requested": "minion",
-  "key_scope": "core"
-}
+{"code": "KEY_SCOPE_MISMATCH", "message": "Key 'abc123' is scoped to 'core' but requested path is '/minion/'", "component_requested": "minion", "key_scope": "core"}
 ```
 
-- `code` — machine-readable constant (SCREAMING_SNAKE_CASE) for programmatic handling
-- `message` — human-readable description with enough context to diagnose without reading logs
-- Additional fields — context-specific key/value pairs that make the error self-contained for support and debugging
-
-Bare `HTTP 401` with no body is acceptable for package manager serving endpoints (RPM/DEB/OCI) since `dnf`/`apt`/`docker` do not parse response bodies on auth failure. The structured error schema applies to the admin API only.
-
-## Configuration Files
-
-- `_bmad/_config/manifest.yaml` — module versions and install dates
-- `_bmad/_config/agent-manifest.csv` — all 18 agent definitions
-- `_bmad/_config/skill-manifest.csv` — all 79 skill definitions
-- `_bmad/bmm/config.yaml` — project name, user name, output paths
-- `_bmad/tea/config.yaml`, `_bmad/wds/config.yaml`, `_bmad/bmb/config.yaml` — per-module settings
+Package-serving endpoints (RPM, DEB, OCI) may answer a bare `401`; `dnf`, `apt` and `docker` do not read bodies.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,6 +87,10 @@ Every push to `main` that touches a service runs the quality gates and then push
 Each build overwrites the previous one.
 Preview images are signed with cosign but never receive `X.Y.Z`, `X.Y` or `latest` tags.
 
+The `aptly` and `backup` images wrap an upstream tool and are versioned by that tool, not by Packyard.
+Pushes to `main` that touch them publish only the upstream version tag, for example `ghcr.io/no42-org/packyard-aptly:1.6.2`, and `compose.yml` pins that tag.
+They are not part of the release matrix and never receive `latest`.
+
 ## Verifying signatures and provenance
 
 Images are signed keylessly by the `Release` workflow. Verify against the workflow identity:

--- a/auth/internal/admin-ui/src/App.tsx
+++ b/auth/internal/admin-ui/src/App.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useQueryClient } from "@tanstack/react-query";
 import { NavLink, Navigate, Route, Routes } from "react-router-dom";
 

--- a/auth/internal/admin-ui/src/api/accounts.ts
+++ b/auth/internal/admin-ui/src/api/accounts.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { apiFetch, apiListFetch, PaginatedResult } from "./client";

--- a/auth/internal/admin-ui/src/api/audit.ts
+++ b/auth/internal/admin-ui/src/api/audit.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useQuery } from "@tanstack/react-query";
 
 import { apiListFetch, PaginatedResult } from "./client";

--- a/auth/internal/admin-ui/src/api/client.ts
+++ b/auth/internal/admin-ui/src/api/client.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 // API client for /api/v1/* — thin fetch wrapper that:
 //
 //   1. Always sends credentials so the session cookie travels (the cookie is

--- a/auth/internal/admin-ui/src/api/components.ts
+++ b/auth/internal/admin-ui/src/api/components.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { apiFetch } from "./client";

--- a/auth/internal/admin-ui/src/api/operators.ts
+++ b/auth/internal/admin-ui/src/api/operators.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { apiFetch, apiListFetch, PaginatedResult } from "./client";

--- a/auth/internal/admin-ui/src/api/session.ts
+++ b/auth/internal/admin-ui/src/api/session.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useQuery } from "@tanstack/react-query";
 
 import { ApiError, apiFetch } from "./client";

--- a/auth/internal/admin-ui/src/components/ErrorBanner.tsx
+++ b/auth/internal/admin-ui/src/components/ErrorBanner.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { ApiError } from "../api/client";
 
 interface Props {

--- a/auth/internal/admin-ui/src/components/Modal.tsx
+++ b/auth/internal/admin-ui/src/components/Modal.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useEffect, useRef } from "react";
 import { ReactNode } from "react";
 

--- a/auth/internal/admin-ui/src/components/Pagination.tsx
+++ b/auth/internal/admin-ui/src/components/Pagination.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useNavigate } from "react-router-dom";
 
 interface Props {

--- a/auth/internal/admin-ui/src/main.tsx
+++ b/auth/internal/admin-ui/src/main.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/auth/internal/admin-ui/src/routes/AccountDetail.tsx
+++ b/auth/internal/admin-ui/src/routes/AccountDetail.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 

--- a/auth/internal/admin-ui/src/routes/Accounts.tsx
+++ b/auth/internal/admin-ui/src/routes/Accounts.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 

--- a/auth/internal/admin-ui/src/routes/Audit.tsx
+++ b/auth/internal/admin-ui/src/routes/Audit.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useEffect, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 

--- a/auth/internal/admin-ui/src/routes/Components.tsx
+++ b/auth/internal/admin-ui/src/routes/Components.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useState } from "react";
 
 import {

--- a/auth/internal/admin-ui/src/routes/Login.tsx
+++ b/auth/internal/admin-ui/src/routes/Login.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useSearchParams } from "react-router-dom";
 
 // Known error codes the OAuth callback may pass back via ?error=. Anything

--- a/auth/internal/admin-ui/src/routes/Operators.tsx
+++ b/auth/internal/admin-ui/src/routes/Operators.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { useState } from "react";
 
 import {

--- a/auth/internal/admin-ui/vite.config.ts
+++ b/auth/internal/admin-ui/vite.config.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 

--- a/scripts/backup-keystore.sh
+++ b/scripts/backup-keystore.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
 # backup-keystore.sh — SQLite online backup for the packyard auth keystore (Story 5.4)
 #
 # USAGE (inside the backup container):

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
 # health-check.sh — verify packyard stack is operational
 # Exit 0 on success, non-zero on failure.
 # Extended by later stories (Story 1.2 adds /gpg/lts.asc check,

--- a/scripts/stage-artifact.sh
+++ b/scripts/stage-artifact.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
 # stage-artifact.sh — upload an unsigned artefact to RustFS staging
 # Usage: stage-artifact.sh <component> <series> <format> <os-arch> <local-file>
 #

--- a/src/components/Landing/Terminal.tsx
+++ b/src/components/Landing/Terminal.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import React, {useEffect, useState} from 'react';
 import {TERMINAL_SCRIPT, type TerminalLine} from './data';
 

--- a/src/components/Landing/data.ts
+++ b/src/components/Landing/data.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 // Content tables for the Packyard landing page.
 // Kept as a plain module so it's cheap to tweak without touching components.
 

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import React, {useState} from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import React from 'react';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';

--- a/src/theme/Mermaid/MermaidZoomOverlay.tsx
+++ b/src/theme/Mermaid/MermaidZoomOverlay.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import React, {useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
 import BrowserOnly from '@docusaurus/BrowserOnly';

--- a/src/theme/Mermaid/index.tsx
+++ b/src/theme/Mermaid/index.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 // --wrap swizzle of @docusaurus/theme-mermaid.
 //
 // Depends on theme-mermaid internal structure: we query the rendered <svg>


### PR DESCRIPTION
## Summary
Three fixes from the maintainer-standards audit, one commit each.

- The aptly and backup preview builds no longer tag `latest`. Both images are versioned by the upstream tool they wrap and are outside the release matrix. `compose.yml` pins the upstream version tag, so nothing consumed `latest`. RELEASING.md documents this.
- CLAUDE.md is rewritten around the real make targets, the service layout and the repo conventions. The previous file described the repo as a BMad install with no build or test commands.
- 27 source files gain the GPL-3.0-or-later SPDX header: the admin SPA TypeScript, the Docusaurus React components under `src/`, and three scripts.

Closes #203

## Verification
`make build` and `make docs-build` pass with the headers in place. `bash -n` and `sh -n` parse the three scripts. No file under `auth/`, `src/` or `scripts/` lacks the header now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)