### PR TITLE
fix(traefik): route /v2/ so docker can pull through the public hostname

### DIFF
--- a/docs/reference/subscriber-usage.md
+++ b/docs/reference/subscriber-usage.md
@@ -33,8 +33,9 @@ deb [signed-by=/usr/share/keyrings/lts.gpg] \
 Images are published as `lts-<component>/<image>` with an immutable version tag and a floating series tag that follows the newest version in that series.
 
 ```bash
-# Authenticate (not needed for a public component)
-docker login pkg.example.org/oci \
+# Authenticate (not needed for a public component). The registry host is
+# pkg.example.org; the /oci path element is part of the image name.
+docker login pkg.example.org \
   --username subscriber \
   --password KEY
 

--- a/traefik/dynamic-ci/middlewares.yml
+++ b/traefik/dynamic-ci/middlewares.yml
@@ -17,6 +17,13 @@ http:
         # becomes /<component>/<series>/. Applied AFTER packyard-auth, which needs
         # the full path for component scope enforcement.
 
+    packyard-v2-to-oci:
+      replacePathRegex:
+        regex: '^/v2/oci/(.*)'
+        replacement: '/oci/v2/$1'
+        # Docker-style registry references put the /oci path element inside
+        # the repository name; forward-auth expects it before /v2/.
+
     packyard-strip-oci:
       stripPrefix:
         prefixes:

--- a/traefik/dynamic-ci/routers-public.yml
+++ b/traefik/dynamic-ci/routers-public.yml
@@ -39,6 +39,24 @@ http:
       service: packyard-zot-svc
       # No tls: — CI uses plaintext HTTP
 
+    # docker, crane and cosign address a registry at /v2/ on the host root, so
+    # the documented reference <host>/oci/lts-<component>/<image> arrives as
+    # /v2/oci/lts-<component>/<image>/... Rewrite it to the /oci/v2/... shape
+    # forward-auth scopes on, then strip /oci for Zot like the /oci/ router.
+    # The bare /v2/ ping is left alone and answers 401 from forward-auth,
+    # which anonymous clients accept.
+    oci-v2-authenticated:
+      entryPoints:
+        - websecure
+      rule: 'PathPrefix(`/v2/`)'
+      middlewares:
+        - packyard-v2-to-oci  # MUST be first — turns /v2/oci/... into /oci/v2/...
+        - packyard-auth       # sees the rewritten /oci/v2/lts-<component>/... path
+        - packyard-strip-oci  # Zot receives /v2/lts-<component>/...
+      service: packyard-zot-svc
+      tls:
+        certResolver: letsencrypt
+
   services:
     packyard-static-svc:
       loadBalancer:

--- a/traefik/dynamic-dev/middlewares.yml
+++ b/traefik/dynamic-dev/middlewares.yml
@@ -17,6 +17,13 @@ http:
         # becomes /<component>/<series>/. Applied AFTER packyard-auth, which needs
         # the full path for component scope enforcement.
 
+    packyard-v2-to-oci:
+      replacePathRegex:
+        regex: '^/v2/oci/(.*)'
+        replacement: '/oci/v2/$1'
+        # Docker-style registry references put the /oci path element inside
+        # the repository name; forward-auth expects it before /v2/.
+
     packyard-strip-oci:
       stripPrefix:
         prefixes:

--- a/traefik/dynamic-dev/routers-public.yml
+++ b/traefik/dynamic-dev/routers-public.yml
@@ -43,6 +43,24 @@ http:
       service: packyard-zot-svc
       tls: {}
 
+    # docker, crane and cosign address a registry at /v2/ on the host root, so
+    # the documented reference <host>/oci/lts-<component>/<image> arrives as
+    # /v2/oci/lts-<component>/<image>/... Rewrite it to the /oci/v2/... shape
+    # forward-auth scopes on, then strip /oci for Zot like the /oci/ router.
+    # The bare /v2/ ping is left alone and answers 401 from forward-auth,
+    # which anonymous clients accept.
+    oci-v2-authenticated:
+      entryPoints:
+        - websecure
+      rule: "PathPrefix(`/v2/`)"
+      middlewares:
+        - packyard-v2-to-oci  # MUST be first — turns /v2/oci/... into /oci/v2/...
+        - packyard-auth       # sees the rewritten /oci/v2/lts-<component>/... path
+        - packyard-strip-oci  # Zot receives /v2/lts-<component>/...
+      service: packyard-zot-svc
+      tls:
+        certResolver: letsencrypt
+
   services:
     packyard-static-svc:
       loadBalancer:

--- a/traefik/dynamic/middlewares.yml
+++ b/traefik/dynamic/middlewares.yml
@@ -17,6 +17,13 @@ http:
         # becomes /<component>/<series>/. Applied AFTER packyard-auth, which needs
         # the full path for component scope enforcement.
 
+    packyard-v2-to-oci:
+      replacePathRegex:
+        regex: '^/v2/oci/(.*)'
+        replacement: '/oci/v2/$1'
+        # Docker-style registry references put the /oci path element inside
+        # the repository name; forward-auth expects it before /v2/.
+
     packyard-strip-oci:
       stripPrefix:
         prefixes:

--- a/traefik/dynamic/routers-public.yml
+++ b/traefik/dynamic/routers-public.yml
@@ -44,6 +44,24 @@ http:
       tls:
         certResolver: letsencrypt
 
+    # docker, crane and cosign address a registry at /v2/ on the host root, so
+    # the documented reference <host>/oci/lts-<component>/<image> arrives as
+    # /v2/oci/lts-<component>/<image>/... Rewrite it to the /oci/v2/... shape
+    # forward-auth scopes on, then strip /oci for Zot like the /oci/ router.
+    # The bare /v2/ ping is left alone and answers 401 from forward-auth,
+    # which anonymous clients accept.
+    oci-v2-authenticated:
+      entryPoints:
+        - websecure
+      rule: 'Host(`{{ env "PKG_DOMAIN" }}`) && PathPrefix(`/v2/`)'
+      middlewares:
+        - packyard-v2-to-oci  # MUST be first — turns /v2/oci/... into /oci/v2/...
+        - packyard-auth       # sees the rewritten /oci/v2/lts-<component>/... path
+        - packyard-strip-oci  # Zot receives /v2/lts-<component>/...
+      service: packyard-zot-svc
+      tls:
+        certResolver: letsencrypt
+
   services:
     packyard-static-svc:
       loadBalancer:


### PR DESCRIPTION
docker, crane and cosign address a registry at `/v2/` on the host root, so the documented reference `<host>/oci/lts-<component>/<image>` arrives as `/v2/oci/...`. Traefik only routed `/oci/` and answered 404: the promoted images were correct but nobody could pull them.

A new `oci-v2-authenticated` router in all three Traefik variants matches `/v2/`, rewrites `/v2/oci/X` to `/oci/v2/X` (so forward-auth sees the path shape it scopes on), then strips `/oci` for Zot exactly like the `/oci/` router. The bare `/v2/` ping stays a 401 from forward-auth, which anonymous clients accept.

Verified on pkg.onms.eu with the same file: `docker pull pkg.onms.eu/oci/lts-bluebird/core:38.1.0` succeeds, `crane digest ...:38` returns the promoted digest, `cosign verify` passes against the promote-release identity.

`docker login` targets the host, not `<host>/oci`; the subscriber guide is corrected. Private components need a `WWW-Authenticate` challenge from forward-auth for docker to send credentials, tracked in #221.

Refs #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
