### PR TITLE
ci(promote): accept a long key id as GPG_KEY_ID in the served-key check

### DIFF
--- a/.github/workflows/promote-deb.yml
+++ b/.github/workflows/promote-deb.yml
@@ -60,8 +60,11 @@ jobs:
         run: |
           served=$(curl -fsSL "https://${HOST}/gpg/lts.asc" | gpg --show-keys --with-colons | awk -F: '/^fpr/{print $10}')
           [ -n "$served" ] || { echo "ERROR: https://${HOST}/gpg/lts.asc is not a GPG public key"; exit 1; }
-          want=$(tr '[:lower:]' '[:upper:]' <<< "${GPG_KEY_ID}")
-          grep -qx "${want}" <<< "${served}" \
+          # GPG_KEY_ID may be the full 40-hex fingerprint or a 16-hex long key id,
+          # which is the fingerprint's suffix. Anything shorter is too weak to match on.
+          want=$(tr '[:lower:]' '[:upper:]' <<< "${GPG_KEY_ID}" | tr -d ' ')
+          [[ "${want}" =~ ^[0-9A-F]{16,40}$ ]] || { echo "ERROR: GPG_KEY_ID must be a 16 to 40 character hex key id or fingerprint"; exit 1; }
+          grep -qE "${want}\$" <<< "${served}" \
             || { echo "ERROR: GPG_KEY_ID does not match any fingerprint served at https://${HOST}/gpg/lts.asc"; exit 1; }
           echo "signing key ${want} is served by the host"
 

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -173,8 +173,11 @@ jobs:
         run: |
           served=$(curl -fsSL "https://${HOST}/gpg/lts.asc" | gpg --show-keys --with-colons | awk -F: '/^fpr/{print $10}')
           [ -n "$served" ] || { echo "ERROR: https://${HOST}/gpg/lts.asc is not a GPG public key"; exit 1; }
-          want=$(tr '[:lower:]' '[:upper:]' <<< "${GPG_KEY_ID}")
-          grep -qx "${want}" <<< "${served}" \
+          # GPG_KEY_ID may be the full 40-hex fingerprint or a 16-hex long key id,
+          # which is the fingerprint's suffix. Anything shorter is too weak to match on.
+          want=$(tr '[:lower:]' '[:upper:]' <<< "${GPG_KEY_ID}" | tr -d ' ')
+          [[ "${want}" =~ ^[0-9A-F]{16,40}$ ]] || { echo "ERROR: GPG_KEY_ID must be a 16 to 40 character hex key id or fingerprint"; exit 1; }
+          grep -qE "${want}\$" <<< "${served}" \
             || { echo "ERROR: GPG_KEY_ID does not match any fingerprint served at https://${HOST}/gpg/lts.asc"; exit 1; }
           echo "signing key ${want} is served by the host"
 

--- a/.github/workflows/promote-rpm.yml
+++ b/.github/workflows/promote-rpm.yml
@@ -60,8 +60,11 @@ jobs:
         run: |
           served=$(curl -fsSL "https://${HOST}/gpg/lts.asc" | gpg --show-keys --with-colons | awk -F: '/^fpr/{print $10}')
           [ -n "$served" ] || { echo "ERROR: https://${HOST}/gpg/lts.asc is not a GPG public key"; exit 1; }
-          want=$(tr '[:lower:]' '[:upper:]' <<< "${GPG_KEY_ID}")
-          grep -qx "${want}" <<< "${served}" \
+          # GPG_KEY_ID may be the full 40-hex fingerprint or a 16-hex long key id,
+          # which is the fingerprint's suffix. Anything shorter is too weak to match on.
+          want=$(tr '[:lower:]' '[:upper:]' <<< "${GPG_KEY_ID}" | tr -d ' ')
+          [[ "${want}" =~ ^[0-9A-F]{16,40}$ ]] || { echo "ERROR: GPG_KEY_ID must be a 16 to 40 character hex key id or fingerprint"; exit 1; }
+          grep -qE "${want}\$" <<< "${served}" \
             || { echo "ERROR: GPG_KEY_ID does not match any fingerprint served at https://${HOST}/gpg/lts.asc"; exit 1; }
           echo "signing key ${want} is served by the host"
 


### PR DESCRIPTION
The served-key check in the three promotion workflows compared `GPG_KEY_ID` against full 40-character fingerprints only. A 16-character long key id is the fingerprint's suffix and is what `gpg` prints by default, so the check now matches on the suffix and rejects anything shorter than 16 hex characters.

Refs #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)