### PR TITLE
fix(deb): serve the aptly publish tree at /deb/<component>/<series>/

### DIFF
--- a/aptly/scripts/create-snapshot.sh
+++ b/aptly/scripts/create-snapshot.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
 # create-snapshot.sh — create an immutable Aptly snapshot from staged DEBs
 # Usage: create-snapshot.sh <component> <series> <distro>
 # Example: create-snapshot.sh core 2025 bookworm
@@ -20,7 +22,10 @@ echo "Creating snapshot: ${SNAPSHOT_NAME}" >&2
 # Create local repo if it doesn't already exist
 if ! aptly repo show "${REPO_NAME}" > /dev/null 2>&1; then
   echo "Creating Aptly repo: ${REPO_NAME}" >&2
-  aptly repo create -component="${COMPONENT}" "${REPO_NAME}" >&2
+  # apt component is always "main": the Packyard component already names the
+  # publish point (/deb/<component>/<series>/), so sources.list lines read
+  # "<distro> main" as subscribers expect.
+  aptly repo create -component=main "${REPO_NAME}" >&2
 fi
 
 # Add staged DEBs to the local repo

--- a/aptly/scripts/publish-snapshot.sh
+++ b/aptly/scripts/publish-snapshot.sh
@@ -34,7 +34,7 @@ if aptly publish show "${DISTRO}" "${PUBLISH_POINT}" > /dev/null 2>&1; then
   echo "Switching published snapshot at ${PUBLISH_POINT} to ${SNAPSHOT_NAME}..."
   aptly publish switch \
     "${SIGN_ARGS[@]}" \
-    -component="${COMPONENT}" \
+    -component=main \
     "${DISTRO}" \
     "${PUBLISH_POINT}" \
     "${SNAPSHOT_NAME}"
@@ -44,7 +44,7 @@ else
   aptly publish snapshot \
     "${SIGN_ARGS[@]}" \
     -distribution="${DISTRO}" \
-    -component="${COMPONENT}" \
+    -component=main \
     "${SNAPSHOT_NAME}" \
     "${PUBLISH_POINT}"
 fi

--- a/compose.yml
+++ b/compose.yml
@@ -121,7 +121,7 @@ services:
       - /run:uid=101,gid=101                    # nginx PID and lock files
       - /var/cache/nginx:uid=101,gid=101        # client/proxy/fastcgi temp dirs
     volumes:
-      - aptly-data:/opt/aptly/public:ro
+      - aptly-data:/opt/aptly:ro   # nginx root is /opt/aptly/public, aptly's publish tree
       - ./deb/nginx.conf:/etc/nginx/nginx.conf:ro
     networks:
       - proxy

--- a/traefik/dynamic-ci/middlewares.yml
+++ b/traefik/dynamic-ci/middlewares.yml
@@ -9,6 +9,14 @@ http:
         # authResponseHeaders omitted — auth service returns no headers to pass downstream
         # fail-closed: Traefik returns 503 if auth service is unreachable (NFR11)
 
+    packyard-strip-deb:
+      stripPrefix:
+        prefixes:
+          - "/deb"
+        # nginx serves aptly's publish tree at its root, so /deb/<component>/<series>/
+        # becomes /<component>/<series>/. Applied AFTER packyard-auth, which needs
+        # the full path for component scope enforcement.
+
     packyard-strip-oci:
       stripPrefix:
         prefixes:

--- a/traefik/dynamic-ci/routers-public.yml
+++ b/traefik/dynamic-ci/routers-public.yml
@@ -24,7 +24,8 @@ http:
         - web
       rule: "PathPrefix(`/deb/`)"
       middlewares:
-        - packyard-auth
+        - packyard-auth       # MUST be first — forwardAuth sees the full /deb/<component>/... path
+        - packyard-strip-deb
       service: packyard-deb-svc
       # No tls: — CI uses plaintext HTTP
 

--- a/traefik/dynamic-dev/middlewares.yml
+++ b/traefik/dynamic-dev/middlewares.yml
@@ -9,6 +9,14 @@ http:
         # authResponseHeaders omitted — auth service returns no headers to pass downstream
         # fail-closed: Traefik returns 503 if auth service is unreachable (NFR11)
 
+    packyard-strip-deb:
+      stripPrefix:
+        prefixes:
+          - "/deb"
+        # nginx serves aptly's publish tree at its root, so /deb/<component>/<series>/
+        # becomes /<component>/<series>/. Applied AFTER packyard-auth, which needs
+        # the full path for component scope enforcement.
+
     packyard-strip-oci:
       stripPrefix:
         prefixes:

--- a/traefik/dynamic-dev/routers-public.yml
+++ b/traefik/dynamic-dev/routers-public.yml
@@ -28,7 +28,8 @@ http:
         - websecure
       rule: "PathPrefix(`/deb/`)"
       middlewares:
-        - packyard-auth
+        - packyard-auth       # MUST be first — forwardAuth sees the full /deb/<component>/... path
+        - packyard-strip-deb
       service: packyard-deb-svc
       tls: {}
 

--- a/traefik/dynamic/middlewares.yml
+++ b/traefik/dynamic/middlewares.yml
@@ -9,6 +9,14 @@ http:
         # authResponseHeaders omitted — auth service returns no headers to pass downstream
         # fail-closed: Traefik returns 503 if auth service is unreachable (NFR11)
 
+    packyard-strip-deb:
+      stripPrefix:
+        prefixes:
+          - "/deb"
+        # nginx serves aptly's publish tree at its root, so /deb/<component>/<series>/
+        # becomes /<component>/<series>/. Applied AFTER packyard-auth, which needs
+        # the full path for component scope enforcement.
+
     packyard-strip-oci:
       stripPrefix:
         prefixes:

--- a/traefik/dynamic/routers-public.yml
+++ b/traefik/dynamic/routers-public.yml
@@ -27,7 +27,8 @@ http:
         - websecure
       rule: 'Host(`{{ env "PKG_DOMAIN" }}`) && PathPrefix(`/deb/`)'
       middlewares:
-        - packyard-auth
+        - packyard-auth       # MUST be first — forwardAuth sees the full /deb/<component>/... path
+        - packyard-strip-deb
       service: packyard-deb-svc
       tls:
         certResolver: letsencrypt


### PR DESCRIPTION
The fourth `promote-release` run published RPMs, DEBs and images, and its final check found `/deb/bluebird/38/dists/bookworm/InRelease` answering 404 although aptly had written it. Three defects in the existing DEB serving path, none specific to the new workflow:

- The `deb` nginx container mounted the aptly volume at `/opt/aptly/public`, one level too deep, so the publish tree was at `public/public/` from nginx's point of view. It now mounts `/opt/aptly`, making nginx's root the publish tree.
- Traefik did not strip the `/deb` prefix the way it strips `/oci`. A `packyard-strip-deb` middleware runs after forward-auth in `dynamic`, `dynamic-ci` and `dynamic-dev`.
- aptly published the apt component under the Packyard component name, while the subscriber guide and the e2e test use `main`. The scripts now publish `main`; the Packyard component already names the publish point.

CI has the identical configuration and does not run `tests/e2e/deb-subscriber.sh`, which is why this went unnoticed (tracked separately).

Verified locally: `docker compose config`, `make lint-workflows`. Verified on the host after applying: see the follow-up promotion run.

Refs #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
