### PR TITLE
fix(rpm): let capability-less root writers provision and publish the RPM tree

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -239,15 +239,16 @@ jobs:
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "rm -rf /tmp/rpm-stage && mkdir -p /tmp/rpm-stage"
           scp ./release/*.rpm deploy@${{ secrets.HOST }}:/tmp/rpm-stage/
-          # The rpm service runs as uid 101 but the auth service creates the
-          # component tree as root, so publish as root inside the container.
+          # The tree is group 101, setgid and group-writable; the container has
+          # no capabilities, so publish as root with group 101 to write into
+          # directories created by either the auth service or the rpm image.
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
             set -euo pipefail
             C='${DEPLOY_DIR}/compose.yml'
             RPM_ID=\$(docker compose -f \"\$C\" ps -q rpm)
             docker cp /tmp/rpm-stage/ \"\${RPM_ID}:/tmp/\"
-            docker compose -f \"\$C\" exec -T --user 0 rpm bash -c '
+            docker compose -f \"\$C\" exec -T --user 0:101 rpm bash -c '
               set -euo pipefail
               for f in /tmp/rpm-stage/*.rpm; do
                 /scripts/add-package.sh \"\$f\" \"${COMPONENT}\" \"${SERIES}\" ${RPM_TARGETS}
@@ -356,7 +357,7 @@ jobs:
           ssh deploy@${{ secrets.HOST }} "
             C='${DEPLOY_DIR}/compose.yml'
             rm -rf /tmp/rpm-stage /tmp/deb-stage
-            docker compose -f \"\$C\" exec -T --user 0 rpm rm -rf /tmp/rpm-stage 2>/dev/null || true
+            docker compose -f \"\$C\" exec -T --user 0:101 rpm rm -rf /tmp/rpm-stage 2>/dev/null || true
             docker compose -f \"\$C\" exec -T aptly rm -rf /tmp/deb-stage /tmp/gpg-pass /root/.gnupg 2>/dev/null || true
           " 2>/dev/null || true
           pkill -f 'ssh -fN -L 5000' || true

--- a/.github/workflows/promote-rpm.yml
+++ b/.github/workflows/promote-rpm.yml
@@ -165,12 +165,12 @@ jobs:
           SERIES: ${{ inputs.series }}
           OS: ${{ inputs.os }}
         run: |
-          # createrepo_c and the publish scripts live in the rpm image. The
-          # service runs as uid 101 but the auth service creates component
-          # directories as root, so publish as root inside the container.
+          # createrepo_c and the publish scripts live in the rpm image. The tree
+          # is group 101, setgid and group-writable; the container has no
+          # capabilities, so publish as root with group 101.
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
-            docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T --user 0 rpm bash -c '
+            docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T --user 0:101 rpm bash -c '
               set -euo pipefail
               for f in /tmp/rpm-stage/*.rpm; do
                 /scripts/add-package.sh \"\$f\" \"${COMPONENT}\" \"${SERIES}\" \"${OS}\"
@@ -187,7 +187,7 @@ jobs:
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
             rm -rf /tmp/rpm-stage
-            docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T --user 0 rpm \
+            docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T --user 0:101 rpm \
               rm -rf /tmp/rpm-stage 2>/dev/null || true
           " 2>/dev/null || true
           # Close SSH tunnel

--- a/compose.yml
+++ b/compose.yml
@@ -37,6 +37,12 @@ services:
     security_opt:
       - no-new-privileges:true
     read_only: true
+    # The RPM tree in rpm-data belongs to group 101 (nginx), setgid and
+    # group-writable (rpm/scripts/init-rpm-tree.sh). auth runs as root with
+    # every capability dropped, so it needs that group to create component
+    # directories there.
+    group_add:
+      - "101"
     tmpfs:
       - /tmp                    # Go runtime scratch
     expose:

--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -257,6 +257,8 @@ chmod 640 /path/to/checkout/.env
 
 The RPM tree lives in the `rpm-data` volume and is written from inside the `rpm` container, which ships `createrepo_c`. The host needs no RPM tooling.
 
+Three processes write that tree and none of them has capabilities: nginx as uid 101, the auth service as root (it creates component directories from the component record), and the promotion exec as root. The rpm image's start script therefore makes the tree group 101, setgid and group-writable, `compose.yml` gives the auth service `group_add: ["101"]`, and the promotion exec runs as `0:101`. A volume created by an image older than 0.5.1 is normalised on the next start of the `rpm` container.
+
 ---
 
 ## 6. Pre-Deployment Checklist

--- a/rpm/scripts/init-rpm-tree.sh
+++ b/rpm/scripts/init-rpm-tree.sh
@@ -1,21 +1,25 @@
 #!/bin/sh
-# init-rpm-tree.sh — creates the series-versioned, per-OS RPM directory tree on first start
-# Runs via /docker-entrypoint.d/ before nginx starts (nginx:alpine entrypoint pattern)
-# Idempotent: mkdir -p is safe to run on every container start
-
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# init-rpm-tree.sh — prepare the RPM tree root on container start.
+#
+# Runs as the nginx user (uid 101) from /docker-entrypoint.d. The tree is
+# shared with two other writers that run as root with every capability
+# dropped: the auth service, which creates component directories from the
+# component record, and the promotion exec that publishes packages. Root
+# without CAP_DAC_OVERRIDE is bound by ordinary permissions, so the tree is
+# owned by group 101, setgid so new entries inherit the group, and
+# group-writable. auth joins group 101 via group_add in compose.yml; the
+# promotion exec runs as 0:101.
+#
+# Component and series directories are NOT created here. The component
+# record owns them (POST /api/v1/components).
 set -e
-
-COMPONENTS="core minion sentinel"
-SERIES="2025"
-OS_TARGETS="el8-x86_64 el9-x86_64 el10-x86_64 centos10-x86_64"
 ROOT="/usr/share/nginx/html"
-
-for component in $COMPONENTS; do
-    for series in $SERIES; do
-        for os in $OS_TARGETS; do
-            mkdir -p "${ROOT}/rpm/${component}/${series}/${os}"
-        done
-    done
-done
-
-echo "RPM directory tree initialised under ${ROOT}/rpm/"
+mkdir -p "${ROOT}/rpm"
+chmod 2775 "${ROOT}/rpm"
+# Normalise directories this user owns from earlier image versions, which
+# created them 0755 and therefore unwritable for the other writers.
+find "${ROOT}/rpm" -type d -user "$(id -u)" ! -perm 2775 -exec chmod 2775 {} + 2>/dev/null || true
+echo "RPM tree root ready at ${ROOT}/rpm/ (group $(id -g), setgid, group-writable)"

--- a/tests/rpm/add-package-test.sh
+++ b/tests/rpm/add-package-test.sh
@@ -3,7 +3,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # add-package-test.sh — publish a fixture RPM into two OS targets inside the
-# rpm image and check that the bytes are stored once and each target has its
+# rpm image under the same conditions as production: the container runs as
+# uid 101 with every capability dropped and a read-only root filesystem, the
+# component directories are created by a capability-less root:101 process
+# (what the auth service is, with group_add), and the publish exec runs as
+# root:101. Checks that the bytes are stored once and each target has its
 # own repodata. Needs Docker. Run via `make test-rpm-publish`.
 set -euo pipefail
 
@@ -11,7 +15,10 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORK="$(mktemp -d)"
 IMAGE="packyard-rpm-test:local"
 NFPM_IMAGE="goreleaser/nfpm:v2.44.0"
-trap 'rm -rf "${WORK}"' EXIT
+NAME="packyard-rpm-test-$$"
+VOL="${NAME}-data"
+cleanup() { docker rm -f "${NAME}" >/dev/null 2>&1 || true; docker volume rm "${VOL}" >/dev/null 2>&1 || true; rm -rf "${WORK}"; }
+trap cleanup EXIT
 
 echo "== build rpm image"
 docker build -q -t "${IMAGE}" "${REPO_ROOT}/rpm" > /dev/null
@@ -20,51 +27,72 @@ echo "== build fixture RPM with nfpm"
 cp "${REPO_ROOT}/tests/rpm/fixtures/nfpm.yaml" "${WORK}/"
 echo "hello" > "${WORK}/hello.txt"
 docker run --rm -v "${WORK}:/work" -w /work "${NFPM_IMAGE}" package --packager rpm --target /work/ > /dev/null
-FIXTURE="$(ls "${WORK}"/*.rpm)"
-echo "   $(basename "${FIXTURE}")"
+echo "   $(ls "${WORK}"/*.rpm | xargs -n1 basename)"
 
-# The tree is normally created by the auth service from the component record.
-# Simulate that: provision el9 and el10, leave el8 absent.
-echo "== publish into el9 and el10"
-docker run --rm \
-  -v "${WORK}:/stage:ro" \
-  --entrypoint /bin/bash \
-  "${IMAGE}" -c '
-    set -euo pipefail
-    ROOT=/usr/share/nginx/html
-    mkdir -p "${ROOT}/rpm/bluebird/38/el9-x86_64" "${ROOT}/rpm/bluebird/38/el10-x86_64"
-    /scripts/add-package.sh /stage/*.rpm bluebird 38 el9-x86_64 el10-x86_64 > /dev/null
+echo "== start the rpm container hardened like compose.yml"
+docker volume create "${VOL}" > /dev/null
+docker run -d --name "${NAME}" \
+  --user 101:101 --cap-drop ALL --security-opt no-new-privileges:true --read-only \
+  --tmpfs /run:uid=101,gid=101 --tmpfs /var/cache/nginx:uid=101,gid=101 --tmpfs /tmp \
+  -v "${VOL}:/usr/share/nginx/html" -v "${WORK}:/stage:ro" \
+  "${IMAGE}" > /dev/null
+sleep 2
+docker exec "${NAME}" sh -c 'stat -c "%u:%g %a" /usr/share/nginx/html/rpm' | grep -q '^101:101 2775$' \
+  || { echo "FAIL: tree root is not 101:101 2775"; docker exec "${NAME}" stat /usr/share/nginx/html/rpm; exit 1; }
+echo "   tree root is 101:101 2775"
 
-    f9="$(ls "${ROOT}"/rpm/bluebird/38/el9-x86_64/*.rpm)"
-    f10="$(ls "${ROOT}"/rpm/bluebird/38/el10-x86_64/*.rpm)"
-    i9="$(stat -c %i "${f9}")"; i10="$(stat -c %i "${f10}")"
-    [ "${i9}" = "${i10}" ] || { echo "FAIL: expected one inode, got ${i9} and ${i10}"; exit 1; }
-    echo "   one inode: ${i9}"
+echo "== provision component directories as the auth service would (root:101, no capabilities)"
+docker exec --user 0:101 "${NAME}" sh -c '
+  set -e
+  mkdir -p /usr/share/nginx/html/rpm/bluebird/38/el9-x86_64 /usr/share/nginx/html/rpm/bluebird/38/el10-x86_64
+  stat -c "%u:%g %a" /usr/share/nginx/html/rpm/bluebird/38/el9-x86_64
+' | grep -q '^0:101 2755$' || { echo "FAIL: auth-style mkdir did not yield root:101 setgid dirs"; exit 1; }
+echo "   created as 0:101 2755 (setgid inherited)"
 
-    for os in el9-x86_64 el10-x86_64; do
-      [ -f "${ROOT}/rpm/bluebird/38/${os}/repodata/repomd.xml" ] || { echo "FAIL: no repodata in ${os}"; exit 1; }
-      grep -q "packyard-fixture" "${ROOT}/rpm/bluebird/38/${os}/repodata/"*primary.xml* 2>/dev/null \
-        || zcat "${ROOT}/rpm/bluebird/38/${os}/repodata/"*primary.xml.gz | grep -q packyard-fixture \
-        || { echo "FAIL: ${os} primary.xml does not list the package"; exit 1; }
-      echo "   ${os}: repodata lists packyard-fixture"
-    done
+echo "== publish into el9 and el10 as root:101"
+docker exec --user 0:101 "${NAME}" bash -c '
+  set -euo pipefail
+  ROOT=/usr/share/nginx/html
+  /scripts/add-package.sh /stage/*.rpm bluebird 38 el9-x86_64 el10-x86_64 > /dev/null
 
-    echo "== missing target is refused before publishing"
-    if /scripts/add-package.sh /stage/*.rpm bluebird 38 el9-x86_64 el8-x86_64 > /tmp/out 2>&1; then
-      echo "FAIL: el8 target should have been refused"; exit 1
-    fi
-    grep -q "rpm_os_families" /tmp/out || { echo "FAIL: error should point at rpm_os_families"; cat /tmp/out; exit 1; }
-    echo "   refused with the rpm_os_families hint"
+  f9="$(ls "${ROOT}"/rpm/bluebird/38/el9-x86_64/*.rpm)"
+  f10="$(ls "${ROOT}"/rpm/bluebird/38/el10-x86_64/*.rpm)"
+  i9="$(stat -c %i "${f9}")"; i10="$(stat -c %i "${f10}")"
+  [ "${i9}" = "${i10}" ] || { echo "FAIL: expected one inode, got ${i9} and ${i10}"; exit 1; }
+  echo "   one inode: ${i9}"
 
-    echo "== traversal is refused"
-    if /scripts/add-package.sh /stage/*.rpm bluebird ../38 el9-x86_64 > /dev/null 2>&1; then
-      echo "FAIL: ../38 should have been refused"; exit 1
-    fi
-    echo "   ../38 refused"
+  for os in el9-x86_64 el10-x86_64; do
+    [ -f "${ROOT}/rpm/bluebird/38/${os}/repodata/repomd.xml" ] || { echo "FAIL: no repodata in ${os}"; exit 1; }
+    zcat "${ROOT}/rpm/bluebird/38/${os}/repodata/"*primary.xml.gz | grep -q packyard-fixture \
+      || { echo "FAIL: ${os} primary.xml does not list the package"; exit 1; }
+    echo "   ${os}: repodata lists packyard-fixture"
+  done
 
-    echo "== series 38 accepted, series 2025 still accepted"
-    mkdir -p "${ROOT}/rpm/core/2025/el9-x86_64"
-    /scripts/add-package.sh /stage/*.rpm core 2025 el9-x86_64 > /dev/null
-    echo "   ok"
-  '
+  echo "== nginx (uid 101) can read what root:101 published"
+  stat -c "%a" "${ROOT}/rpm/bluebird/38/el9-x86_64/repodata/repomd.xml" | grep -qE "^6[0-9][4-7]$" \
+    || { echo "FAIL: repomd.xml is not world-readable"; exit 1; }
+  echo "   repodata world-readable"
+
+  echo "== missing target is refused before publishing"
+  if /scripts/add-package.sh /stage/*.rpm bluebird 38 el9-x86_64 el8-x86_64 > /tmp/out 2>&1; then
+    echo "FAIL: el8 target should have been refused"; exit 1
+  fi
+  grep -q "rpm_os_families" /tmp/out || { echo "FAIL: error should point at rpm_os_families"; cat /tmp/out; exit 1; }
+  echo "   refused with the rpm_os_families hint"
+
+  echo "== traversal is refused"
+  if /scripts/add-package.sh /stage/*.rpm bluebird ../38 el9-x86_64 > /dev/null 2>&1; then
+    echo "FAIL: ../38 should have been refused"; exit 1
+  fi
+  echo "   ../38 refused"
+
+  echo "== a year series still works"
+  mkdir -p "${ROOT}/rpm/core/2025/el9-x86_64"
+  /scripts/add-package.sh /stage/*.rpm core 2025 el9-x86_64 > /dev/null
+  echo "   ok"
+'
+echo "== nginx serves the published repodata"
+docker exec "${NAME}" sh -c 'curl -sf -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8080/rpm/bluebird/38/el10-x86_64/repodata/repomd.xml' | grep -qx 200 \
+  || { echo "FAIL: nginx does not serve repomd.xml"; exit 1; }
+echo "   200 from nginx"
 echo "PASS"


### PR DESCRIPTION
## Summary
Creating a component with RPM settings failed on pkg.onms.eu with `RPM_INIT_FAILED: mkdir /data/rpm/rpm/bluebird: permission denied`. The auth service runs as root with every capability dropped, so it cannot write into the tree the rpm image owns as uid 101. CI never caught it because `init-rpm-tree.sh` pre-created exactly the directories the seed script asks for.

- The rpm image's start script makes the tree root group 101, setgid and group-writable, normalises directories from older images, and stops hard-coding component directories. The component record owns them.
- `compose.yml` gives the auth service `group_add: ["101"]`.
- `promote-rpm.yml` and `promote-release.yml` publish as `0:101`.
- The deployment guide explains the three writers and the permission model.

## Verification
`make test-rpm-publish` now starts the rpm container as uid 101 with `--cap-drop ALL`, a read-only root and the compose tmpfs mounts, provisions directories as a capability-less `0:101` process (what auth is with `group_add`), publishes as `0:101`, asserts one inode across two targets, world-readable repodata, and a 200 from nginx for the published `repomd.xml`. Passes locally. The same layout was applied by hand on pkg.onms.eu and verified there.

The integration workflow now exercises the real path: with no pre-created directories, the seed's component creation makes auth provision them.

Refs #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)