### PR TITLE
feat(components): edit RPM series, OS families and architectures after creation

### DIFF
--- a/auth/internal/admin-ui/src/api/components.ts
+++ b/auth/internal/admin-ui/src/api/components.ts
@@ -35,11 +35,23 @@ export function useCreateComponent() {
   });
 }
 
+// Fields PATCH /api/v1/components/{name} accepts. A list replaces the stored
+// list; at least one field must be present.
+export type ComponentPatch = Partial<
+  Pick<Component, "visibility" | "rpm_series" | "rpm_os_families" | "rpm_architectures">
+>;
+
+// The updated record plus the series/family-arch targets the patch stopped
+// declaring. Their directories stay on disk (operator responsibility).
+export interface ComponentUpdateResult extends Component {
+  rpm_targets_removed: string[];
+}
+
 export function useUpdateComponent(name: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: Partial<Pick<Component, "visibility">>) =>
-      apiFetch<Component>(`/api/v1/components/${encodeURIComponent(name)}`, {
+    mutationFn: (body: ComponentPatch) =>
+      apiFetch<ComponentUpdateResult>(`/api/v1/components/${encodeURIComponent(name)}`, {
         method: "PATCH",
         body: JSON.stringify(body),
       }),

--- a/auth/internal/admin-ui/src/routes/Components.tsx
+++ b/auth/internal/admin-ui/src/routes/Components.tsx
@@ -148,10 +148,24 @@ function CreateComponentModal({ open, onClose }: { open: boolean; onClose: () =>
 function EditComponentModal({ component, onClose }: { component: Component; onClose: () => void }) {
   const update = useUpdateComponent(component.name);
   const [visibility, setVisibility] = useState(component.visibility);
+  const [series, setSeries] = useState(component.rpm_series.join(","));
+  const [families, setFamilies] = useState(component.rpm_os_families.join(","));
+  const [archs, setArchs] = useState(component.rpm_architectures.join(","));
+  const [removed, setRemoved] = useState<string[] | null>(null);
 
   const submit = async () => {
     try {
-      await update.mutateAsync({ visibility });
+      const result = await update.mutateAsync({
+        visibility,
+        rpm_series: csv(series),
+        rpm_os_families: csv(families),
+        rpm_architectures: csv(archs),
+      });
+      if (result.rpm_targets_removed.length > 0) {
+        // Keep the dialog open: the operator should see what stays on disk.
+        setRemoved(result.rpm_targets_removed);
+        return;
+      }
       onClose();
     } catch {
       /* error rendered below */
@@ -166,28 +180,62 @@ function EditComponentModal({ component, onClose }: { component: Component; onCl
       actions={
         <>
           <button className="btn-secondary" onClick={onClose}>
-            Cancel
+            {removed ? "Close" : "Cancel"}
           </button>
-          <button onClick={submit} disabled={update.isPending}>
-            Save
-          </button>
+          {!removed && (
+            <button onClick={submit} disabled={update.isPending}>
+              Save
+            </button>
+          )}
         </>
       }
     >
-      <div className="field">
-        <label>Visibility</label>
-        <select
-          value={visibility}
-          onChange={(e) => setVisibility(e.target.value as "public" | "private")}
-        >
-          <option value="private">private</option>
-          <option value="public">public</option>
-        </select>
-      </div>
-      <p className="muted">
-        Other fields (series / OS families / architectures) are immutable per the components API.
-      </p>
-      <ErrorBanner error={update.error} />
+      {removed ? (
+        <div className="field">
+          <p>Saved. These RPM targets are no longer declared on the component:</p>
+          <ul>
+            {removed.map((t) => (
+              <li key={t}>
+                <code>{t}</code>
+              </li>
+            ))}
+          </ul>
+          <p className="muted">
+            Their directories and packages remain on disk and keep being served. Remove them by hand if
+            they should disappear.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="field">
+            <label>Visibility</label>
+            <select
+              value={visibility}
+              onChange={(e) => setVisibility(e.target.value as "public" | "private")}
+            >
+              <option value="private">private</option>
+              <option value="public">public</option>
+            </select>
+          </div>
+          <div className="field">
+            <label>RPM series (comma-separated, e.g. 38,39)</label>
+            <input type="text" value={series} onChange={(e) => setSeries(e.target.value)} />
+          </div>
+          <div className="field">
+            <label>OS families (comma-separated, e.g. el9,el10)</label>
+            <input type="text" value={families} onChange={(e) => setFamilies(e.target.value)} />
+          </div>
+          <div className="field">
+            <label>Architectures (comma-separated, e.g. x86_64,aarch64)</label>
+            <input type="text" value={archs} onChange={(e) => setArchs(e.target.value)} />
+          </div>
+          <p className="muted">
+            New series, OS family and architecture combinations are provisioned on save. Removing one
+            leaves its directory on disk.
+          </p>
+          <ErrorBanner error={update.error} />
+        </>
+      )}
     </Modal>
   );
 }

--- a/auth/internal/handler/components.go
+++ b/auth/internal/handler/components.go
@@ -257,14 +257,29 @@ func (h *ComponentsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // updateComponentRequest is the JSON body for PATCH /api/v1/components/{name}.
+// Every field is optional; at least one must be present. A list replaces the
+// stored list.
 type updateComponentRequest struct {
-	Visibility string `json:"visibility"`
+	Visibility       *string   `json:"visibility"`
+	RPMSeries        *[]string `json:"rpm_series"`
+	RPMOSFamilies    *[]string `json:"rpm_os_families"`
+	RPMArchitectures *[]string `json:"rpm_architectures"`
 }
 
-// Update handles PATCH /api/v1/components/{name} — updates mutable component fields.
-// Currently only visibility ("public" or "private") may be changed.
-// The change is persisted immediately; forward-auth picks it up on the next request
-// without a service restart.
+// updateComponentResponse is the updated record plus the RPM targets
+// (series/family-arch) the patch stopped declaring. Their directories stay on
+// disk; the operator removes them, as with DELETE.
+type updateComponentResponse struct {
+	*store.Component
+	RPMTargetsRemoved []string `json:"rpm_targets_removed"`
+}
+
+// Update handles PATCH /api/v1/components/{name}: visibility and the three RPM
+// lists. New series × os_family × arch combinations are provisioned on disk
+// before the record changes, so a failed mkdir leaves the record untouched.
+// Combinations no longer declared are reported in rpm_targets_removed and
+// left on disk. The change is persisted immediately; forward-auth picks it up
+// on the next request without a service restart.
 func (h *ComponentsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
@@ -273,13 +288,79 @@ func (h *ComponentsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "request body must be valid JSON")
 		return
 	}
-	if req.Visibility != "public" && req.Visibility != "private" {
+	patch := store.ComponentPatch{
+		Visibility:       req.Visibility,
+		RPMSeries:        req.RPMSeries,
+		RPMOSFamilies:    req.RPMOSFamilies,
+		RPMArchitectures: req.RPMArchitectures,
+	}
+	if patch.IsEmpty() {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
+			"at least one of visibility, rpm_series, rpm_os_families, rpm_architectures is required")
+		return
+	}
+	if req.Visibility != nil && *req.Visibility != "public" && *req.Visibility != "private" {
 		writeError(w, http.StatusBadRequest, "INVALID_VISIBILITY",
-			fmt.Sprintf("visibility %q is invalid; must be \"public\" or \"private\"", req.Visibility))
+			fmt.Sprintf("visibility %q is invalid; must be \"public\" or \"private\"", *req.Visibility))
+		return
+	}
+	for _, field := range []struct {
+		label  string
+		values *[]string
+	}{
+		{"rpm_series", req.RPMSeries},
+		{"rpm_os_families", req.RPMOSFamilies},
+		{"rpm_architectures", req.RPMArchitectures},
+	} {
+		if field.values == nil {
+			continue
+		}
+		for _, v := range *field.values {
+			if !pathSegmentRe.MatchString(v) {
+				writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
+					fmt.Sprintf("%s contains invalid value %q", field.label, v))
+				return
+			}
+		}
+	}
+
+	current, err := h.Store.GetComponent(r.Context(), name)
+	if err != nil {
+		if errors.Is(err, store.ErrComponentNotFound) {
+			writeError(w, http.StatusNotFound, "COMPONENT_NOT_FOUND",
+				fmt.Sprintf("component %q not found", name))
+			return
+		}
+		h.Logger.Error("failed to load component", logsafe.Attr("name", name), slog.String("error", err.Error()))
+		writeError(w, http.StatusInternalServerError, "COMPONENT_UPDATE_FAILED", "failed to update component")
 		return
 	}
 
-	comp, err := h.Store.UpdateComponentVisibility(r.Context(), name, req.Visibility)
+	// The record as it will look after the patch, to provision new directories
+	// first and to compute what the patch stops declaring.
+	next := *current
+	if patch.Visibility != nil {
+		next.Visibility = *patch.Visibility
+	}
+	if patch.RPMSeries != nil {
+		next.RPMSeries = *patch.RPMSeries
+	}
+	if patch.RPMOSFamilies != nil {
+		next.RPMOSFamilies = *patch.RPMOSFamilies
+	}
+	if patch.RPMArchitectures != nil {
+		next.RPMArchitectures = *patch.RPMArchitectures
+	}
+	// Snapshot before the store call: a store may hand back the same object.
+	before := rpmTargets(current)
+	if err := h.initRPMTree(r.Context(), &next); err != nil {
+		h.Logger.Error("failed to provision RPM tree", logsafe.Attr("name", name), slog.String("error", err.Error()))
+		writeError(w, http.StatusInternalServerError, "RPM_INIT_FAILED",
+			fmt.Sprintf("RPM directory initialisation failed: %v", err))
+		return
+	}
+
+	updated, err := h.Store.UpdateComponent(r.Context(), name, patch)
 	if err != nil {
 		if errors.Is(err, store.ErrComponentNotFound) {
 			writeError(w, http.StatusNotFound, "COMPONENT_NOT_FOUND",
@@ -293,7 +374,39 @@ func (h *ComponentsHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(comp)
+	_ = json.NewEncoder(w).Encode(updateComponentResponse{
+		Component:         updated,
+		RPMTargetsRemoved: removedRPMTargets(before, updated),
+	})
+}
+
+// rpmTargets lists every series/family-arch combination a component declares.
+func rpmTargets(c *store.Component) []string {
+	var out []string
+	for _, series := range c.RPMSeries {
+		for _, family := range c.RPMOSFamilies {
+			for _, arch := range c.RPMArchitectures {
+				out = append(out, series+"/"+family+"-"+arch)
+			}
+		}
+	}
+	return out
+}
+
+// removedRPMTargets returns the targets in before that after no longer
+// declares, in before's order. Never nil, so the JSON field is [] not null.
+func removedRPMTargets(before []string, after *store.Component) []string {
+	keep := make(map[string]bool)
+	for _, t := range rpmTargets(after) {
+		keep[t] = true
+	}
+	removed := []string{}
+	for _, t := range before {
+		if !keep[t] {
+			removed = append(removed, t)
+		}
+	}
+	return removed
 }
 
 // pathSegmentRe bounds every value that becomes a directory name under

--- a/auth/internal/handler/components_test.go
+++ b/auth/internal/handler/components_test.go
@@ -27,7 +27,7 @@ import (
 type stubComponentStore struct {
 	comps    map[string]*store.Component
 	keys     map[string]int64 // component → active key count (for impact preview)
-	updateFn func(ctx context.Context, name, visibility string) (*store.Component, error)
+	updateFn func(ctx context.Context, name string, patch store.ComponentPatch) (*store.Component, error)
 }
 
 func newStubComponentStore() *stubComponentStore {
@@ -109,15 +109,26 @@ func (s *stubComponentStore) DeleteComponentWithRevoke(ctx context.Context, name
 	return n, nil
 }
 
-func (s *stubComponentStore) UpdateComponentVisibility(ctx context.Context, name, visibility string) (*store.Component, error) {
+func (s *stubComponentStore) UpdateComponent(ctx context.Context, name string, patch store.ComponentPatch) (*store.Component, error) {
 	if s.updateFn != nil {
-		return s.updateFn(ctx, name, visibility)
+		return s.updateFn(ctx, name, patch)
 	}
 	c, ok := s.comps[name]
 	if !ok {
 		return nil, store.ErrComponentNotFound
 	}
-	c.Visibility = visibility
+	if patch.Visibility != nil {
+		c.Visibility = *patch.Visibility
+	}
+	if patch.RPMSeries != nil {
+		c.RPMSeries = *patch.RPMSeries
+	}
+	if patch.RPMOSFamilies != nil {
+		c.RPMOSFamilies = *patch.RPMOSFamilies
+	}
+	if patch.RPMArchitectures != nil {
+		c.RPMArchitectures = *patch.RPMArchitectures
+	}
 	s.comps[name] = c // explicit re-store so callers see the mutation via map lookup
 	return c, nil
 }
@@ -445,7 +456,7 @@ func TestComponentUpdate_PrivateToPublic(t *testing.T) {
 		RPMSeries: []string{}, RPMOSFamilies: []string{}, RPMArchitectures: []string{},
 	})
 
-	body, _ := json.Marshal(updateComponentRequest{Visibility: "public"})
+	body, _ := json.Marshal(map[string]string{"visibility": "public"})
 	r := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", body)
 	w := httptest.NewRecorder()
 	h.Update(w, r)
@@ -470,7 +481,7 @@ func TestComponentUpdate_PublicToPrivate(t *testing.T) {
 		RPMSeries: []string{}, RPMOSFamilies: []string{}, RPMArchitectures: []string{},
 	})
 
-	body, _ := json.Marshal(updateComponentRequest{Visibility: "private"})
+	body, _ := json.Marshal(map[string]string{"visibility": "private"})
 	r := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", body)
 	w := httptest.NewRecorder()
 	h.Update(w, r)
@@ -489,7 +500,7 @@ func TestComponentUpdate_PublicToPrivate(t *testing.T) {
 
 func TestComponentUpdate_NotFound(t *testing.T) {
 	h, _ := newTestComponentsHandler(t)
-	body, _ := json.Marshal(updateComponentRequest{Visibility: "public"})
+	body, _ := json.Marshal(map[string]string{"visibility": "public"})
 	r := chiRequest(http.MethodPatch, "/api/v1/components/unknown", "unknown", body)
 	w := httptest.NewRecorder()
 	h.Update(w, r)
@@ -502,7 +513,7 @@ func TestComponentUpdate_NotFound(t *testing.T) {
 
 func TestComponentUpdate_InvalidVisibility(t *testing.T) {
 	h, _ := newTestComponentsHandler(t)
-	body, _ := json.Marshal(updateComponentRequest{Visibility: "restricted"})
+	body, _ := json.Marshal(map[string]string{"visibility": "restricted"})
 	r := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", body)
 	w := httptest.NewRecorder()
 	h.Update(w, r)
@@ -527,11 +538,15 @@ func TestComponentUpdate_MalformedBody(t *testing.T) {
 
 func TestComponentUpdate_StoreError(t *testing.T) {
 	h, cs := newTestComponentsHandler(t)
-	cs.updateFn = func(_ context.Context, _, _ string) (*store.Component, error) {
+	_, _ = cs.CreateComponent(context.Background(), &store.Component{
+		Name: "core", Visibility: "private",
+		RPMSeries: []string{}, RPMOSFamilies: []string{}, RPMArchitectures: []string{},
+	})
+	cs.updateFn = func(_ context.Context, _ string, _ store.ComponentPatch) (*store.Component, error) {
 		return nil, errors.New("database locked")
 	}
 
-	body, _ := json.Marshal(updateComponentRequest{Visibility: "public"})
+	body, _ := json.Marshal(map[string]string{"visibility": "public"})
 	r := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", body)
 	w := httptest.NewRecorder()
 	h.Update(w, r)
@@ -553,4 +568,99 @@ func assertErrorCode(t *testing.T, w *httptest.ResponseRecorder, code string) {
 	if e.Code != code {
 		t.Errorf("error code: want %q, got %q", code, e.Code)
 	}
+}
+
+func TestComponentUpdate_AddSeriesProvisionsDirectories(t *testing.T) {
+	h, st := newTestComponentsHandler(t)
+	ctx := context.Background()
+	_, _ = st.CreateComponent(ctx, &store.Component{
+		Name: "bluebird", Visibility: "public",
+		RPMSeries: []string{"38"}, RPMOSFamilies: []string{"el9"}, RPMArchitectures: []string{"x86_64"},
+	})
+
+	body, _ := json.Marshal(map[string][]string{"rpm_series": {"38", "39"}})
+	r := chiRequest(http.MethodPatch, "/api/v1/components/bluebird", "bluebird", body)
+	w := httptest.NewRecorder()
+	h.Update(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp updateComponentResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.RPMSeries) != 2 || resp.RPMSeries[1] != "39" {
+		t.Errorf("rpm_series: want [38 39], got %v", resp.RPMSeries)
+	}
+	if len(resp.RPMTargetsRemoved) != 0 {
+		t.Errorf("rpm_targets_removed: want none, got %v", resp.RPMTargetsRemoved)
+	}
+	if _, err := os.Stat(filepath.Join(h.RPMDataRoot, "rpm", "bluebird", "39", "el9-x86_64")); err != nil {
+		t.Errorf("new series directory not provisioned: %v", err)
+	}
+}
+
+func TestComponentUpdate_RemovedTargetReportedNotDeleted(t *testing.T) {
+	h, st := newTestComponentsHandler(t)
+	ctx := context.Background()
+	comp := &store.Component{
+		Name: "bluebird", Visibility: "public",
+		RPMSeries: []string{"38"}, RPMOSFamilies: []string{"el9", "el10"}, RPMArchitectures: []string{"x86_64"},
+	}
+	_, _ = st.CreateComponent(ctx, comp)
+	if err := h.initRPMTree(ctx, comp); err != nil {
+		t.Fatalf("initRPMTree: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string][]string{"rpm_os_families": {"el9"}})
+	r := chiRequest(http.MethodPatch, "/api/v1/components/bluebird", "bluebird", body)
+	w := httptest.NewRecorder()
+	h.Update(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp updateComponentResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.RPMTargetsRemoved) != 1 || resp.RPMTargetsRemoved[0] != "38/el10-x86_64" {
+		t.Errorf("rpm_targets_removed: want [38/el10-x86_64], got %v", resp.RPMTargetsRemoved)
+	}
+	if _, err := os.Stat(filepath.Join(h.RPMDataRoot, "rpm", "bluebird", "38", "el10-x86_64")); err != nil {
+		t.Errorf("removed target directory must stay on disk: %v", err)
+	}
+}
+
+func TestComponentUpdate_InvalidSegmentRejected(t *testing.T) {
+	h, st := newTestComponentsHandler(t)
+	_, _ = st.CreateComponent(context.Background(), &store.Component{
+		Name: "bluebird", Visibility: "public",
+		RPMSeries: []string{"38"}, RPMOSFamilies: []string{"el9"}, RPMArchitectures: []string{"x86_64"},
+	})
+	body, _ := json.Marshal(map[string][]string{"rpm_series": {"../39"}})
+	r := chiRequest(http.MethodPatch, "/api/v1/components/bluebird", "bluebird", body)
+	w := httptest.NewRecorder()
+	h.Update(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+	assertErrorCode(t, w, "INVALID_REQUEST")
+	if _, err := os.Stat(filepath.Join(h.RPMDataRoot, "rpm", "bluebird")); err == nil {
+		t.Errorf("no directory may be created for a rejected patch")
+	}
+}
+
+func TestComponentUpdate_EmptyPatchRejected(t *testing.T) {
+	h, _ := newTestComponentsHandler(t)
+	r := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", []byte("{}"))
+	w := httptest.NewRecorder()
+	h.Update(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+	assertErrorCode(t, w, "INVALID_REQUEST")
 }

--- a/auth/internal/handler/forward_auth_integration_test.go
+++ b/auth/internal/handler/forward_auth_integration_test.go
@@ -65,7 +65,7 @@ func TestForwardAuthIntegration_PrivateToPublic(t *testing.T) {
 	}
 
 	// --- Step 3: PATCH visibility to "public" via ComponentsHandler ---
-	patchBody, _ := json.Marshal(updateComponentRequest{Visibility: "public"})
+	patchBody, _ := json.Marshal(map[string]string{"visibility": "public"})
 	patchReq := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", patchBody)
 	patchRec := httptest.NewRecorder()
 	compHandler.Update(patchRec, patchReq)
@@ -120,7 +120,7 @@ func TestForwardAuthIntegration_PublicToPrivate(t *testing.T) {
 	}
 
 	// --- Step 3: PATCH visibility to "private" via ComponentsHandler ---
-	patchBody, _ := json.Marshal(updateComponentRequest{Visibility: "private"})
+	patchBody, _ := json.Marshal(map[string]string{"visibility": "private"})
 	patchReq := chiRequest(http.MethodPatch, "/api/v1/components/core", "core", patchBody)
 	patchRec := httptest.NewRecorder()
 	compHandler.Update(patchRec, patchReq)

--- a/auth/internal/handler/forward_auth_test.go
+++ b/auth/internal/handler/forward_auth_test.go
@@ -479,8 +479,8 @@ func (e *errComponentStore) CountActiveComponentKeys(ctx context.Context, compon
 func (e *errComponentStore) DeleteComponentWithRevoke(ctx context.Context, name string) (int64, error) {
 	return e.inner.DeleteComponentWithRevoke(ctx, name)
 }
-func (e *errComponentStore) UpdateComponentVisibility(ctx context.Context, name, vis string) (*store.Component, error) {
-	return e.inner.UpdateComponentVisibility(ctx, name, vis)
+func (e *errComponentStore) UpdateComponent(ctx context.Context, name string, patch store.ComponentPatch) (*store.Component, error) {
+	return e.inner.UpdateComponent(ctx, name, patch)
 }
 
 // FuzzExtractComponent checks the invariants extractComponent must hold for

--- a/auth/internal/store/cached_components.go
+++ b/auth/internal/store/cached_components.go
@@ -174,9 +174,9 @@ func (c *CachedComponentStore) evict(name string) {
 	metrics.ComponentCacheEntries.Set(float64(len(c.entries)))
 }
 
-// UpdateComponentVisibility passes through and evicts the name on success.
-func (c *CachedComponentStore) UpdateComponentVisibility(ctx context.Context, name, visibility string) (*Component, error) {
-	comp, err := c.ComponentStore.UpdateComponentVisibility(ctx, name, visibility)
+// UpdateComponent passes through and evicts the name on success.
+func (c *CachedComponentStore) UpdateComponent(ctx context.Context, name string, patch ComponentPatch) (*Component, error) {
+	comp, err := c.ComponentStore.UpdateComponent(ctx, name, patch)
 	if err == nil && c.enabled() {
 		c.evict(name)
 	}

--- a/auth/internal/store/cached_components_test.go
+++ b/auth/internal/store/cached_components_test.go
@@ -26,7 +26,7 @@ type countingComponentStore struct {
 	comps     map[string]*Component
 	getCalls  int
 	err       error // returned by GetComponent when non-nil
-	updateErr error // returned by UpdateComponentVisibility when non-nil
+	updateErr error // returned by UpdateComponent when non-nil
 	gate      chan struct{}
 }
 
@@ -93,7 +93,7 @@ func (s *countingComponentStore) GetComponent(ctx context.Context, name string) 
 	return c, nil
 }
 
-func (s *countingComponentStore) UpdateComponentVisibility(_ context.Context, name, visibility string) (*Component, error) {
+func (s *countingComponentStore) UpdateComponent(_ context.Context, name string, patch ComponentPatch) (*Component, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.updateErr != nil {
@@ -103,7 +103,9 @@ func (s *countingComponentStore) UpdateComponentVisibility(_ context.Context, na
 	if !ok {
 		return nil, ErrComponentNotFound
 	}
-	c.Visibility = visibility
+	if patch.Visibility != nil {
+		c.Visibility = *patch.Visibility
+	}
 	cp := *c
 	return &cp, nil
 }
@@ -253,7 +255,7 @@ func TestCached_PublicToPrivateEvictsImmediately(t *testing.T) {
 		cs := NewCachedComponentStore(context.Background(), inner, testTTL)
 
 		mustGet(t, cs, "core")
-		if _, err := cs.UpdateComponentVisibility(context.Background(), "core", "private"); err != nil {
+		if _, err := cs.UpdateComponent(context.Background(), "core", ComponentPatch{Visibility: ptr("private")}); err != nil {
 			t.Fatal(err)
 		}
 		c := mustGet(t, cs, "core")
@@ -295,7 +297,7 @@ func TestCached_FailedWriteDoesNotEvict(t *testing.T) {
 		mustGet(t, cs, "core")
 
 		inner.setUpdateErr(errors.New("disk full"))
-		if _, err := cs.UpdateComponentVisibility(context.Background(), "core", "private"); err == nil {
+		if _, err := cs.UpdateComponent(context.Background(), "core", ComponentPatch{Visibility: ptr("private")}); err == nil {
 			t.Fatal("expected write error")
 		}
 		mustGet(t, cs, "core")
@@ -402,7 +404,7 @@ func TestCached_WriteDuringInFlightLookupIsNotResurrected(t *testing.T) {
 
 		// Operator flips visibility while the read is in flight.
 		inner.setGate(nil)
-		if _, err := cs.UpdateComponentVisibility(context.Background(), "core", "private"); err != nil {
+		if _, err := cs.UpdateComponent(context.Background(), "core", ComponentPatch{Visibility: ptr("private")}); err != nil {
 			t.Fatal(err)
 		}
 		close(gate) // stale "public" result now returns to the decorator
@@ -451,3 +453,5 @@ func TestCached_GaugeTracksLen(t *testing.T) {
 		}
 	})
 }
+
+func ptr(v string) *string { return &v }

--- a/auth/internal/store/sqlite.go
+++ b/auth/internal/store/sqlite.go
@@ -703,23 +703,74 @@ func (s *SQLiteStore) DeleteComponentWithRevoke(ctx context.Context, name string
 	return revoked, nil
 }
 
-// UpdateComponentVisibility sets the visibility field for a component.
+// UpdateComponent applies a ComponentPatch in one transaction: nil fields are
+// left as they are, a non-nil list replaces the stored list. The updated
+// record is returned.
 // Returns the updated component record or ErrComponentNotFound if the component does not exist.
 // Uses RETURNING to read back the row in the same statement, avoiding a TOCTOU between
 // the UPDATE and a subsequent SELECT.
-func (s *SQLiteStore) UpdateComponentVisibility(ctx context.Context, name, visibility string) (*Component, error) {
-	row := s.db.QueryRowContext(ctx,
-		`UPDATE components SET visibility = ? WHERE name = ?
-		 RETURNING name, visibility, rpm_series, rpm_os_families, rpm_architectures, created_at`,
-		visibility, name)
-	c, err := scanComponent(row)
+func (s *SQLiteStore) UpdateComponent(ctx context.Context, name string, patch ComponentPatch) (*Component, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("update component: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	current, err := scanComponent(tx.QueryRowContext(ctx,
+		`SELECT name, visibility, rpm_series, rpm_os_families, rpm_architectures, created_at
+		 FROM components WHERE name = ?`, name))
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("update component visibility: %w", ErrComponentNotFound)
+		return nil, fmt.Errorf("update component: %w", ErrComponentNotFound)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("update component visibility: %w", err)
+		return nil, fmt.Errorf("update component: %w", err)
 	}
-	return c, nil
+	if patch.Visibility != nil {
+		current.Visibility = *patch.Visibility
+	}
+	if patch.RPMSeries != nil {
+		current.RPMSeries = *patch.RPMSeries
+	}
+	if patch.RPMOSFamilies != nil {
+		current.RPMOSFamilies = *patch.RPMOSFamilies
+	}
+	if patch.RPMArchitectures != nil {
+		current.RPMArchitectures = *patch.RPMArchitectures
+	}
+	seriesJSON, err := json.Marshal(nonNil(current.RPMSeries))
+	if err != nil {
+		return nil, fmt.Errorf("marshal rpm_series: %w", err)
+	}
+	familiesJSON, err := json.Marshal(nonNil(current.RPMOSFamilies))
+	if err != nil {
+		return nil, fmt.Errorf("marshal rpm_os_families: %w", err)
+	}
+	archsJSON, err := json.Marshal(nonNil(current.RPMArchitectures))
+	if err != nil {
+		return nil, fmt.Errorf("marshal rpm_architectures: %w", err)
+	}
+	row := tx.QueryRowContext(ctx,
+		`UPDATE components
+		 SET visibility = ?, rpm_series = ?, rpm_os_families = ?, rpm_architectures = ?
+		 WHERE name = ?
+		 RETURNING name, visibility, rpm_series, rpm_os_families, rpm_architectures, created_at`,
+		current.Visibility, string(seriesJSON), string(familiesJSON), string(archsJSON), name)
+	updated, err := scanComponent(row)
+	if err != nil {
+		return nil, fmt.Errorf("update component: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("update component: commit: %w", err)
+	}
+	return updated, nil
+}
+
+// nonNil turns a nil slice into an empty one so JSON stores [] rather than null.
+func nonNil(v []string) []string {
+	if v == nil {
+		return []string{}
+	}
+	return v
 }
 
 // LoadComponentSets queries the components table and returns two maps for O(1) lookups:

--- a/auth/internal/store/sqlite_test.go
+++ b/auth/internal/store/sqlite_test.go
@@ -421,7 +421,7 @@ func TestLoadComponentSets(t *testing.T) {
 	}
 }
 
-func TestUpdateComponentVisibility_Success(t *testing.T) {
+func TestUpdateComponent_VisibilitySuccess(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 
@@ -429,9 +429,9 @@ func TestUpdateComponentVisibility_Success(t *testing.T) {
 		t.Fatalf("CreateComponent: %v", err)
 	}
 
-	updated, err := s.UpdateComponentVisibility(ctx, "core", "public")
+	updated, err := s.UpdateComponent(ctx, "core", ComponentPatch{Visibility: strPtr("public")})
 	if err != nil {
-		t.Fatalf("UpdateComponentVisibility: %v", err)
+		t.Fatalf("UpdateComponent: %v", err)
 	}
 	if updated.Visibility != "public" {
 		t.Errorf("expected visibility public, got %q", updated.Visibility)
@@ -450,9 +450,9 @@ func TestUpdateComponentVisibility_Success(t *testing.T) {
 	}
 }
 
-func TestUpdateComponentVisibility_NotFound(t *testing.T) {
+func TestUpdateComponent_NotFound(t *testing.T) {
 	s := newTestStore(t)
-	_, err := s.UpdateComponentVisibility(context.Background(), "nonexistent", "public")
+	_, err := s.UpdateComponent(context.Background(), "nonexistent", ComponentPatch{Visibility: strPtr("public")})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -461,7 +461,7 @@ func TestUpdateComponentVisibility_NotFound(t *testing.T) {
 	}
 }
 
-func TestUpdateComponentVisibility_RoundTrip(t *testing.T) {
+func TestUpdateComponent_VisibilityRoundTrip(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 
@@ -471,9 +471,9 @@ func TestUpdateComponentVisibility_RoundTrip(t *testing.T) {
 
 	// public → private → public
 	for _, vis := range []string{"private", "public"} {
-		got, err := s.UpdateComponentVisibility(ctx, "core", vis)
+		got, err := s.UpdateComponent(ctx, "core", ComponentPatch{Visibility: strPtr(vis)})
 		if err != nil {
-			t.Fatalf("UpdateComponentVisibility(%q): %v", vis, err)
+			t.Fatalf("UpdateComponent(%q): %v", vis, err)
 		}
 		if got.Visibility != vis {
 			t.Errorf("returned visibility: want %q, got %q", vis, got.Visibility)
@@ -920,5 +920,55 @@ func TestCanonicalEmail(t *testing.T) {
 		if got := canonicalEmail(c.in); got != c.want {
 			t.Errorf("canonicalEmail(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+func strPtr(v string) *string { return &v }
+
+func TestUpdateComponent_RPMListsReplaceAndPersist(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	c := newTestComponent("core", "public")
+	c.RPMSeries = []string{"2025"}
+	c.RPMOSFamilies = []string{"el9"}
+	c.RPMArchitectures = []string{"x86_64"}
+	if _, err := s.CreateComponent(ctx, c); err != nil {
+		t.Fatalf("CreateComponent: %v", err)
+	}
+	series := []string{"2025", "38"}
+	got, err := s.UpdateComponent(ctx, "core", ComponentPatch{RPMSeries: &series})
+	if err != nil {
+		t.Fatalf("UpdateComponent: %v", err)
+	}
+	if len(got.RPMSeries) != 2 || got.RPMSeries[1] != "38" {
+		t.Errorf("rpm_series: want [2025 38], got %v", got.RPMSeries)
+	}
+	if len(got.RPMOSFamilies) != 1 || got.RPMOSFamilies[0] != "el9" {
+		t.Errorf("rpm_os_families must be untouched, got %v", got.RPMOSFamilies)
+	}
+	if got.Visibility != "public" {
+		t.Errorf("visibility must be untouched, got %q", got.Visibility)
+	}
+	again, err := s.GetComponent(ctx, "core")
+	if err != nil {
+		t.Fatalf("GetComponent: %v", err)
+	}
+	if len(again.RPMSeries) != 2 {
+		t.Errorf("persisted rpm_series: want 2 entries, got %v", again.RPMSeries)
+	}
+}
+
+func TestUpdateComponent_EmptyPatchIsNoOp(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	if _, err := s.CreateComponent(ctx, newTestComponent("core", "private")); err != nil {
+		t.Fatalf("CreateComponent: %v", err)
+	}
+	got, err := s.UpdateComponent(ctx, "core", ComponentPatch{})
+	if err != nil {
+		t.Fatalf("UpdateComponent: %v", err)
+	}
+	if got.Visibility != "private" {
+		t.Errorf("visibility changed by empty patch: %q", got.Visibility)
 	}
 }

--- a/auth/internal/store/store.go
+++ b/auth/internal/store/store.go
@@ -87,6 +87,20 @@ type Component struct {
 	CreatedAt        time.Time `json:"created_at"`
 }
 
+// ComponentPatch carries the mutable component fields for UpdateComponent.
+// A nil field is left unchanged; a non-nil slice replaces the stored list.
+type ComponentPatch struct {
+	Visibility       *string
+	RPMSeries        *[]string
+	RPMOSFamilies    *[]string
+	RPMArchitectures *[]string
+}
+
+// IsEmpty reports whether the patch changes nothing.
+func (p ComponentPatch) IsEmpty() bool {
+	return p.Visibility == nil && p.RPMSeries == nil && p.RPMOSFamilies == nil && p.RPMArchitectures == nil
+}
+
 // ComponentStore is the interface for component provisioning storage.
 type ComponentStore interface {
 	CreateComponent(ctx context.Context, comp *Component) (*Component, error)
@@ -96,7 +110,7 @@ type ComponentStore interface {
 	RevokeComponentKeys(ctx context.Context, component string) (int64, error)
 	CountActiveComponentKeys(ctx context.Context, component string) (int64, error)
 	DeleteComponentWithRevoke(ctx context.Context, name string) (int64, error)
-	UpdateComponentVisibility(ctx context.Context, name, visibility string) (*Component, error)
+	UpdateComponent(ctx context.Context, name string, patch ComponentPatch) (*Component, error)
 }
 
 // AccountStatus values that align with the accounts.status CHECK constraint.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -258,16 +258,39 @@ before deleting the directory.
 
 ### Updating a component
 
-`PATCH /api/v1/components/{name}` updates mutable fields. Currently only
-`visibility` may be changed. The update is persisted immediately and takes
-effect on the next subscriber request — no restart required.
+`PATCH /api/v1/components/{name}` updates `visibility`, `rpm_series`, `rpm_os_families` and `rpm_architectures`.
+Every field is optional and at least one must be present; a list replaces the stored list.
+Values follow the same path-segment rule as creation.
+The update is persisted immediately and takes effect on the next subscriber request, no restart required.
+
+New `series × os_family × architecture` combinations are provisioned on disk before the record changes, so a failed directory creation (`RPM_INIT_FAILED`) leaves the record untouched.
+Combinations the patch stops declaring are returned in `rpm_targets_removed` as `<series>/<family>-<arch>`; their directories and packages stay on disk and keep being served until an operator removes them, the same rule as for `DELETE`.
 
 ```bash
-curl -s -X PATCH https://admin.pkg.example.org/api/v1/components/minion \
+curl -s -X PATCH https://admin.pkg.example.org/api/v1/components/bluebird \
   -H 'Content-Type: application/json' \
   --cookie "$COOKIE" \
-  -d '{"visibility":"public"}' | jq .
+  -d '{"rpm_series":["38","39"],"rpm_os_families":["el9"]}' | jq .
 ```
+
+```json
+{
+  "name": "bluebird",
+  "visibility": "public",
+  "rpm_series": ["38", "39"],
+  "rpm_os_families": ["el9"],
+  "rpm_architectures": ["x86_64"],
+  "created_at": "2026-09-07T13:25:59Z",
+  "rpm_targets_removed": ["38/el10-x86_64"]
+}
+```
+
+| Code | Status | When |
+|------|--------|------|
+| `INVALID_REQUEST` | 400 | Malformed JSON, empty patch, or a value that is not a single path segment |
+| `INVALID_VISIBILITY` | 400 | `visibility` is not `public` or `private` |
+| `COMPONENT_NOT_FOUND` | 404 | No such component |
+| `RPM_INIT_FAILED` | 500 | A new directory could not be created; the record is unchanged |
 
 ## Operators
 


### PR DESCRIPTION
## Summary
Adding a series or an OS target to an existing component meant deleting and recreating it, which revokes every key scoped to it. `PATCH /api/v1/components/{name}` now accepts `rpm_series`, `rpm_os_families` and `rpm_architectures` alongside `visibility`.

- Every field optional, at least one required; a list replaces the stored list; values follow the same path-segment rule as creation.
- New `series × family × arch` combinations are provisioned on disk **before** the record changes, so a failed mkdir (`RPM_INIT_FAILED`) leaves the record untouched.
- Combinations the patch stops declaring are returned as `rpm_targets_removed` and stay on disk, the same rule `DELETE` follows.
- Store: `UpdateComponentVisibility` becomes `UpdateComponent(name, patch)` in one transaction; the cached wrapper evicts on success as before.
- Admin UI: the Edit dialog exposes the three lists and, when a save drops targets, keeps the dialog open listing them with a note that their directories remain.
- Docs: PATCH body, response and error codes in the API reference.

Closes #210

## Verification
`make test` (new handler tests: add-series provisions the directory, removed target is reported and kept on disk, invalid segment creates nothing, empty patch rejected; store tests for list replacement and empty patch), `make lint`, `npm run typecheck`, `make admin-ui-test`, `make build`, `make docs-build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
