### PR TITLE
feat: promote upstream GitHub Releases with one dispatch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@
 # Applying a changed value needs `docker compose up -d <service>` to recreate
 # the container; `docker compose restart` keeps the old environment.
 
+# Compose project name. Pins container names to <project>-<service>-1 no
+# matter which directory the checkout lives in, so promotion workflows that
+# run `docker compose -f $DEPLOY_DIR/compose.yml exec ...` as the deploy user
+# find the running services. See docs/ops/production-deployment.md §5.
+COMPOSE_PROJECT_NAME=packyard
+
 # ACME/TLS — required for production certificate issuance
 ACME_EMAIL=ops@example.org
 PKG_DOMAIN=pkg.example.org

--- a/.github/workflows/promote-deb.yml
+++ b/.github/workflows/promote-deb.yml
@@ -49,10 +49,21 @@ jobs:
             [[ "$v" =~ $re ]] && [[ "$v" != *..* ]] || { echo "ERROR: invalid input value: $v"; exit 1; }
           done
 
-      - name: Verify GPG key is not a placeholder
+      - name: Verify the signing key is the key subscribers download
+        # The public key lives on the deployment (static/content/gpg/lts.asc is
+        # a placeholder in this repository). Compare fingerprints with what the
+        # host serves, so packages are never signed with a key subscribers
+        # cannot verify.
+        env:
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          HOST: ${{ secrets.HOST }}
         run: |
-          grep -q 'BEGIN PGP PUBLIC KEY BLOCK' ./static/content/gpg/lts.asc \
-            || { echo "ERROR: lts.asc is still a placeholder — replace with real GPG key before promoting"; exit 1; }
+          served=$(curl -fsSL "https://${HOST}/gpg/lts.asc" | gpg --show-keys --with-colons | awk -F: '/^fpr/{print $10}')
+          [ -n "$served" ] || { echo "ERROR: https://${HOST}/gpg/lts.asc is not a GPG public key"; exit 1; }
+          want=$(tr '[:lower:]' '[:upper:]' <<< "${GPG_KEY_ID}")
+          grep -qx "${want}" <<< "${served}" \
+            || { echo "ERROR: GPG_KEY_ID does not match any fingerprint served at https://${HOST}/gpg/lts.asc"; exit 1; }
+          echo "signing key ${want} is served by the host"
 
       - name: Set up SSH
         run: |

--- a/.github/workflows/promote-deb.yml
+++ b/.github/workflows/promote-deb.yml
@@ -7,7 +7,7 @@ on:
         description: "LTS component name (must be provisioned via POST /api/v1/components)"
         required: true
       series:
-        description: "LTS series (e.g. 2025)"
+        description: "Series label, e.g. an LTS year (2025) or a major version (38)"
         required: true
       distro:
         description: "Debian distro (bookworm|trixie|jammy|noble)"
@@ -20,6 +20,9 @@ concurrency:
 env:
   AWS_DEFAULT_REGION: us-east-1
   RUSTFS_ENDPOINT: http://localhost:9000
+  # Compose checkout on the host. Set the repository variable DEPLOY_DIR when
+  # the deployment does not live at the documented default.
+  DEPLOY_DIR: ${{ vars.DEPLOY_DIR || '/opt/packyard' }}
 
 permissions:
   contents: read
@@ -32,6 +35,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Validate inputs
+        env:
+          COMPONENT: ${{ inputs.component }}
+          SERIES: ${{ inputs.series }}
+          TARGET: ${{ inputs.distro }}
+        run: |
+          # Inputs end up in remote shell commands and filesystem paths: one
+          # path segment each, no traversal, no quotes.
+          re='^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+          for v in "$COMPONENT" "$SERIES" "$TARGET"; do
+            [[ "$v" =~ $re ]] && [[ "$v" != *..* ]] || { echo "ERROR: invalid input value: $v"; exit 1; }
+          done
 
       - name: Verify GPG key is not a placeholder
         run: |
@@ -104,8 +120,9 @@ jobs:
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "rm -rf /tmp/deb-stage && mkdir -p /tmp/deb-stage"
           scp ./staging/*.deb deploy@${{ secrets.HOST }}:/tmp/deb-stage/
+          # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
-            APTLY_ID=\$(docker compose -f /opt/packyard/compose.yml ps -q aptly)
+            APTLY_ID=\$(docker compose -f '${DEPLOY_DIR}/compose.yml' ps -q aptly)
             docker cp /tmp/deb-stage/ \"\${APTLY_ID}:/tmp/\"
           "
 
@@ -117,7 +134,7 @@ jobs:
         run: |
           # shellcheck disable=SC2029  # client-side expansion is intended
           SNAPSHOT_NAME=$(ssh deploy@${{ secrets.HOST }} \
-            "docker compose -f /opt/packyard/compose.yml exec -T \
+            "docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T \
               -e COMPONENT='${COMPONENT}' -e SERIES='${SERIES}' -e DISTRO='${DISTRO}' \
               -e DEB_STAGE_DIR=/tmp/deb-stage \
               aptly /scripts/create-snapshot.sh '${COMPONENT}' '${SERIES}' '${DISTRO}'")
@@ -133,7 +150,7 @@ jobs:
         run: |
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} \
-            "docker compose -f /opt/packyard/compose.yml exec -T aptly \
+            "docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly \
               /scripts/publish-snapshot.sh \
               '${SNAPSHOT_NAME}' '${COMPONENT}' '${SERIES}' '${DISTRO}'"
 
@@ -145,7 +162,7 @@ jobs:
         run: |
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
-            docker compose -f /opt/packyard/compose.yml exec -T aptly \
+            docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly \
               test -f '/opt/aptly/public/${COMPONENT}/${SERIES}/dists/${DISTRO}/InRelease' \
               && echo 'SMOKE TEST PASS' \
               || { echo 'SMOKE TEST FAIL'; exit 1; }
@@ -158,16 +175,17 @@ jobs:
         run: |
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} \
-            "docker compose -f /opt/packyard/compose.yml exec -T aptly \
+            "docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly \
               /scripts/prune-snapshots.sh '${COMPONENT}' '${SERIES}'"
 
       - name: Cleanup
         if: always()
         run: |
           rm -f ~/.ssh/id_ed25519
+          # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
             rm -rf /tmp/deb-stage
-            docker compose -f /opt/packyard/compose.yml exec -T aptly \
+            docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly \
               rm -rf /tmp/deb-stage 2>/dev/null || true
           " 2>/dev/null || true
           pkill -f 'ssh -fN -L 9000' || true

--- a/.github/workflows/promote-oci.yml
+++ b/.github/workflows/promote-oci.yml
@@ -7,7 +7,7 @@ on:
         description: "LTS component name (must be provisioned via POST /api/v1/components)"
         required: true
       series:
-        description: "LTS series (e.g. 2025)"
+        description: "Series label, e.g. an LTS year (2025) or a major version (38)"
         required: true
 
 env:

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,359 @@
+name: Promote release
+
+# Ingests one upstream GitHub Release into one component and series: RPMs and
+# DEBs from the release assets, images copied registry-to-registry from the
+# upstream registry into Zot. Everything is re-signed with Packyard's own
+# identities (GPG for packages, keyless cosign for images).
+#
+# Triggered by the upstream release job with a token limited to Actions:write
+# on this repository, or by hand for a re-run. See
+# docs/ops/upstream-release-dispatch.md and docs/reference/promotion-pipeline.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_repo:
+        description: "Upstream repository owner/name whose GitHub Release is promoted"
+        required: true
+        default: Bluebird-Community/opennms
+      tag:
+        description: "Release tag in the upstream repository, e.g. v38.1.0"
+        required: true
+      component:
+        description: "Packyard component (must exist, see POST /api/v1/components)"
+        required: true
+        default: bluebird
+      series:
+        description: "Series label under the component, e.g. 38 or 2025"
+        required: true
+        default: "38"
+      rpm_targets:
+        description: "Comma-separated RPM os-arch targets; each must be provisioned on the component"
+        required: true
+        default: el9-x86_64,el10-x86_64
+      deb_distros:
+        description: "Comma-separated Debian/Ubuntu distributions to publish"
+        required: true
+        default: bookworm,trixie,jammy,noble
+      images:
+        description: "Comma-separated image names to copy; each becomes lts-<component>/<image>. Empty skips images"
+        required: false
+        default: core,minion,sentinel
+      source_registry:
+        description: "Registry path holding the upstream images as <source_registry>/<image>:<version>"
+        required: true
+        default: quay.io/bluebird
+      source_workflow:
+        description: "Upstream workflow file that signed the release (cosign identity)"
+        required: true
+        default: main.yml
+
+# One promotion per component and series at a time, never cancelled: a
+# cancelled run can leave a published index without a signature.
+concurrency:
+  group: promote-release-${{ inputs.component }}-${{ inputs.series }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  # Compose checkout on the host. Set the repository variable DEPLOY_DIR when
+  # the deployment does not live at the documented default.
+  DEPLOY_DIR: ${{ vars.DEPLOY_DIR || '/opt/packyard' }}
+  ZOT_REGISTRY: localhost:5000
+  OIDC_ISSUER: https://token.actions.githubusercontent.com
+
+jobs:
+  promote:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      id-token: write  # cosign keyless: Fulcio certificate bound to this workflow's OIDC identity
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate inputs
+        env:
+          SOURCE_REPO: ${{ inputs.source_repo }}
+          TAG: ${{ inputs.tag }}
+          COMPONENT: ${{ inputs.component }}
+          SERIES: ${{ inputs.series }}
+          RPM_TARGETS_IN: ${{ inputs.rpm_targets }}
+          DEB_DISTROS_IN: ${{ inputs.deb_distros }}
+          IMAGES_IN: ${{ inputs.images }}
+          SOURCE_REGISTRY: ${{ inputs.source_registry }}
+          SOURCE_WORKFLOW: ${{ inputs.source_workflow }}
+        run: |
+          # Every value ends up in a remote shell command, a filesystem path or
+          # a registry reference: one path segment each, no traversal, no quotes.
+          seg='^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+          check() { [[ "$2" =~ $seg ]] && [[ "$2" != *..* ]] || { echo "ERROR: invalid $1: '$2'"; exit 1; }; }
+          check tag "$TAG"; check component "$COMPONENT"; check series "$SERIES"
+          [[ "$SOURCE_REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || { echo "ERROR: invalid source_repo"; exit 1; }
+          [[ "$SOURCE_REGISTRY" =~ ^[a-z0-9.:-]+(/[a-z0-9._-]+)*$ ]] || { echo "ERROR: invalid source_registry"; exit 1; }
+          check source_workflow "$SOURCE_WORKFLOW"
+          split() { tr ',' ' ' <<< "$1" | xargs; }
+          RPM_TARGETS=$(split "$RPM_TARGETS_IN"); DEB_DISTROS=$(split "$DEB_DISTROS_IN"); IMAGES=$(split "$IMAGES_IN")
+          [ -n "$RPM_TARGETS" ] || { echo "ERROR: rpm_targets is empty"; exit 1; }
+          [ -n "$DEB_DISTROS" ] || { echo "ERROR: deb_distros is empty"; exit 1; }
+          for v in $RPM_TARGETS; do check rpm_target "$v"; done
+          for v in $DEB_DISTROS; do check deb_distro "$v"; done
+          for v in $IMAGES; do check image "$v"; done
+          {
+            echo "VERSION=${TAG#v}"
+            echo "RPM_TARGETS=$RPM_TARGETS"
+            echo "DEB_DISTROS=$DEB_DISTROS"
+            echo "IMAGES=$IMAGES"
+            echo "SOURCE_IDENTITY=https://github.com/${SOURCE_REPO}/.github/workflows/${SOURCE_WORKFLOW}@refs/tags/${TAG}"
+          } >> "$GITHUB_ENV"
+          echo "Promoting ${SOURCE_REPO}@${TAG} -> ${COMPONENT}/${SERIES} (version ${TAG#v})"
+          echo "  rpm targets: ${RPM_TARGETS}"
+          echo "  deb distros: ${DEB_DISTROS}"
+          echo "  images:      ${IMAGES:-none}"
+
+      - name: Install signing tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends rpm dpkg-sig
+          rpmsign --version
+          dpkg-sig --version | head -1
+
+      - name: Install crane
+        env:
+          CRANE_VERSION: v0.20.2
+          CRANE_SHA256: c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137f44b
+        run: |
+          curl -fsSL "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+            -o /tmp/crane.tar.gz
+          echo "${CRANE_SHA256}  /tmp/crane.tar.gz" | sha256sum --check --strict
+          tar -xzf /tmp/crane.tar.gz -C /tmp crane
+          sudo mv /tmp/crane /usr/local/bin/crane
+          crane version
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          cosign-release: 'v3.0.6'
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          echo "${{ secrets.SSH_KNOWN_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Preflight the host
+        # Fail before anything is downloaded or signed if the host is not
+        # ready: checkout present, rpm and aptly running, rpm image current.
+        run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          ssh deploy@${{ secrets.HOST }} "
+            set -euo pipefail
+            C='${DEPLOY_DIR}/compose.yml'
+            [ -f \"\$C\" ] || { echo \"ERROR: \$C not found; set the DEPLOY_DIR repository variable\"; exit 1; }
+            for svc in rpm aptly zot; do
+              [ -n \"\$(docker compose -f \"\$C\" ps -q \"\$svc\")\" ] || { echo \"ERROR: service \$svc is not running\"; exit 1; }
+            done
+            docker compose -f \"\$C\" exec -T rpm test -x /scripts/add-package.sh \
+              || { echo 'ERROR: the running rpm container has no /scripts/add-package.sh; pull the current rpm image (docker compose up -d rpm)'; exit 1; }
+            echo 'host preflight OK'
+          "
+
+      - name: Verify the signing key is the key subscribers download
+        # The public key lives on the deployment (static/content/gpg/lts.asc is
+        # a placeholder in this repository). Compare fingerprints with what the
+        # host serves, so packages are never signed with a key subscribers
+        # cannot verify.
+        env:
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          HOST: ${{ secrets.HOST }}
+        run: |
+          served=$(curl -fsSL "https://${HOST}/gpg/lts.asc" | gpg --show-keys --with-colons | awk -F: '/^fpr/{print $10}')
+          [ -n "$served" ] || { echo "ERROR: https://${HOST}/gpg/lts.asc is not a GPG public key"; exit 1; }
+          want=$(tr '[:lower:]' '[:upper:]' <<< "${GPG_KEY_ID}")
+          grep -qx "${want}" <<< "${served}" \
+            || { echo "ERROR: GPG_KEY_ID does not match any fingerprint served at https://${HOST}/gpg/lts.asc"; exit 1; }
+          echo "signing key ${want} is served by the host"
+
+      - name: Download and verify release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REPO: ${{ inputs.source_repo }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          mkdir -p ./release
+          gh release download "${TAG}" -R "${SOURCE_REPO}" -D ./release \
+            -p '*.rpm' -p '*.deb' -p 'SHA256SUMS' -p 'SHA256SUMS.sig' -p 'SHA256SUMS.pem'
+          cd ./release
+          ls -l
+          rpms=$(find . -maxdepth 1 -name '*.rpm' | wc -l); debs=$(find . -maxdepth 1 -name '*.deb' | wc -l)
+          [ "$rpms" -gt 0 ] || { echo "ERROR: release ${TAG} has no .rpm assets"; exit 1; }
+          [ "$debs" -gt 0 ] || { echo "ERROR: release ${TAG} has no .deb assets"; exit 1; }
+          [ -f SHA256SUMS ] || { echo "ERROR: release ${TAG} has no SHA256SUMS"; exit 1; }
+          # The checksums file is itself signed by the upstream release workflow.
+          cosign verify-blob \
+            --certificate SHA256SUMS.pem --signature SHA256SUMS.sig \
+            --certificate-identity "${SOURCE_IDENTITY}" \
+            --certificate-oidc-issuer "${OIDC_ISSUER}" \
+            SHA256SUMS
+          # Every downloaded package must be listed, and every listed one we have must match.
+          for f in *.rpm *.deb; do
+            grep -qF "  ${f}" SHA256SUMS || { echo "ERROR: ${f} is not listed in SHA256SUMS"; exit 1; }
+          done
+          sha256sum --check --strict --ignore-missing SHA256SUMS
+
+      - name: Import GPG key (ephemeral) and sign packages
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+          gpg --list-secret-keys "${GPG_KEY_ID}"
+          # Pre-cache the passphrase in gpg-agent via loopback pinentry. A wrong
+          # passphrase fails here with gpg's own message rather than later
+          # from rpmsign or dpkg-sig. Passphrase on fd 3; stdin is the empty
+          # message to sign.
+          gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 -u "${GPG_KEY_ID}" \
+            --sign --output /dev/null - < /dev/null 3< <(printf '%s\n' "${GPG_PASSPHRASE}")
+          for rpm in ./release/*.rpm; do
+            rpmsign --addsign --define "_gpg_name ${GPG_KEY_ID}" "$rpm"
+            echo "Signed: $(basename "$rpm")"
+          done
+          for deb in ./release/*.deb; do
+            dpkg-sig --sign builder -k "${GPG_KEY_ID}" "$deb"
+            echo "Signed: $(basename "$deb")"
+          done
+
+      - name: Publish RPMs inside the rpm container
+        env:
+          COMPONENT: ${{ inputs.component }}
+          SERIES: ${{ inputs.series }}
+        run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          ssh deploy@${{ secrets.HOST }} "rm -rf /tmp/rpm-stage && mkdir -p /tmp/rpm-stage"
+          scp ./release/*.rpm deploy@${{ secrets.HOST }}:/tmp/rpm-stage/
+          # The rpm service runs as uid 101 but the auth service creates the
+          # component tree as root, so publish as root inside the container.
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          ssh deploy@${{ secrets.HOST }} "
+            set -euo pipefail
+            C='${DEPLOY_DIR}/compose.yml'
+            RPM_ID=\$(docker compose -f \"\$C\" ps -q rpm)
+            docker cp /tmp/rpm-stage/ \"\${RPM_ID}:/tmp/\"
+            docker compose -f \"\$C\" exec -T --user 0 rpm bash -c '
+              set -euo pipefail
+              for f in /tmp/rpm-stage/*.rpm; do
+                /scripts/add-package.sh \"\$f\" \"${COMPONENT}\" \"${SERIES}\" ${RPM_TARGETS}
+              done
+            '
+          "
+
+      - name: Publish DEBs through aptly
+        env:
+          COMPONENT: ${{ inputs.component }}
+          SERIES: ${{ inputs.series }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          ssh deploy@${{ secrets.HOST }} "rm -rf /tmp/deb-stage && mkdir -p /tmp/deb-stage"
+          scp ./release/*.deb deploy@${{ secrets.HOST }}:/tmp/deb-stage/
+          # aptly signs Release inside its container: import the key into the
+          # container's tmpfs home and hand it the passphrase through a file.
+          C="${DEPLOY_DIR}/compose.yml"
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          printf '%s\n' "${GPG_PRIVATE_KEY}" | ssh deploy@${{ secrets.HOST }} \
+            "docker compose -f '${C}' exec -T aptly gpg --batch --quiet --import"
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          printf '%s\n' "${GPG_PASSPHRASE}" | ssh deploy@${{ secrets.HOST }} \
+            "docker compose -f '${C}' exec -T aptly sh -c 'umask 077; cat > /tmp/gpg-pass'"
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          ssh deploy@${{ secrets.HOST }} "
+            set -euo pipefail
+            C='${C}'
+            APTLY_ID=\$(docker compose -f \"\$C\" ps -q aptly)
+            docker cp /tmp/deb-stage/ \"\${APTLY_ID}:/tmp/\"
+            first_distro=\$(set -- ${DEB_DISTROS}; echo \"\$1\")
+            SNAP=\$(docker compose -f \"\$C\" exec -T -e DEB_STAGE_DIR=/tmp/deb-stage aptly \
+              /scripts/create-snapshot.sh '${COMPONENT}' '${SERIES}' \"\$first_distro\")
+            [ -n \"\$SNAP\" ] || { echo 'ERROR: snapshot name is empty'; exit 1; }
+            echo \"snapshot: \$SNAP\"
+            for d in ${DEB_DISTROS}; do
+              docker compose -f \"\$C\" exec -T \
+                -e GPG_KEY_ID='${GPG_KEY_ID}' -e GPG_PASSPHRASE_FILE=/tmp/gpg-pass aptly \
+                /scripts/publish-snapshot.sh \"\$SNAP\" '${COMPONENT}' '${SERIES}' \"\$d\"
+              docker compose -f \"\$C\" exec -T aptly \
+                test -f \"/opt/aptly/public/${COMPONENT}/${SERIES}/dists/\$d/InRelease\" \
+                || { echo \"ERROR: InRelease missing for \$d\"; exit 1; }
+            done
+            docker compose -f \"\$C\" exec -T aptly /scripts/prune-snapshots.sh '${COMPONENT}' '${SERIES}'
+          "
+
+      - name: Open Zot tunnel
+        if: env.IMAGES != ''
+        run: |
+          ssh -fN -L 5000:localhost:5000 deploy@${{ secrets.HOST }}
+          timeout 15 bash -c 'until nc -z localhost 5000 2>/dev/null; do sleep 1; done'
+
+      - name: Copy images into Zot and sign them
+        if: env.IMAGES != ''
+        env:
+          COMPONENT: ${{ inputs.component }}
+          SERIES: ${{ inputs.series }}
+          SOURCE_REGISTRY: ${{ inputs.source_registry }}
+          OWN_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/promote-release.yml@${{ github.ref }}
+        run: |
+          for img in ${IMAGES}; do
+            src="${SOURCE_REGISTRY}/${img}:${VERSION}"
+            dst="${ZOT_REGISTRY}/lts-${COMPONENT}/${img}"
+            # Upstream signature first: never copy an image the source did not sign.
+            cosign verify \
+              --certificate-identity "${SOURCE_IDENTITY}" \
+              --certificate-oidc-issuer "${OIDC_ISSUER}" \
+              "${src}" > /dev/null
+            # Registry-to-registry by digest keeps the multi-arch index intact.
+            crane copy --insecure "${src}" "${dst}:${VERSION}"
+            crane tag --insecure "${dst}:${VERSION}" "${SERIES}"
+            digest=$(crane digest --insecure "${dst}:${VERSION}")
+            [ "$(crane digest "${src}")" = "${digest}" ] || { echo "ERROR: digest changed while copying ${img}"; exit 1; }
+            cosign sign --yes --allow-insecure-registry "${dst}@${digest}"
+            cosign verify --allow-insecure-registry \
+              --certificate-identity "${OWN_IDENTITY}" \
+              --certificate-oidc-issuer "${OIDC_ISSUER}" \
+              "${dst}:${SERIES}" > /dev/null
+            echo "Published and signed: lts-${COMPONENT}/${img}:${VERSION} (${SERIES} -> ${digest})"
+          done
+
+      - name: Verify through the public hostname
+        # Public components answer 200; private ones answer 401 without a key.
+        # Either proves routing and content exist. 404 or 5xx is a failure.
+        env:
+          COMPONENT: ${{ inputs.component }}
+          SERIES: ${{ inputs.series }}
+          HOST: ${{ secrets.HOST }}
+        run: |
+          check() {
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$1")
+            case "$code" in 200|401) echo "  $code  $1" ;; *) echo "  $code  $1  <-- FAIL"; exit 1 ;; esac
+          }
+          for t in ${RPM_TARGETS}; do check "https://${HOST}/rpm/${COMPONENT}/${SERIES}/${t}/repodata/repomd.xml"; done
+          for d in ${DEB_DISTROS}; do check "https://${HOST}/deb/${COMPONENT}/${SERIES}/dists/${d}/InRelease"; done
+          for i in ${IMAGES}; do check "https://${HOST}/oci/v2/lts-${COMPONENT}/${i}/manifests/${VERSION}"; done
+
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -f ~/.ssh/id_ed25519
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          ssh deploy@${{ secrets.HOST }} "
+            C='${DEPLOY_DIR}/compose.yml'
+            rm -rf /tmp/rpm-stage /tmp/deb-stage
+            docker compose -f \"\$C\" exec -T --user 0 rpm rm -rf /tmp/rpm-stage 2>/dev/null || true
+            docker compose -f \"\$C\" exec -T aptly rm -rf /tmp/deb-stage /tmp/gpg-pass /root/.gnupg 2>/dev/null || true
+          " 2>/dev/null || true
+          pkill -f 'ssh -fN -L 5000' || true

--- a/.github/workflows/promote-rpm.yml
+++ b/.github/workflows/promote-rpm.yml
@@ -7,7 +7,7 @@ on:
         description: "LTS component name (must be provisioned via POST /api/v1/components)"
         required: true
       series:
-        description: "LTS series (e.g. 2025)"
+        description: "Series label, e.g. an LTS year (2025) or a major version (38)"
         required: true
       os:
         description: "OS target (el8-x86_64|el9-x86_64|el10-x86_64|centos10-x86_64)"
@@ -20,6 +20,9 @@ concurrency:
 env:
   AWS_DEFAULT_REGION: us-east-1
   RUSTFS_ENDPOINT: http://localhost:9000
+  # Compose checkout on the host. Set the repository variable DEPLOY_DIR when
+  # the deployment does not live at the documented default.
+  DEPLOY_DIR: ${{ vars.DEPLOY_DIR || '/opt/packyard' }}
 
 permissions:
   contents: read
@@ -32,6 +35,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Validate inputs
+        env:
+          COMPONENT: ${{ inputs.component }}
+          SERIES: ${{ inputs.series }}
+          TARGET: ${{ inputs.os }}
+        run: |
+          # Inputs end up in remote shell commands and filesystem paths: one
+          # path segment each, no traversal, no quotes.
+          re='^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+          for v in "$COMPONENT" "$SERIES" "$TARGET"; do
+            [[ "$v" =~ $re ]] && [[ "$v" != *..* ]] || { echo "ERROR: invalid input value: $v"; exit 1; }
+          done
 
       - name: Verify GPG key is not a placeholder
         run: |
@@ -116,26 +132,36 @@ jobs:
             echo "Signed: $(basename "$rpm")"
           done
 
-      - name: Create staging directory on host
-        run: ssh deploy@${{ secrets.HOST }} "rm -rf /tmp/rpm-stage && mkdir -p /tmp/rpm-stage"
+      - name: Upload signed RPMs to host and copy into the rpm container
+        run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          ssh deploy@${{ secrets.HOST }} "rm -rf /tmp/rpm-stage && mkdir -p /tmp/rpm-stage"
+          scp ./staging/*.rpm deploy@${{ secrets.HOST }}:/tmp/rpm-stage/
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          ssh deploy@${{ secrets.HOST }} "
+            RPM_ID=\$(docker compose -f '${DEPLOY_DIR}/compose.yml' ps -q rpm)
+            [ -n \"\$RPM_ID\" ] || { echo 'ERROR: rpm service is not running'; exit 1; }
+            docker cp /tmp/rpm-stage/ \"\${RPM_ID}:/tmp/\"
+          "
 
-      - name: Upload signed RPMs to host
-        run: scp ./staging/*.rpm deploy@${{ secrets.HOST }}:/tmp/rpm-stage/
-
-      - name: Publish to host
+      - name: Publish inside the rpm container
         env:
           # P1: route inputs through env vars to avoid GHA text interpolation into remote shell
           COMPONENT: ${{ inputs.component }}
           SERIES: ${{ inputs.series }}
           OS: ${{ inputs.os }}
         run: |
+          # createrepo_c and the publish scripts live in the rpm image. The
+          # service runs as uid 101 but the auth service creates component
+          # directories as root, so publish as root inside the container.
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
-            set -euo pipefail
-            for f in /tmp/rpm-stage/*.rpm; do
-              /opt/packyard/rpm/scripts/add-package.sh \"\$f\" \
-                '${COMPONENT}' '${SERIES}' '${OS}'
-            done
+            docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T --user 0 rpm bash -c '
+              set -euo pipefail
+              for f in /tmp/rpm-stage/*.rpm; do
+                /scripts/add-package.sh \"\$f\" \"${COMPONENT}\" \"${SERIES}\" \"${OS}\"
+              done
+            '
           "
 
       - name: Cleanup
@@ -143,7 +169,12 @@ jobs:
         run: |
           # P3: remove SSH private key from disk
           rm -f ~/.ssh/id_ed25519
-          # P5: remove staged RPMs from host (handles failure mid-loop)
-          ssh deploy@${{ secrets.HOST }} "rm -rf /tmp/rpm-stage" 2>/dev/null || true
+          # P5: remove staged RPMs from host and container (handles failure mid-loop)
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          ssh deploy@${{ secrets.HOST }} "
+            rm -rf /tmp/rpm-stage
+            docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T --user 0 rpm \
+              rm -rf /tmp/rpm-stage 2>/dev/null || true
+          " 2>/dev/null || true
           # Close SSH tunnel
           pkill -f 'ssh -fN -L 9000' || true

--- a/.github/workflows/promote-rpm.yml
+++ b/.github/workflows/promote-rpm.yml
@@ -49,10 +49,21 @@ jobs:
             [[ "$v" =~ $re ]] && [[ "$v" != *..* ]] || { echo "ERROR: invalid input value: $v"; exit 1; }
           done
 
-      - name: Verify GPG key is not a placeholder
+      - name: Verify the signing key is the key subscribers download
+        # The public key lives on the deployment (static/content/gpg/lts.asc is
+        # a placeholder in this repository). Compare fingerprints with what the
+        # host serves, so packages are never signed with a key subscribers
+        # cannot verify.
+        env:
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          HOST: ${{ secrets.HOST }}
         run: |
-          grep -q 'BEGIN PGP PUBLIC KEY BLOCK' ./static/content/gpg/lts.asc \
-            || { echo "ERROR: lts.asc is still a placeholder — replace with real GPG key before promoting"; exit 1; }
+          served=$(curl -fsSL "https://${HOST}/gpg/lts.asc" | gpg --show-keys --with-colons | awk -F: '/^fpr/{print $10}')
+          [ -n "$served" ] || { echo "ERROR: https://${HOST}/gpg/lts.asc is not a GPG public key"; exit 1; }
+          want=$(tr '[:lower:]' '[:upper:]' <<< "${GPG_KEY_ID}")
+          grep -qx "${want}" <<< "${served}" \
+            || { echo "ERROR: GPG_KEY_ID does not match any fingerprint served at https://${HOST}/gpg/lts.asc"; exit 1; }
+          echo "signing key ${want} is served by the host"
 
       - name: Set up SSH
         run: |

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ UNAME_S := $(shell uname -s)
 
 .DEFAULT_GOAL := help
 
-.PHONY: help docs-install docs-serve docs-build docs-clean check-node \
+.PHONY: help docs-install docs-serve docs-build docs-clean check-node test-rpm-publish \
         admin-ui admin-ui-install admin-ui-dev admin-ui-clean \
         build build-clean test lint lint-workflows build-image-auth build-image-rpm build-images \
         ci-guard ci-stack-up ci-stack-down ci-stack-logs ci-seed ci-verify-env e2e-observability
@@ -91,6 +91,10 @@ build-clean:
 ## test: Run the auth service unit tests
 test:
 	cd auth && $(GO) test ./...
+
+## test-rpm-publish: Build the rpm image and publish a fixture RPM into two OS targets (needs Docker)
+test-rpm-publish:
+	bash tests/rpm/add-package-test.sh
 
 ## lint: Check gofmt formatting and run go vet on the auth service
 lint:

--- a/aptly/Dockerfile
+++ b/aptly/Dockerfile
@@ -1,11 +1,14 @@
 FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 ARG APTLY_VERSION=1.6.2
 
+# bzip2 and xz-utils: aptly publish shells out to them to compress index files.
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    bzip2 \
     ca-certificates \
     curl \
     gnupg \
     unzip \
+    xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # Download the architecture-appropriate aptly binary from GitHub releases.

--- a/aptly/scripts/publish-snapshot.sh
+++ b/aptly/scripts/publish-snapshot.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
 # publish-snapshot.sh — publish or atomically switch an Aptly snapshot
 # Usage: publish-snapshot.sh <snapshot-name> <component> <series> <distro>
 # Example: publish-snapshot.sh core-2025-20260329T120000Z core 2025 bookworm
@@ -15,6 +17,14 @@ DISTRO="${4:?distro required (bookworm|trixie|jammy|noble)}"
 
 PUBLISH_POINT=":${COMPONENT}/${SERIES}"
 
+# Signing: aptly signs Release with the default secret key unless told
+# otherwise. Promotion workflows import the key into this container and pass
+# its id and a passphrase file through the environment.
+SIGN_ARGS=()
+[ -n "${GPG_KEY_ID:-}" ] && SIGN_ARGS+=("-gpg-key=${GPG_KEY_ID}")
+[ -n "${GPG_PASSPHRASE_FILE:-}" ] && SIGN_ARGS+=("-passphrase-file=${GPG_PASSPHRASE_FILE}")
+[ "${APTLY_SKIP_SIGNING:-}" = "1" ] && SIGN_ARGS+=("-skip-signing")
+
 echo "Publishing snapshot: ${SNAPSHOT_NAME}"
 echo "  → publish point: ${PUBLISH_POINT} (distribution: ${DISTRO})"
 
@@ -23,6 +33,7 @@ if aptly publish show "${DISTRO}" "${PUBLISH_POINT}" > /dev/null 2>&1; then
   # Atomically switch to new snapshot — subscribers see either old or new, never partial
   echo "Switching published snapshot at ${PUBLISH_POINT} to ${SNAPSHOT_NAME}..."
   aptly publish switch \
+    "${SIGN_ARGS[@]}" \
     -component="${COMPONENT}" \
     "${DISTRO}" \
     "${PUBLISH_POINT}" \
@@ -31,6 +42,7 @@ else
   # First-time publish for this component/series
   echo "Publishing snapshot for the first time at ${PUBLISH_POINT}..."
   aptly publish snapshot \
+    "${SIGN_ARGS[@]}" \
     -distribution="${DISTRO}" \
     -component="${COMPONENT}" \
     "${SNAPSHOT_NAME}" \

--- a/compose.yml
+++ b/compose.yml
@@ -131,6 +131,7 @@ services:
     tmpfs:
       - /run:uid=101,gid=101                    # nginx PID and lock files
       - /var/cache/nginx:uid=101,gid=101        # client/proxy/fastcgi temp dirs
+      - /tmp                                    # createrepo_c scratch during promotion
     volumes:
       - rpm-data:/usr/share/nginx/html  # rw — init script creates directory tree on first start
     networks:

--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -240,6 +240,23 @@ cat ~/.ssh/packyard_deploy
 ssh-keyscan pkg.example.org
 ```
 
+### What the promotion workflows need on the host
+
+The promotion workflows (`promote-rpm.yml`, `promote-deb.yml`, `promote-oci.yml`, `promote-release.yml`) log in as `deploy` and run `docker compose -f $DEPLOY_DIR/compose.yml exec ...` against the running services. Three things make that work:
+
+- **`DEPLOY_DIR`** is a GitHub repository variable naming the checkout on the host. It defaults to `/opt/packyard` when unset. Set it under Settings, Secrets and variables, Actions, Variables if the checkout lives elsewhere, for example `/etc/docker/pkgs`.
+- **`COMPOSE_PROJECT_NAME`** in `.env` pins the Compose project name. Without it Compose derives the name from the checkout's directory, so renaming or moving the checkout, or reaching it through a symlink, changes the project name and `docker compose ... ps -q aptly` finds nothing. Pinning it makes the name independent of the path.
+- **`.env` must be readable by `deploy`.** Compose interpolates `${ADMIN_DOMAIN:?}` and friends from `.env` on every invocation, including `exec`. Make it `root:deploy` with mode `0640`:
+
+```bash
+chgrp deploy /path/to/checkout/.env
+chmod 640 /path/to/checkout/.env
+```
+
+`deploy` is in the `docker` group. On a Docker host that is equivalent to root, so readable `.env` grants nothing the user does not already have. Treat the `SSH_PRIVATE_KEY` secret accordingly: it is a root credential for the package host.
+
+The RPM tree lives in the `rpm-data` volume and is written from inside the `rpm` container, which ships `createrepo_c`. The host needs no RPM tooling.
+
 ---
 
 ## 6. Pre-Deployment Checklist
@@ -250,7 +267,8 @@ ssh-keyscan pkg.example.org
 - [ ] Docker + Compose plugin v2 installed on VM
 - [ ] `deploy` user created, added to `docker` group, SSH key authorized (§5)
 - [ ] GPG LTS signing key generated (§4.1); `lts.asc` committed to `static/content/gpg/`
-- [ ] `.env` file written on VM with production values (§3)
+- [ ] `.env` file written on VM with production values (§3), including `COMPOSE_PROJECT_NAME`, owned `root:deploy` mode `0640` (§5)
+- [ ] Repository variable `DEPLOY_DIR` set if the checkout is not `/opt/packyard` (§5)
 - [ ] All 8 GitHub Actions secrets set in repository settings (§3)
 
 ---

--- a/docs/ops/release-runbook.md
+++ b/docs/ops/release-runbook.md
@@ -2,13 +2,28 @@
 
 How to promote staged LTS packages (RPM, DEB, OCI) through the signing pipeline and into the serving infrastructure.
 
-**Last updated:** 2026-04-14
+**Last updated:** 2026-09-07
 
 ---
 
 ## Overview
 
-Promotion is always manual — one `workflow_dispatch` per component and target. The workflows download from RustFS staging, verify checksums, sign, and publish directly to the serving stack on the VM.
+There are two ways into the serving stack.
+
+**Automated.** An upstream project's release job triggers `promote-release.yml`, which pulls the GitHub Release and the images, verifies them, signs everything with Packyard's keys and publishes all three formats in one run.
+Nothing to stage, nothing to dispatch by hand.
+Setting it up is described in [Upstream release dispatch](upstream-release-dispatch.md); the same workflow can be dispatched by hand to repeat or roll back a release:
+
+```bash
+gh workflow run promote-release.yml \
+  -f source_repo=Bluebird-Community/opennms \
+  -f tag=v38.1.0 \
+  -f component=bluebird \
+  -f series=38
+```
+
+**Manual.** For files that do not come from a GitHub Release, stage them into RustFS and run one `workflow_dispatch` per component and target.
+The rest of this runbook covers the manual path.
 
 | Format | Workflow | Key input parameters |
 |--------|----------|---------------------|
@@ -16,11 +31,16 @@ Promotion is always manual — one `workflow_dispatch` per component and target.
 | DEB | `promote-deb.yml` | `component`, `series`, `distro` |
 | OCI | `promote-oci.yml` | `component`, `series` |
 
+`series` is any path-safe label under the component: an LTS year such as `2025`, or a major version such as `38`.
+The RPM target directories come from the component record (`rpm_series`, `rpm_os_families`, `rpm_architectures`); a promotion into an unprovisioned target fails and says so.
+
 ---
 
 ## 1. Pre-promotion checklist
 
-- [ ] `static/content/gpg/lts.asc` is a real GPG public key (not a placeholder)
+- [ ] `https://<host>/gpg/lts.asc` serves the public key whose fingerprint is the `GPG_KEY_ID` secret (the workflows check this before signing)
+- [ ] The component and, for RPM, its series and OS targets exist (admin UI or `POST /api/v1/components`)
+- [ ] The host contract is in place: `DEPLOY_DIR` variable, `COMPOSE_PROJECT_NAME` and a `deploy`-readable `.env` (see [Production Deployment §5](production-deployment.md#5-creating-the-deploy-user))
 - [ ] All 8 GitHub Actions secrets are set (see [Production Deployment §3](production-deployment.md#3-secrets--environment))
 - [ ] Artifacts are staged in RustFS (§2 below)
 

--- a/docs/ops/upstream-release-dispatch.md
+++ b/docs/ops/upstream-release-dispatch.md
@@ -1,0 +1,88 @@
+# Upstream Release Dispatch
+
+How an upstream project gets its releases onto Packyard automatically.
+The upstream repository publishes a GitHub Release on a version tag and, as its last release step, triggers `promote-release.yml` in this repository.
+Packyard then pulls the assets and images from public sources.
+See [Promotion pipeline](../reference/promotion-pipeline.md) for what the workflow does.
+
+## What the upstream release must provide
+
+- A GitHub Release on the tag with the `.rpm` and `.deb` packages attached.
+- A `SHA256SUMS` file covering those packages, plus `SHA256SUMS.sig` and `SHA256SUMS.pem` from `cosign sign-blob` run by the release workflow.
+- Images pushed to a registry as `<source_registry>/<image>:<version>` and signed keylessly by the same release workflow.
+- `<version>` equals the tag without its `v` prefix.
+
+Packyard verifies the checksums signature and every image against the identity `https://github.com/<source_repo>/.github/workflows/<source_workflow>@refs/tags/<tag>` before touching anything.
+
+## One-time setup
+
+### 1. Provision the component
+
+Create the component in the admin UI and give it the RPM series and OS targets the promotion will publish into.
+The auth service creates the directory tree from that record.
+A promotion into a target that is not on the component fails with a message naming `rpm_os_families`.
+
+For Bluebird: component `bluebird`, `rpm_series ["38"]`, `rpm_os_families ["el9","el10"]`, `rpm_architectures ["x86_64"]`, visibility `public`.
+
+### 2. Create the dispatch token
+
+A fine-grained personal access token owned by a Packyard maintainer:
+
+- Repository access: only `no42-org/packyard`.
+- Permission: **Actions: Read and write**. Nothing else.
+- Expiry: one year. Put the date in a calendar. An expired token fails the upstream release job with `401`, loudly.
+
+The token can start workflows in this repository and nothing more.
+It cannot read secrets, and it cannot reach the package host.
+
+Store it in the upstream repository as the secret `PACKYARD_DISPATCH_TOKEN`.
+
+A GitHub App is the cleaner long-term replacement once the upstream project triggers more than one thing here.
+It is parked until then.
+
+### 3. Add the dispatch job upstream
+
+Append a job to the upstream release workflow that runs only on version tags, after the release and the image pushes have succeeded:
+
+```yaml
+  promote-to-packyard:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [release, core-oci, minion-oci, sentinel-oci]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Trigger Packyard promotion
+        env:
+          GH_TOKEN: ${{ secrets.PACKYARD_DISPATCH_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh workflow run promote-release.yml -R no42-org/packyard \
+            -f source_repo="${GITHUB_REPOSITORY}" \
+            -f tag="${TAG}" \
+            -f component=bluebird \
+            -f series=38
+```
+
+Adjust `needs` to the job names that produce the release and the images.
+The other inputs keep their defaults, which are listed in the pipeline reference.
+
+## Watching a promotion
+
+```bash
+gh run list -R no42-org/packyard --workflow=promote-release.yml --limit 5
+gh run watch -R no42-org/packyard <run-id>
+```
+
+The last step curls every published path through the public hostname and prints the status codes.
+
+## Re-running or rolling back
+
+Dispatch the workflow by hand with the same inputs to repeat a promotion, or with an older `tag` to point the series at an earlier release:
+
+```bash
+gh workflow run promote-release.yml -R no42-org/packyard \
+  -f source_repo=Bluebird-Community/opennms -f tag=v38.1.0 -f component=bluebird -f series=38
+```
+
+Packages of both versions stay in the repositories; the floating `:<series>` image tag moves to the version last promoted.

--- a/docs/reference/promotion-pipeline.md
+++ b/docs/reference/promotion-pipeline.md
@@ -1,16 +1,60 @@
 # Promotion Pipeline
 
-Packages are promoted from staging to serving via GitHub Actions:
+Packages reach the serving stack through GitHub Actions workflows in this repository.
+There are two entry points: an automated one that ingests an upstream GitHub Release, and a manual one that promotes files staged by hand.
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `promote-rpm.yml` | `workflow_dispatch` | Downloads RPM from RustFS staging, GPG-signs it, rebuilds repodata, publishes to rpm service |
-| `promote-deb.yml` | `workflow_dispatch` | Downloads DEB from RustFS staging, GPG-signs it, creates Aptly snapshot, publishes to deb service |
-| `promote-oci.yml` | `workflow_dispatch` | Downloads OCI tarballs, pushes multi-arch image index to Zot, signs all manifests keylessly with cosign |
+| `promote-release.yml` | `workflow_dispatch`, normally called by the upstream release job | Downloads an upstream GitHub Release, verifies it, signs and publishes RPMs and DEBs, copies and signs images. One run per release |
+| `promote-rpm.yml` | `workflow_dispatch` | Downloads RPMs from RustFS staging, GPG-signs them, publishes into the rpm container and rebuilds repodata |
+| `promote-deb.yml` | `workflow_dispatch` | Downloads DEBs from RustFS staging, GPG-signs them, creates an Aptly snapshot and publishes it |
+| `promote-oci.yml` | `workflow_dispatch` | Downloads per-architecture OCI tarballs from RustFS staging, pushes a multi-arch index to Zot and signs it keylessly |
 
-## Staging an artifact
+## Automated: promote an upstream release
 
+The upstream project publishes a GitHub Release on a version tag with its packages, a `SHA256SUMS` file signed with cosign, and images in its own registry.
+Its release job then triggers `promote-release.yml` here with one API call.
+Packyard pulls everything from public sources, so the upstream repository holds no SSH key and no storage credential.
+
+```text
+upstream repo, tag v38.1.0                     no42-org/packyard, promote-release.yml
+──────────────────────────────                 ───────────────────────────────────────────────
+GitHub Release                                 1. validate inputs, preflight the host over SSH
+  bbo-core-38.1.0-761.x86_64.rpm   ──────────► 2. gh release download, cosign verify-blob SHA256SUMS,
+  bbo-core_38.1.0-761_amd64.deb                   sha256sum --check
+  SHA256SUMS, SHA256SUMS.sig/.pem               3. rpmsign / dpkg-sig with the Packyard GPG key
+quay.io/bluebird/core:38.1.0      ──────────► 4. rpm container:  add-package.sh into every rpm_target
+  (cosign-signed)                              5. aptly container: one snapshot, published per deb_distro
+                                               6. cosign verify upstream, crane copy into Zot as
+                                                  lts-<component>/<image>:<version> and :<series>,
+                                                  cosign sign with this workflow's identity
+                                               7. curl every published path through the public hostname
+```
+
+Inputs:
+
+| Input | Meaning | Example |
+|-------|---------|---------|
+| `source_repo` | Upstream repository | `Bluebird-Community/opennms` |
+| `tag` | Release tag to promote | `v38.1.0` |
+| `component` | Packyard component, must exist | `bluebird` |
+| `series` | Series label under the component | `38` |
+| `rpm_targets` | Comma-separated os-arch targets, each provisioned on the component | `el9-x86_64,el10-x86_64` |
+| `deb_distros` | Comma-separated distributions | `bookworm,trixie,jammy,noble` |
+| `images` | Comma-separated image names, empty to skip | `core,minion,sentinel` |
+| `source_registry` | Where upstream images live | `quay.io/bluebird` |
+| `source_workflow` | Upstream workflow that signed the release | `main.yml` |
+
+The version is the tag without its `v` prefix.
+Re-running the workflow for the same tag is safe: files are overwritten with identical content, Aptly skips packages it already holds, and image digests do not change.
+
+Wiring the upstream side is described in [Upstream release dispatch](../ops/upstream-release-dispatch.md).
+
+## Manual: stage and promote by hand
+
+For one-off promotions that do not come from a GitHub Release, stage files into RustFS and dispatch the format-specific workflow.
 The `component` argument must match a name provisioned via `POST /api/v1/components`.
+`series` is any path-safe label, for example an LTS year (`2025`) or a major version (`38`).
 
 ```bash
 RUSTFS_ACCESS_KEY=... RUSTFS_SECRET_KEY=... \
@@ -25,3 +69,13 @@ gh workflow run promote-rpm.yml \
   -f series=2025 \
   -f os=el9-x86_64
 ```
+
+The step-by-step procedure is in the [release runbook](../ops/release-runbook.md).
+
+## What every promotion has in common
+
+- **Packyard signs, upstream signatures are only checked.** RPMs and DEBs carry the Packyard GPG key. Images are signed keylessly by the promoting workflow's GitHub OIDC identity. Subscribers verify one identity for everything on the host.
+- **The GPG key must be the served key.** Before signing, the workflows compare the `GPG_KEY_ID` fingerprint with the key served at `https://<host>/gpg/lts.asc`. The copy of `lts.asc` in this repository is a placeholder.
+- **Publishing happens inside the service containers.** The rpm image ships `createrepo_c` and the publishing scripts, Aptly runs in its own container. The host needs Docker and the `deploy` user, nothing else. See [Production deployment §5](../ops/production-deployment.md#5-creating-the-deploy-user).
+- **One copy per package.** A package published into several RPM targets is hardlinked between the target directories. Aptly stores each `.deb` once in its pool no matter how many distributions publish it.
+- **Concurrency groups serialise per component and target.** Dispatching several promotions at once is safe.

--- a/docs/reference/subscriber-usage.md
+++ b/docs/reference/subscriber-usage.md
@@ -30,25 +30,30 @@ deb [signed-by=/usr/share/keyrings/lts.gpg] \
 
 ## OCI (Docker / Kubernetes)
 
+Images are published as `lts-<component>/<image>` with an immutable version tag and a floating series tag that follows the newest version in that series.
+
 ```bash
-# Authenticate
+# Authenticate (not needed for a public component)
 docker login pkg.example.org/oci \
   --username subscriber \
   --password KEY
 
-# Pull
-docker pull pkg.example.org/oci/lts-core:2025
+# Pull a specific version, or the newest version of a series
+docker pull pkg.example.org/oci/lts-bluebird/core:38.1.0
+docker pull pkg.example.org/oci/lts-bluebird/core:38
 
-# Verify the signature. Images are signed keylessly by the promote-oci
+# Verify the signature. Images are signed keylessly by the promoting
 # workflow, so you pin the signing workflow's identity rather than a key.
 # cosign consults the Sigstore transparency log, which needs outbound HTTPS.
 cosign verify \
-  --certificate-identity-regexp 'https://github.com/no42-org/packyard/\.github/workflows/promote-oci\.yml@refs/heads/main' \
+  --certificate-identity-regexp 'https://github.com/no42-org/packyard/\.github/workflows/promote-release\.yml@refs/heads/main' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  pkg.example.org/oci/lts-core:2025
+  pkg.example.org/oci/lts-bluebird/core:38.1.0
 ```
 
-The signature is stored in the registry next to the image, so `docker pull` and `cosign verify` both go through the same authenticated `/oci/` endpoint.
+Images promoted from staged tarballs with the older `promote-oci.yml` workflow are named `lts-<component>:<series>` and verify against `promote-oci\.yml` in the identity above.
+
+The signature is stored in the registry next to the image, so `docker pull` and `cosign verify` both go through the same `/oci/` endpoint.
 
 ## Public Keys
 

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -1,5 +1,14 @@
-FROM nginx:1.31-alpine@sha256:72ba65eb42c10344912a84ff42408db7d34f2feb642204570ab8fc5ffd29f1d3
+# Debian-based nginx rather than Alpine: createrepo_c is only packaged in
+# Alpine edge/testing, while Debian ships createrepo-c as a regular package.
+FROM nginx:1.31-trixie@sha256:05b8cb60c354a44ab824ea6e7dc69b46d50762cdbe728a347a5b656e6fb3d7c4
+# createrepo-c lets promotion workflows publish RPMs inside this container
+# (`docker compose exec --user 0 rpm /scripts/add-package.sh ...`) instead of
+# needing the tooling and write access to the volume on the host.
+# rpm-common provides the rpmrc/macros librpm reads when parsing packages.
+RUN apt-get update && apt-get install -y --no-install-recommends createrepo-c rpm-common \
+    && rm -rf /var/lib/apt/lists/*
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY scripts/init-rpm-tree.sh /docker-entrypoint.d/10-init-rpm-tree.sh
-RUN chmod +x /docker-entrypoint.d/10-init-rpm-tree.sh \
+COPY scripts/add-package.sh scripts/rebuild-metadata.sh /scripts/
+RUN chmod +x /docker-entrypoint.d/10-init-rpm-tree.sh /scripts/*.sh \
     && chown -R nginx:nginx /usr/share/nginx/html

--- a/rpm/scripts/add-package.sh
+++ b/rpm/scripts/add-package.sh
@@ -1,24 +1,76 @@
 #!/usr/bin/env bash
-# add-package.sh — copy a signed RPM into the tree and rebuild metadata
-# Usage: add-package.sh <signed-rpm> <component> <series> <os-arch>
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Relies on GHA concurrency group (rpm-publish-${component}-${os}) to prevent
-# concurrent createrepo_c runs on the same directory. No shell-level file lock.
+# add-package.sh — publish one signed RPM into one or more OS targets of a
+# component series and rebuild the metadata of each target.
+#
+# Usage: add-package.sh <signed-rpm> <component> <series> <os-arch> [<os-arch>...]
+#
+# The package bytes are stored once: the file is copied into the first target
+# and hardlinked into every further target (same volume, same filesystem).
+# Each target keeps its own repodata/, so subscriber URLs stay per OS.
+#
+# Target directories are owned by the component record (the auth service
+# creates them from rpm_series x rpm_os_families x rpm_architectures). This
+# script never creates them: a missing target means the component is not
+# configured for that OS.
+#
+# Relies on the GHA concurrency group of the calling workflow to prevent
+# concurrent createrepo_c runs on the same directory. No shell-level lock.
 set -euo pipefail
 
 RPM_FILE="${1:?signed RPM path required}"
 COMPONENT="${2:?component required}"
 SERIES="${3:?series required}"
-OS_ARCH="${4:?os-arch required}"
+shift 3
+[ "$#" -ge 1 ] || { echo "ERROR: at least one os-arch target required (e.g. el9-x86_64)"; exit 1; }
 ROOT="${RPM_ROOT:-/usr/share/nginx/html}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET="${ROOT}/rpm/${COMPONENT}/${SERIES}/${OS_ARCH}"
+
+# Same rule as the component API: one path segment, no traversal.
+SEGMENT_RE='^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+for value in "${COMPONENT}" "${SERIES}" "$@"; do
+  if ! [[ "${value}" =~ ${SEGMENT_RE} ]] || [[ "${value}" == *..* ]]; then
+    echo "ERROR: invalid path segment: ${value}"
+    exit 1
+  fi
+done
 
 [ -f "${RPM_FILE}" ] || { echo "ERROR: file not found: ${RPM_FILE}"; exit 1; }
-[ -d "${TARGET}" ] || { echo "ERROR: target dir not found: ${TARGET}"; exit 1; }
 
-echo "Copying $(basename "${RPM_FILE}") to ${TARGET}/"
-cp "${RPM_FILE}" "${TARGET}/"
+# Validate every target before touching anything, so a typo in the last
+# target does not leave the first ones half-published.
+for os_arch in "$@"; do
+  target="${ROOT}/rpm/${COMPONENT}/${SERIES}/${os_arch}"
+  if [ ! -d "${target}" ]; then
+    echo "ERROR: target dir not found: ${target}"
+    echo "       Add the OS family and architecture to the component's rpm_os_families /"
+    echo "       rpm_architectures (and the series to rpm_series) via the admin UI or"
+    echo "       PATCH /api/v1/components/${COMPONENT}; the auth service creates the tree."
+    exit 1
+  fi
+  [ -w "${target}" ] || { echo "ERROR: target dir not writable: ${target}"; exit 1; }
+done
 
-"${SCRIPT_DIR}/rebuild-metadata.sh" "${ROOT}" "${COMPONENT}" "${SERIES}" "${OS_ARCH}"
+FILENAME="$(basename "${RPM_FILE}")"
+FIRST=""
+for os_arch in "$@"; do
+  target="${ROOT}/rpm/${COMPONENT}/${SERIES}/${os_arch}"
+  dest="${target}/${FILENAME}"
+  if [ -z "${FIRST}" ]; then
+    echo "Copying ${FILENAME} to ${target}/"
+    cp "${RPM_FILE}" "${dest}"
+    FIRST="${dest}"
+  else
+    rm -f "${dest}"
+    if ln "${FIRST}" "${dest}" 2>/dev/null; then
+      echo "Linking ${FILENAME} into ${target}/"
+    else
+      echo "WARN: hardlink failed, copying ${FILENAME} into ${target}/"
+      cp "${FIRST}" "${dest}"
+    fi
+  fi
+  "${SCRIPT_DIR}/rebuild-metadata.sh" "${ROOT}" "${COMPONENT}" "${SERIES}" "${os_arch}"
+done

--- a/rpm/scripts/rebuild-metadata.sh
+++ b/rpm/scripts/rebuild-metadata.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
 # rebuild-metadata.sh — runs createrepo_c for one component/series/os-arch tree
 # Usage: rebuild-metadata.sh <root> <component> <series> <os-arch>
 #
-# Serialisation is enforced externally by the GHA concurrency group:
-#   rpm-publish-${component}-${os}  (cancel-in-progress: false)
-# Do NOT add file locks here — the lock must cover the entire publish operation
-# (copy + rebuild), not just the rebuild step.
+# Serialisation is enforced externally by the GHA concurrency group of the
+# calling workflow (cancel-in-progress: false). Do NOT add file locks here:
+# the lock must cover the entire publish operation (copy + rebuild), not just
+# the rebuild step.
 set -euo pipefail
 
 ROOT="${1:?RPM tree root required (e.g. /usr/share/nginx/html)}"
@@ -13,9 +16,19 @@ COMPONENT="${2:?component required}"
 SERIES="${3:?series required}"
 OS_ARCH="${4:?os-arch required}"
 
+SEGMENT_RE='^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+for value in "${COMPONENT}" "${SERIES}" "${OS_ARCH}"; do
+  if ! [[ "${value}" =~ ${SEGMENT_RE} ]] || [[ "${value}" == *..* ]]; then
+    echo "ERROR: invalid path segment: ${value}"
+    exit 1
+  fi
+done
+
 TARGET="${ROOT}/rpm/${COMPONENT}/${SERIES}/${OS_ARCH}"
 [ -d "${TARGET}" ] || { echo "ERROR: directory not found: ${TARGET}"; exit 1; }
 
 echo "Rebuilding RPM metadata for ${TARGET}..."
-createrepo_c --update --workers 4 "${TARGET}"
+# gzip metadata: createrepo_c 1.x defaults to zstd, which older dnf/yum
+# clients (EL8) cannot read.
+createrepo_c --update --workers 4 --general-compress-type gz "${TARGET}"
 echo "Done."

--- a/scripts/stage-artifact.sh
+++ b/scripts/stage-artifact.sh
@@ -21,9 +21,11 @@ if ! [[ "$COMPONENT" =~ ^[a-zA-Z0-9_-]+$ ]]; then
   echo "       Allowed: letters, digits, hyphens, underscores"
   exit 1
 fi
-SERIES="${2:?series required (e.g. 2025)}"
-if ! [[ "$SERIES" =~ ^[0-9]{4}$ ]]; then
-  echo "ERROR: series must be a 4-digit number (got: ${SERIES})"
+SERIES="${2:?series required (e.g. 2025 or 38)}"
+# Any single path segment, same rule as the component API. A series is a
+# label (an LTS year, a major version), not necessarily a year.
+if ! [[ "$SERIES" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]] || [[ "$SERIES" == *..* ]]; then
+  echo "ERROR: series must be a single path segment of letters, digits, dot, hyphen, underscore (got: ${SERIES})"
   exit 1
 fi
 FORMAT="${3:?format required (rpm|deb|oci)}"

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -17,6 +17,7 @@ const sidebars: SidebarsConfig = {
         'ops/operator-onboarding',
         'ops/admin-migration-runbook',
         'ops/release-runbook',
+        'ops/upstream-release-dispatch',
         'ops/restore-keystore',
         'ops/manual-test-plan',
         'ops/troubleshooting',

--- a/tests/rpm/add-package-test.sh
+++ b/tests/rpm/add-package-test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# add-package-test.sh — publish a fixture RPM into two OS targets inside the
+# rpm image and check that the bytes are stored once and each target has its
+# own repodata. Needs Docker. Run via `make test-rpm-publish`.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+IMAGE="packyard-rpm-test:local"
+NFPM_IMAGE="goreleaser/nfpm:v2.44.0"
+trap 'rm -rf "${WORK}"' EXIT
+
+echo "== build rpm image"
+docker build -q -t "${IMAGE}" "${REPO_ROOT}/rpm" > /dev/null
+
+echo "== build fixture RPM with nfpm"
+cp "${REPO_ROOT}/tests/rpm/fixtures/nfpm.yaml" "${WORK}/"
+echo "hello" > "${WORK}/hello.txt"
+docker run --rm -v "${WORK}:/work" -w /work "${NFPM_IMAGE}" package --packager rpm --target /work/ > /dev/null
+FIXTURE="$(ls "${WORK}"/*.rpm)"
+echo "   $(basename "${FIXTURE}")"
+
+# The tree is normally created by the auth service from the component record.
+# Simulate that: provision el9 and el10, leave el8 absent.
+echo "== publish into el9 and el10"
+docker run --rm \
+  -v "${WORK}:/stage:ro" \
+  --entrypoint /bin/bash \
+  "${IMAGE}" -c '
+    set -euo pipefail
+    ROOT=/usr/share/nginx/html
+    mkdir -p "${ROOT}/rpm/bluebird/38/el9-x86_64" "${ROOT}/rpm/bluebird/38/el10-x86_64"
+    /scripts/add-package.sh /stage/*.rpm bluebird 38 el9-x86_64 el10-x86_64 > /dev/null
+
+    f9="$(ls "${ROOT}"/rpm/bluebird/38/el9-x86_64/*.rpm)"
+    f10="$(ls "${ROOT}"/rpm/bluebird/38/el10-x86_64/*.rpm)"
+    i9="$(stat -c %i "${f9}")"; i10="$(stat -c %i "${f10}")"
+    [ "${i9}" = "${i10}" ] || { echo "FAIL: expected one inode, got ${i9} and ${i10}"; exit 1; }
+    echo "   one inode: ${i9}"
+
+    for os in el9-x86_64 el10-x86_64; do
+      [ -f "${ROOT}/rpm/bluebird/38/${os}/repodata/repomd.xml" ] || { echo "FAIL: no repodata in ${os}"; exit 1; }
+      grep -q "packyard-fixture" "${ROOT}/rpm/bluebird/38/${os}/repodata/"*primary.xml* 2>/dev/null \
+        || zcat "${ROOT}/rpm/bluebird/38/${os}/repodata/"*primary.xml.gz | grep -q packyard-fixture \
+        || { echo "FAIL: ${os} primary.xml does not list the package"; exit 1; }
+      echo "   ${os}: repodata lists packyard-fixture"
+    done
+
+    echo "== missing target is refused before publishing"
+    if /scripts/add-package.sh /stage/*.rpm bluebird 38 el9-x86_64 el8-x86_64 > /tmp/out 2>&1; then
+      echo "FAIL: el8 target should have been refused"; exit 1
+    fi
+    grep -q "rpm_os_families" /tmp/out || { echo "FAIL: error should point at rpm_os_families"; cat /tmp/out; exit 1; }
+    echo "   refused with the rpm_os_families hint"
+
+    echo "== traversal is refused"
+    if /scripts/add-package.sh /stage/*.rpm bluebird ../38 el9-x86_64 > /dev/null 2>&1; then
+      echo "FAIL: ../38 should have been refused"; exit 1
+    fi
+    echo "   ../38 refused"
+
+    echo "== series 38 accepted, series 2025 still accepted"
+    mkdir -p "${ROOT}/rpm/core/2025/el9-x86_64"
+    /scripts/add-package.sh /stage/*.rpm core 2025 el9-x86_64 > /dev/null
+    echo "   ok"
+  '
+echo "PASS"

--- a/tests/rpm/fixtures/nfpm.yaml
+++ b/tests/rpm/fixtures/nfpm.yaml
@@ -1,0 +1,16 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Minimal package definition used by tests/rpm/add-package-test.sh to build a
+# fixture RPM with nfpm. The content is one text file; only the RPM envelope
+# matters to createrepo_c.
+name: packyard-fixture
+arch: x86_64
+version: 1.0.0
+release: 1
+maintainer: Packyard tests <noreply@no42.org>
+description: Fixture package for Packyard RPM publishing tests
+license: GPL-3.0-or-later
+contents:
+  - src: ./hello.txt
+    dst: /usr/share/packyard-fixture/hello.txt


### PR DESCRIPTION
## Summary
Adds `promote-release.yml`: one dispatch ingests an upstream GitHub Release into a component and series. Assets and images are pulled from public sources and verified against the upstream cosign identity before Packyard signs them with its own GPG key and workflow identity. The upstream repository needs only a token that can start this workflow.

Supporting changes, one commit each:
- **RPM publishing inside the rpm container.** The image moves to the Debian trixie nginx base with `createrepo-c` (Alpine only has it in edge/testing) and ships the publish scripts. `add-package.sh` publishes one file into several os-arch targets via hardlinks. Series is any path-safe label, so `38` works. New `make test-rpm-publish`. The aptly image gains `bzip2`, without which `aptly publish` fails.
- **Host contract.** The promotion workflows read the checkout path from the `DEPLOY_DIR` repository variable, validate their inputs, and the RPM workflow uses the container path. The deployment guide documents `DEPLOY_DIR`, `COMPOSE_PROJECT_NAME` and a `deploy`-readable `.env`.
- **Live signing-key check.** The repo copy of `lts.asc` is a placeholder by design, so the old check could never pass here. Workflows now compare the `GPG_KEY_ID` fingerprint with the key the host serves.
- **Docs.** Pipeline reference, release runbook, subscriber guide, and a new upstream-dispatch guide.

Closes #205

## Verification
- `make test-rpm-publish` builds the image, publishes a fixture RPM into two targets, and asserts one inode, two repodata sets, the missing-target error and traversal rejection.
- Spikes recorded in the design: `crane copy` into Zot 2.1.2 keeps the index digest; `cosign verify` passes for the Bluebird release identity and its `SHA256SUMS` signature; one Aptly snapshot publishes to four distributions with one pool inode.
- actionlint, zizmor and `make lint-workflows` clean; `make docs-build` passes.
- The workflow itself runs only against the production host, so its first end-to-end run is the manual dispatch for v38.1.0 planned in the rollout.

## Rollout after merge
Needs a Packyard release so the rpm image exists under an immutable tag, then `DEPLOY_DIR`, `COMPOSE_PROJECT_NAME`, the `.env` mode change, and the `bluebird` component's RPM settings on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)