### PR TITLE
ci(preview): refuse to publish a preview image for a non-rc version

### DIFF
--- a/.github/workflows/build-auth.yml
+++ b/.github/workflows/build-auth.yml
@@ -46,6 +46,14 @@ jobs:
         id: version
         run: |
           ver=$(grep -oP '(?<=const version = ")[^"]+' auth/cmd/server/version.go)
+          # Preview builds publish the version found in the tree as a mutable
+          # tag. Right after a release that version is the release itself, and
+          # pushing would overwrite the immutable, signed release image. Refuse
+          # until the post-release -rc bump has landed (RELEASING.md §4).
+          case "$ver" in
+            *-rc) ;;
+            *) echo "ERROR: refusing to publish a preview for release version ${ver}; bump main to the next -rc version first"; exit 1 ;;
+          esac
           printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -46,6 +46,14 @@ jobs:
         id: version
         run: |
           ver=$(cat rpm/VERSION)
+          # Preview builds publish the version found in the tree as a mutable
+          # tag. Right after a release that version is the release itself, and
+          # pushing would overwrite the immutable, signed release image. Refuse
+          # until the post-release -rc bump has landed (RELEASING.md §4).
+          case "$ver" in
+            *-rc) ;;
+            *) echo "ERROR: refusing to publish a preview for release version ${ver}; bump main to the next -rc version first"; exit 1 ;;
+          esac
           printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2

--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -46,6 +46,14 @@ jobs:
         id: version
         run: |
           ver=$(cat static/VERSION)
+          # Preview builds publish the version found in the tree as a mutable
+          # tag. Right after a release that version is the release itself, and
+          # pushing would overwrite the immutable, signed release image. Refuse
+          # until the post-release -rc bump has landed (RELEASING.md §4).
+          case "$ver" in
+            *-rc) ;;
+            *) echo "ERROR: refusing to publish a preview for release version ${ver}; bump main to the next -rc version first"; exit 1 ;;
+          esac
           printf 'tags<<EOF\n%s:%s\nEOF\n' "${IMAGE}" "${ver}" >> "${GITHUB_OUTPUT}"
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,7 +66,9 @@ Confirm the landing page at https://no42-org.github.io/packyard/ shows the new v
 
 ## 4. Bump to the next development version
 
-Bump `main` to the next patch version with an `-rc` suffix so preview builds are never mistaken for a release:
+Bump `main` to the next patch version with an `-rc` suffix so preview builds are never mistaken for a release.
+Do this immediately after tagging: preview builds publish the version in the tree as a mutable tag, so a push to `main` before the bump would overwrite the release image.
+The preview workflows refuse to publish a version without the `-rc` suffix, so a forgotten bump fails the next preview build instead of clobbering a release.
 
 ```bash
 NEXT=1.2.4-rc


### PR DESCRIPTION
Preview builds tag the image with the version found in the tree. Right after a release that version *is* the release, so a push to `main` before the post-release `-rc` bump overwrites the immutable, signed release image. That happened today: `packyard-rpm:0.5.0` pointed at a preview build from #212 until I re-pointed the tag at the signed digest by hand (cosign verifies again).

The three preview workflows now fail when the version has no `-rc` suffix, and RELEASING.md states the bump must follow the tag immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
