### PR TITLE
ci(promote): loopback pinentry for aptly signing; clean up before dropping the SSH key

### DIFF
--- a/.github/workflows/promote-deb.yml
+++ b/.github/workflows/promote-deb.yml
@@ -135,13 +135,20 @@ jobs:
         # apt verifies the repository's InRelease, not individual packages.
         # aptly signs it inside its container: import the key into the
         # container's tmpfs home and hand it the passphrase through a file.
+        # gpg reads a passphrase file only in loopback pinentry mode; without
+        # it, signing fails with "Inappropriate ioctl for device" (no tty).
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           # shellcheck disable=SC2029  # client-side expansion is intended
           printf '%s\n' "${GPG_PRIVATE_KEY}" | ssh deploy@${{ secrets.HOST }} \
-            "docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly gpg --batch --quiet --import"
+            "docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly sh -c '
+              mkdir -p /root/.gnupg && chmod 700 /root/.gnupg
+              printf \"pinentry-mode loopback\n\" > /root/.gnupg/gpg.conf
+              printf \"allow-loopback-pinentry\n\" > /root/.gnupg/gpg-agent.conf
+              gpg --batch --quiet --import
+            '"
           # shellcheck disable=SC2029  # client-side expansion is intended
           printf '%s\n' "${GPG_PASSPHRASE}" | ssh deploy@${{ secrets.HOST }} \
             "docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly sh -c 'umask 077; cat > /tmp/gpg-pass'"
@@ -203,10 +210,11 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -f ~/.ssh/id_ed25519
+          # Remote cleanup first: it needs the SSH key that is removed below.
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
             docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T aptly \
-              rm -rf /tmp/deb-stage /tmp/gpg-pass /root/.gnupg 2>/dev/null || true
-          " 2>/dev/null || true
+              sh -c 'gpgconf --kill gpg-agent 2>/dev/null; rm -rf /tmp/deb-stage /tmp/gpg-pass /root/.gnupg' 2>/dev/null || true
+          " || echo "WARN: remote cleanup failed"
           pkill -f 'ssh -fN -L 9000' || true
+          rm -f ~/.ssh/id_ed25519

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -275,9 +275,16 @@ jobs:
           "
           # aptly signs Release inside its container: import the key into the
           # container's tmpfs home and hand it the passphrase through a file.
+          # gpg reads a passphrase file only in loopback pinentry mode; without
+          # it, signing fails with "Inappropriate ioctl for device" (no tty).
           # shellcheck disable=SC2029  # client-side expansion is intended
           printf '%s\n' "${GPG_PRIVATE_KEY}" | ssh deploy@${{ secrets.HOST }} \
-            "docker compose -f '${C}' exec -T aptly gpg --batch --quiet --import"
+            "docker compose -f '${C}' exec -T aptly sh -c '
+              mkdir -p /root/.gnupg && chmod 700 /root/.gnupg
+              printf \"pinentry-mode loopback\n\" > /root/.gnupg/gpg.conf
+              printf \"allow-loopback-pinentry\n\" > /root/.gnupg/gpg-agent.conf
+              gpg --batch --quiet --import
+            '"
           # shellcheck disable=SC2029  # client-side expansion is intended
           printf '%s\n' "${GPG_PASSPHRASE}" | ssh deploy@${{ secrets.HOST }} \
             "docker compose -f '${C}' exec -T aptly sh -c 'umask 077; cat > /tmp/gpg-pass'"
@@ -355,11 +362,14 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -f ~/.ssh/id_ed25519
+          # Remote cleanup first: it needs the SSH key that is removed below.
+          # Staged packages, the imported GPG key, its passphrase file and the
+          # agent that may cache the passphrase all leave the containers.
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
             C='${DEPLOY_DIR}/compose.yml'
             docker compose -f \"\$C\" exec -T --user 0:101 rpm rm -rf /tmp/rpm-stage 2>/dev/null || true
-            docker compose -f \"\$C\" exec -T aptly rm -rf /tmp/deb-stage /tmp/gpg-pass /root/.gnupg 2>/dev/null || true
-          " 2>/dev/null || true
+            docker compose -f \"\$C\" exec -T aptly sh -c 'gpgconf --kill gpg-agent 2>/dev/null; rm -rf /tmp/deb-stage /tmp/gpg-pass /root/.gnupg' 2>/dev/null || true
+          " || echo "WARN: remote cleanup failed"
           pkill -f 'ssh -fN -L 5000' || true
+          rm -f ~/.ssh/id_ed25519

--- a/.github/workflows/promote-rpm.yml
+++ b/.github/workflows/promote-rpm.yml
@@ -177,13 +177,11 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          # P3: remove SSH private key from disk
-          rm -f ~/.ssh/id_ed25519
-          # P5: remove staged RPMs from the container (handles failure mid-loop)
+          # Remote cleanup first: it needs the SSH key that is removed below.
           # shellcheck disable=SC2029  # client-side expansion is intended
           ssh deploy@${{ secrets.HOST }} "
             docker compose -f '${DEPLOY_DIR}/compose.yml' exec -T --user 0:101 rpm \
               rm -rf /tmp/rpm-stage 2>/dev/null || true
-          " 2>/dev/null || true
-          # Close SSH tunnel
+          " || echo "WARN: remote cleanup failed"
           pkill -f 'ssh -fN -L 9000' || true
+          rm -f ~/.ssh/id_ed25519


### PR DESCRIPTION
Two findings from the third `promote-release` run, which published the RPMs and got as far as aptly signing:

- `gpg: signing failed: Inappropriate ioctl for device`. gpg honours `--passphrase-file` only in loopback pinentry mode. The key-import step now writes `gpg.conf` and `gpg-agent.conf` for loopback before importing. Verified in the aptly container on pkg.onms.eu with a throwaway key.
- The Cleanup step removed the SSH key before running the remote cleanup, so the remote part always failed silently. After the failed run the imported GPG key and its passphrase file were still in the aptly container. Remote cleanup now runs first, kills gpg-agent, and warns on failure. The same ordering bug is fixed in `promote-rpm.yml` and `promote-deb.yml`.

actionlint and zizmor clean.

Refs #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
