### PR TITLE
ci(promote): drop dpkg-sig; sign DEB repositories in the aptly container

### DIFF
--- a/.github/workflows/promote-deb.yml
+++ b/.github/workflows/promote-deb.yml
@@ -116,20 +116,7 @@ jobs:
             echo "OK: $file"
           done
 
-      - name: Import GPG key (ephemeral) and sign DEBs
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
-        run: |
-          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
-          gpg --list-secret-keys "${GPG_KEY_ID}"
-          for deb in ./staging/*.deb; do
-            [ -f "$deb" ] || { echo "No DEB files found in staging/"; exit 1; }
-            dpkg-sig --sign builder -k "${GPG_KEY_ID}" "$deb"
-            echo "Signed: $(basename "$deb")"
-          done
-
-      - name: Upload signed DEBs to host and copy into aptly container
+      - name: Upload DEBs to host and copy into aptly container
         run: |
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "rm -rf /tmp/deb-stage && mkdir -p /tmp/deb-stage"
@@ -139,6 +126,21 @@ jobs:
             APTLY_ID=\$(docker compose -f '${DEPLOY_DIR}/compose.yml' ps -q aptly)
             docker cp /tmp/deb-stage/ \"\${APTLY_ID}:/tmp/\"
           "
+
+      - name: Import GPG key into the aptly container
+        # apt verifies the repository's InRelease, not individual packages.
+        # aptly signs it inside its container: import the key into the
+        # container's tmpfs home and hand it the passphrase through a file.
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          printf '%s\n' "${GPG_PRIVATE_KEY}" | ssh deploy@${{ secrets.HOST }} \
+            "docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly gpg --batch --quiet --import"
+          # shellcheck disable=SC2029  # client-side expansion is intended
+          printf '%s\n' "${GPG_PASSPHRASE}" | ssh deploy@${{ secrets.HOST }} \
+            "docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly sh -c 'umask 077; cat > /tmp/gpg-pass'"
 
       - name: Create Aptly snapshot on host
         env:
@@ -161,10 +163,12 @@ jobs:
           COMPONENT: ${{ inputs.component }}
           SERIES: ${{ inputs.series }}
           DISTRO: ${{ inputs.distro }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
         run: |
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} \
-            "docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly \
+            "docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T \
+              -e GPG_KEY_ID='${GPG_KEY_ID}' -e GPG_PASSPHRASE_FILE=/tmp/gpg-pass aptly \
               /scripts/publish-snapshot.sh \
               '${SNAPSHOT_NAME}' '${COMPONENT}' '${SERIES}' '${DISTRO}'"
 
@@ -200,6 +204,6 @@ jobs:
           ssh deploy@${{ secrets.HOST }} "
             rm -rf /tmp/deb-stage
             docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly \
-              rm -rf /tmp/deb-stage 2>/dev/null || true
+              rm -rf /tmp/deb-stage /tmp/gpg-pass /root/.gnupg 2>/dev/null || true
           " 2>/dev/null || true
           pkill -f 'ssh -fN -L 9000' || true

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -116,11 +116,12 @@ jobs:
           echo "  images:      ${IMAGES:-none}"
 
       - name: Install signing tools
+        # rpmsign for the RPMs. DEBs are not signed individually: apt verifies
+        # the repository's InRelease, which aptly signs inside its container.
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends rpm dpkg-sig
+          sudo apt-get install -y -qq --no-install-recommends rpm
           rpmsign --version
-          dpkg-sig --version | head -1
 
       - name: Install crane
         env:
@@ -208,7 +209,7 @@ jobs:
           done
           sha256sum --check --strict --ignore-missing SHA256SUMS
 
-      - name: Import GPG key (ephemeral) and sign packages
+      - name: Import GPG key (ephemeral) and sign RPMs
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
@@ -218,17 +219,12 @@ jobs:
           gpg --list-secret-keys "${GPG_KEY_ID}"
           # Pre-cache the passphrase in gpg-agent via loopback pinentry. A wrong
           # passphrase fails here with gpg's own message rather than later
-          # from rpmsign or dpkg-sig. Passphrase on fd 3; stdin is the empty
-          # message to sign.
+          # from rpmsign. Passphrase on fd 3; stdin is the empty message to sign.
           gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 -u "${GPG_KEY_ID}" \
             --sign --output /dev/null - < /dev/null 3< <(printf '%s\n' "${GPG_PASSPHRASE}")
           for rpm in ./release/*.rpm; do
             rpmsign --addsign --define "_gpg_name ${GPG_KEY_ID}" "$rpm"
             echo "Signed: $(basename "$rpm")"
-          done
-          for deb in ./release/*.deb; do
-            dpkg-sig --sign builder -k "${GPG_KEY_ID}" "$deb"
-            echo "Signed: $(basename "$deb")"
           done
 
       - name: Publish RPMs inside the rpm container

--- a/docs/reference/promotion-pipeline.md
+++ b/docs/reference/promotion-pipeline.md
@@ -22,7 +22,7 @@ upstream repo, tag v38.1.0                     no42-org/packyard, promote-releas
 GitHub Release                                 1. validate inputs, preflight the host over SSH
   bbo-core-38.1.0-761.x86_64.rpm   ──────────► 2. gh release download, cosign verify-blob SHA256SUMS,
   bbo-core_38.1.0-761_amd64.deb                   sha256sum --check
-  SHA256SUMS, SHA256SUMS.sig/.pem               3. rpmsign / dpkg-sig with the Packyard GPG key
+  SHA256SUMS, SHA256SUMS.sig/.pem               3. rpmsign with the Packyard GPG key
 quay.io/bluebird/core:38.1.0      ──────────► 4. rpm container:  add-package.sh into every rpm_target
   (cosign-signed)                              5. aptly container: one snapshot, published per deb_distro
                                                6. cosign verify upstream, crane copy into Zot as
@@ -74,7 +74,7 @@ The step-by-step procedure is in the [release runbook](../ops/release-runbook.md
 
 ## What every promotion has in common
 
-- **Packyard signs, upstream signatures are only checked.** RPMs and DEBs carry the Packyard GPG key. Images are signed keylessly by the promoting workflow's GitHub OIDC identity. Subscribers verify one identity for everything on the host.
+- **Packyard signs, upstream signatures are only checked.** RPMs carry the Packyard GPG key; DEB repositories carry it on their `InRelease`, which is what apt verifies (individual `.deb` files are not signed, apt never checks those). Images are signed keylessly by the promoting workflow's GitHub OIDC identity. Subscribers verify one identity for everything on the host.
 - **The GPG key must be the served key.** Before signing, the workflows compare the `GPG_KEY_ID` fingerprint with the key served at `https://<host>/gpg/lts.asc`. The copy of `lts.asc` in this repository is a placeholder.
 - **Publishing happens inside the service containers.** The rpm image ships `createrepo_c` and the publishing scripts, Aptly runs in its own container. The host needs Docker and the `deploy` user, nothing else. See [Production deployment §5](../ops/production-deployment.md#5-creating-the-deploy-user).
 - **One copy per package.** A package published into several RPM targets is hardlinked between the target directories. Aptly stores each `.deb` once in its pool no matter how many distributions publish it.


### PR DESCRIPTION
The first `promote-release` run failed at tool install: `dpkg-sig` is no longer packaged on Ubuntu 24.04. It was also unnecessary, since apt verifies the repository's signed `InRelease` and never checks per-package signatures.

- `promote-release.yml` installs only `rpm` and signs RPMs; DEB repositories are signed by aptly inside its container as before.
- `promote-deb.yml` had the same latent failure and never gave aptly a key to sign with. It now imports the GPG key and passphrase into the aptly container and passes them to `publish-snapshot.sh`, matching `promote-release.yml`.
- Docs and the spec state that RPMs and the DEB `InRelease` carry the Packyard key.

actionlint and zizmor clean.

Refs #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)