### PR TITLE
fix(admin-ui): stop the whoami request loop on the login page

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -81,6 +81,12 @@ jobs:
           go-version-file: auth/go.mod
           cache-dependency-path: auth/go.sum
       - run: make test
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: auth/internal/admin-ui/package-lock.json
+      - run: make admin-ui-test
 
   build-docs:
     name: Build docs

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ UNAME_S := $(shell uname -s)
 .DEFAULT_GOAL := help
 
 .PHONY: help docs-install docs-serve docs-build docs-clean check-node test-rpm-publish \
-        admin-ui admin-ui-install admin-ui-dev admin-ui-clean \
+        admin-ui admin-ui-install admin-ui-test admin-ui-dev admin-ui-clean \
         build build-clean test lint lint-workflows build-image-auth build-image-rpm build-images \
         ci-guard ci-stack-up ci-stack-down ci-stack-logs ci-seed ci-verify-env e2e-observability
 
@@ -61,6 +61,10 @@ admin-ui-install: check-node $(ADMIN_UI_DIR)/node_modules/.package-lock.json
 
 $(ADMIN_UI_DIR)/node_modules/.package-lock.json: $(ADMIN_UI_DIR)/package-lock.json | check-node
 	cd $(ADMIN_UI_DIR) && $(NPM) ci
+
+## admin-ui-test: Run the admin SPA unit tests (vitest)
+admin-ui-test: admin-ui-install
+	cd $(ADMIN_UI_DIR) && $(NPM) test
 
 ## admin-ui: Build the admin SPA bundle into the Go embed directory
 admin-ui: $(ADMIN_UI_DIR)/node_modules/.package-lock.json

--- a/auth/internal/admin-ui/package-lock.json
+++ b/auth/internal/admin-ui/package-lock.json
@@ -18,10 +18,39 @@
         "@types/react-dom": "^19.2.5",
         "@vitejs/plugin-react": "^6.1.1",
         "typescript": "^7.0.2",
-        "vite": "^8.2.2"
+        "vite": "^8.2.2",
+        "vitest": "^5.0.0"
       },
       "engines": {
         "node": ">=20.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -339,6 +368,31 @@
       "peerDependencies": {
         "react": "^18 || ^19"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.18",
@@ -730,6 +784,64 @@
         }
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -758,6 +870,33 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1066,6 +1205,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -1083,6 +1232,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/picocolors": {
@@ -1239,6 +1402,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1247,6 +1417,40 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1377,6 +1581,106 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/auth/internal/admin-ui/package.json
+++ b/auth/internal/admin-ui/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.102.8",
@@ -21,7 +22,8 @@
     "@types/react-dom": "^19.2.5",
     "@vitejs/plugin-react": "^6.1.1",
     "typescript": "^7.0.2",
-    "vite": "^8.2.2"
+    "vite": "^8.2.2",
+    "vitest": "^5.0.0"
   },
   "engines": {
     "node": ">=20.0"

--- a/auth/internal/admin-ui/src/api/client.ts
+++ b/auth/internal/admin-ui/src/api/client.ts
@@ -36,19 +36,21 @@ export class ApiError extends Error {
   }
 }
 
-let unauthorizedHandler: (() => void) | null = null;
+let unauthorizedHandler: ((failedPath: string) => void) | null = null;
 
-// setUnauthorizedHandler registers a callback invoked exactly once whenever
-// any API call returns 401 — used to invalidate the cached operator and
-// redirect to /login. Set from main.tsx; tests can clear by passing null.
-export function setUnauthorizedHandler(fn: (() => void) | null) {
+// setUnauthorizedHandler registers a callback invoked whenever any API call
+// returns 401, with the path that failed. main.tsx wires it to
+// handleUnauthorized (api/unauthorized.ts), which decides whether to clear
+// the cached operator, re-confirm the session and redirect to /login. Tests
+// can clear by passing null.
+export function setUnauthorizedHandler(fn: ((failedPath: string) => void) | null) {
   unauthorizedHandler = fn;
 }
 
-function fireUnauthorized() {
+function fireUnauthorized(failedPath: string) {
   if (unauthorizedHandler) {
     try {
-      unauthorizedHandler();
+      unauthorizedHandler(failedPath);
     } catch {
       /* swallow; the redirect side-effect must not throw further */
     }
@@ -94,7 +96,7 @@ export async function apiFetch<T = unknown>(
 
   if (!res.ok) {
     const payload = (body as ApiErrorPayload) ?? null;
-    if (res.status === 401) fireUnauthorized();
+    if (res.status === 401) fireUnauthorized(path);
     throw new ApiError(res.status, payload, `HTTP ${res.status}`);
   }
 
@@ -120,7 +122,7 @@ export async function apiListFetch<T>(path: string): Promise<PaginatedResult<T>>
   }
   if (!res.ok) {
     const payload = (body as ApiErrorPayload) ?? null;
-    if (res.status === 401) fireUnauthorized();
+    if (res.status === 401) fireUnauthorized(path);
     throw new ApiError(res.status, payload, `HTTP ${res.status}`);
   }
   return {

--- a/auth/internal/admin-ui/src/api/unauthorized.test.ts
+++ b/auth/internal/admin-ui/src/api/unauthorized.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  LOGIN_PATH,
+  SESSION_PROBE_PATH,
+  handleUnauthorized,
+  isSessionProbe,
+} from "./unauthorized";
+
+function effects() {
+  return {
+    clearSession: vi.fn(),
+    invalidateSession: vi.fn(),
+    redirectToLogin: vi.fn(),
+  };
+}
+
+describe("handleUnauthorized", () => {
+  it("does nothing on the login page, so a failing probe cannot loop", () => {
+    const e = effects();
+    handleUnauthorized(SESSION_PROBE_PATH, LOGIN_PATH, e);
+    expect(e.clearSession).not.toHaveBeenCalled();
+    expect(e.invalidateSession).not.toHaveBeenCalled();
+    expect(e.redirectToLogin).not.toHaveBeenCalled();
+  });
+
+  it("never invalidates the session query for a 401 from the probe itself", () => {
+    const e = effects();
+    handleUnauthorized(SESSION_PROBE_PATH, "/admin/accounts", e);
+    expect(e.clearSession).toHaveBeenCalledTimes(1);
+    expect(e.invalidateSession).not.toHaveBeenCalled();
+    expect(e.redirectToLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears, re-confirms once and redirects for a 401 from a data call", () => {
+    const e = effects();
+    handleUnauthorized("/api/v1/accounts?page=2", "/admin/accounts", e);
+    expect(e.clearSession).toHaveBeenCalledTimes(1);
+    expect(e.invalidateSession).toHaveBeenCalledTimes(1);
+    expect(e.redirectToLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles after a bounded number of steps when the probe keeps failing", () => {
+    // Simulate the React Query feedback: every invalidation refetches the
+    // probe, which answers 401 and re-enters the handler. With the guard the
+    // chain is data-call -> probe -> stop.
+    const e = effects();
+    let entries = 0;
+    const invalidate = () => {
+      entries += 1;
+      if (entries > 10) throw new Error("loop");
+      handleUnauthorized(SESSION_PROBE_PATH, "/admin/accounts", { ...e, invalidateSession: invalidate });
+    };
+    handleUnauthorized("/api/v1/keys", "/admin/accounts", { ...e, invalidateSession: invalidate });
+    expect(entries).toBe(1);
+  });
+});
+
+describe("isSessionProbe", () => {
+  it("matches the probe path with or without a query string", () => {
+    expect(isSessionProbe(SESSION_PROBE_PATH)).toBe(true);
+    expect(isSessionProbe(`${SESSION_PROBE_PATH}?t=1`)).toBe(true);
+    expect(isSessionProbe("/api/v1/auth/whoami-else")).toBe(false);
+    expect(isSessionProbe("/api/v1/accounts")).toBe(false);
+  });
+});

--- a/auth/internal/admin-ui/src/api/unauthorized.ts
+++ b/auth/internal/admin-ui/src/api/unauthorized.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// What the SPA does when any API call answers 401. Kept free of React and
+// browser globals so the decision can be unit-tested; main.tsx supplies the
+// effects.
+//
+// The trap this guards against: the session probe (whoami) fails with 401,
+// the handler invalidates the session query, the mounted query has
+// staleTime 0 and refetches at once, which fails with 401 again. On a
+// logged-out login page that loop ran at roughly ten requests per second
+// (issue #209). Two rules stop it:
+//
+//   1. On /admin/login there is nothing to do: App already renders the
+//      logged-out branch from the probe's own error.
+//   2. A 401 from the probe itself clears the cached operator but never
+//      invalidates the session query; only a 401 from a data call does, so
+//      the probe re-confirms the state exactly once.
+
+export const SESSION_PROBE_PATH = "/api/v1/auth/whoami";
+export const LOGIN_PATH = "/admin/login";
+
+export interface UnauthorizedEffects {
+  /** Drop the cached operator so App renders the logged-out branch. */
+  clearSession: () => void;
+  /** Mark the session query stale so it re-confirms on next render. */
+  invalidateSession: () => void;
+  /** Hard-navigate to the login route. */
+  redirectToLogin: () => void;
+}
+
+export function handleUnauthorized(
+  failedPath: string,
+  currentPathname: string,
+  effects: UnauthorizedEffects,
+): void {
+  if (currentPathname === LOGIN_PATH) {
+    return;
+  }
+  effects.clearSession();
+  if (!isSessionProbe(failedPath)) {
+    effects.invalidateSession();
+  }
+  effects.redirectToLogin();
+}
+
+export function isSessionProbe(path: string): boolean {
+  // Strip a query string or fragment; compare the path only.
+  const bare = path.split(/[?#]/, 1)[0];
+  return bare === SESSION_PROBE_PATH;
+}

--- a/auth/internal/admin-ui/src/main.tsx
+++ b/auth/internal/admin-ui/src/main.tsx
@@ -10,6 +10,7 @@ import { BrowserRouter } from "react-router-dom";
 
 import { App } from "./App";
 import { setUnauthorizedHandler } from "./api/client";
+import { LOGIN_PATH, handleUnauthorized } from "./api/unauthorized";
 import "./styles.css";
 
 const queryClient = new QueryClient({
@@ -24,17 +25,20 @@ const queryClient = new QueryClient({
   },
 });
 
-// Wire the global 401 handler: any API call returning 401 invalidates the
-// cached operator (so App's logged-out branch renders), then forces a hard
-// redirect to /admin/login so partially-loaded protected pages don't keep
-// firing failing requests in the background.
-setUnauthorizedHandler(() => {
-  queryClient.setQueryData(["session", "whoami"], null);
-  queryClient.invalidateQueries({ queryKey: ["session"] });
-  if (window.location.pathname !== "/admin/login") {
-    window.location.href = "/admin/login";
-  }
-});
+// Wire the global 401 handler. The decision lives in api/unauthorized.ts
+// (unit-tested); this supplies the effects. See that file for why a 401 from
+// the session probe must not invalidate the session query (#209).
+setUnauthorizedHandler((failedPath) =>
+  handleUnauthorized(failedPath, window.location.pathname, {
+    clearSession: () => queryClient.setQueryData(["session", "whoami"], null),
+    invalidateSession: () => {
+      void queryClient.invalidateQueries({ queryKey: ["session"] });
+    },
+    redirectToLogin: () => {
+      window.location.href = LOGIN_PATH;
+    },
+  }),
+);
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {


### PR DESCRIPTION
## Summary
A 401 from the session probe fired the global unauthorized handler, which invalidated the session query; with `staleTime: 0` the mounted query refetched immediately and failed again. On pkg.onms.eu a logged-out browser on `/admin/login` produced about 8,600 `whoami` requests in 15 minutes.

The decision now lives in `api/unauthorized.ts`, free of React and browser globals: nothing happens on `/admin/login`, and a 401 from the probe itself clears the cached operator without invalidating the session query. Only a 401 from a data call re-confirms the session, once. `apiFetch` passes the failing path to the handler. The "disabled operator is logged out on focus" behaviour of the session hook is unchanged.

Adds Vitest to the admin UI (`make admin-ui-test`, run in the Auth unit tests gate) with tests for the guard, including a bounded-chain check that simulates React Query's refetch.

Closes #209

## Verification
`make admin-ui-test`: 5 tests pass. `npm run typecheck`, `make build` pass. actionlint clean on the gate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
