### PR TITLE
feat(admin-ui): delete a component through the safe-locked API

### DIFF
--- a/auth/internal/admin-ui/src/api/componentDelete.test.ts
+++ b/auth/internal/admin-ui/src/api/componentDelete.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { ApiError } from "./client";
+import { canConfirmDelete, parseDeleteImpact } from "./componentDelete";
+
+describe("parseDeleteImpact", () => {
+  it("extracts the impact from the 409 CONFIRM_REQUIRED envelope", () => {
+    const err = new ApiError(
+      409,
+      {
+        code: "CONFIRM_REQUIRED",
+        message: "Deleting will revoke keys",
+        impact: { keys_revoked: 3, rpm_series_removed: ["38", "2025"] },
+      },
+      "HTTP 409",
+    );
+    expect(parseDeleteImpact(err)).toEqual({ keys_revoked: 3, rpm_series_removed: ["38", "2025"] });
+  });
+
+  it("tolerates a preview with missing fields", () => {
+    const err = new ApiError(409, { code: "CONFIRM_REQUIRED", message: "x" }, "HTTP 409");
+    expect(parseDeleteImpact(err)).toEqual({ keys_revoked: 0, rpm_series_removed: [] });
+  });
+
+  it("rethrows anything that is not the preview", () => {
+    const notFound = new ApiError(404, { code: "COMPONENT_NOT_FOUND", message: "nope" }, "HTTP 404");
+    expect(() => parseDeleteImpact(notFound)).toThrow(notFound);
+    const network = new Error("offline");
+    expect(() => parseDeleteImpact(network)).toThrow(network);
+  });
+});
+
+describe("canConfirmDelete", () => {
+  it("requires the exact name, case included", () => {
+    expect(canConfirmDelete("bluebird", "bluebird")).toBe(true);
+    expect(canConfirmDelete("Bluebird", "bluebird")).toBe(false);
+    expect(canConfirmDelete("bluebird ", "bluebird")).toBe(false);
+    expect(canConfirmDelete("", "bluebird")).toBe(false);
+    expect(canConfirmDelete("", "")).toBe(false);
+  });
+});

--- a/auth/internal/admin-ui/src/api/componentDelete.ts
+++ b/auth/internal/admin-ui/src/api/componentDelete.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// The safe-locked delete. DELETE /api/v1/components/{name} without ?confirm
+// answers 409 CONFIRM_REQUIRED with an impact preview; the same call with
+// ?confirm=<name> revokes the component's keys and removes the record. RPM
+// directories stay on disk. The pure helpers here are unit-tested; the hooks
+// wrap them for React Query.
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { ApiError, apiFetch } from "./client";
+
+export interface DeleteImpact {
+  keys_revoked: number;
+  rpm_series_removed: string[];
+}
+
+export interface DeleteResult {
+  keys_revoked: number;
+}
+
+// parseDeleteImpact turns the 409 the preview call throws into the impact
+// object. Any other error is rethrown unchanged.
+export function parseDeleteImpact(err: unknown): DeleteImpact {
+  if (err instanceof ApiError && err.status === 409 && err.code === "CONFIRM_REQUIRED") {
+    const impact = (err.payload as { impact?: Partial<DeleteImpact> } | null)?.impact ?? {};
+    return {
+      keys_revoked: Number(impact.keys_revoked ?? 0),
+      rpm_series_removed: Array.isArray(impact.rpm_series_removed) ? impact.rpm_series_removed : [],
+    };
+  }
+  throw err;
+}
+
+// canConfirmDelete gates the destructive button: the typed name must equal
+// the component name exactly. The API enforces the same rule, case included.
+export function canConfirmDelete(typed: string, name: string): boolean {
+  return typed === name && name.length > 0;
+}
+
+export async function previewComponentDelete(name: string): Promise<DeleteImpact> {
+  try {
+    await apiFetch<unknown>(`/api/v1/components/${encodeURIComponent(name)}`, { method: "DELETE" });
+  } catch (err) {
+    return parseDeleteImpact(err);
+  }
+  // A 2xx here would mean the server deleted without confirmation, which the
+  // API contract forbids. Treat it as an error so the UI never hides it.
+  throw new Error(`DELETE ${name} without confirm did not return the impact preview`);
+}
+
+export function useDeleteComponent(name: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      apiFetch<DeleteResult>(
+        `/api/v1/components/${encodeURIComponent(name)}?confirm=${encodeURIComponent(name)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["components"] }),
+  });
+}

--- a/auth/internal/admin-ui/src/routes/Components.tsx
+++ b/auth/internal/admin-ui/src/routes/Components.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import {
   Component,
@@ -11,6 +11,12 @@ import {
   useCreateComponent,
   useUpdateComponent,
 } from "../api/components";
+import {
+  type DeleteImpact,
+  canConfirmDelete,
+  previewComponentDelete,
+  useDeleteComponent,
+} from "../api/componentDelete";
 import { ErrorBanner } from "../components/ErrorBanner";
 import { Modal } from "../components/Modal";
 
@@ -18,6 +24,7 @@ export function Components() {
   const list = useComponents();
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<Component | null>(null);
+  const [deleting, setDeleting] = useState<Component | null>(null);
 
   return (
     <div>
@@ -55,6 +62,9 @@ export function Components() {
                 <td>
                   <button className="btn-secondary" onClick={() => setEditing(c)}>
                     Edit
+                  </button>{" "}
+                  <button className="btn-danger" onClick={() => setDeleting(c)}>
+                    Delete
                   </button>
                 </td>
               </tr>
@@ -73,6 +83,9 @@ export function Components() {
       <CreateComponentModal open={createOpen} onClose={() => setCreateOpen(false)} />
       {editing && (
         <EditComponentModal component={editing} onClose={() => setEditing(null)} />
+      )}
+      {deleting && (
+        <DeleteComponentModal component={deleting} onClose={() => setDeleting(null)} />
       )}
     </div>
   );
@@ -188,6 +201,95 @@ function EditComponentModal({ component, onClose }: { component: Component; onCl
         Other fields (series / OS families / architectures) are immutable per the components API.
       </p>
       <ErrorBanner error={update.error} />
+    </Modal>
+  );
+}
+
+// DeleteComponentModal drives the API's safe-lock: first the preview (the 409
+// impact), then the destructive call only once the operator has typed the
+// component name exactly. The API enforces the same rule; this mirrors it so
+// the UI cannot skip the preview.
+function DeleteComponentModal({ component, onClose }: { component: Component; onClose: () => void }) {
+  const del = useDeleteComponent(component.name);
+  const [impact, setImpact] = useState<DeleteImpact | null>(null);
+  const [previewError, setPreviewError] = useState<unknown>(null);
+  const [typed, setTyped] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    previewComponentDelete(component.name)
+      .then((i) => {
+        if (!cancelled) setImpact(i);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setPreviewError(e);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [component.name]);
+
+  const submit = async () => {
+    try {
+      await del.mutateAsync();
+      onClose();
+    } catch {
+      /* error rendered below */
+    }
+  };
+
+  const ready = impact !== null && canConfirmDelete(typed, component.name) && !del.isPending;
+
+  return (
+    <Modal
+      open={true}
+      title={`Delete ${component.name}`}
+      onClose={onClose}
+      actions={
+        <>
+          <button className="btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="btn-danger" onClick={submit} disabled={!ready}>
+            Delete component
+          </button>
+        </>
+      }
+    >
+      {impact === null && previewError === null && <p className="muted">Loading impact…</p>}
+      {impact !== null && (
+        <div className="field">
+          <p>Deleting this component will:</p>
+          <ul>
+            <li>
+              revoke <strong>{impact.keys_revoked}</strong> active subscription key
+              {impact.keys_revoked === 1 ? "" : "s"}
+            </li>
+            <li>
+              drop the auth records for RPM series{" "}
+              {impact.rpm_series_removed.length > 0 ? (
+                impact.rpm_series_removed.map((sName) => <code key={sName}>{sName} </code>)
+              ) : (
+                <em>none</em>
+              )}
+            </li>
+          </ul>
+          <p className="muted">
+            Published packages and directories stay on disk and keep being served by the web tier;
+            remove them by hand if they should disappear. This cannot be undone.
+          </p>
+          <label>
+            Type <code>{component.name}</code> to confirm
+          </label>
+          <input
+            type="text"
+            value={typed}
+            autoComplete="off"
+            onChange={(e) => setTyped(e.target.value)}
+          />
+        </div>
+      )}
+      <ErrorBanner error={previewError ?? del.error} />
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary
The Components page had Create and Edit but no way to delete, although the API has a safe-locked delete. The new Delete action drives that contract: the dialog first calls `DELETE` without `confirm` and shows the 409 impact preview (keys to revoke, RPM series affected), then enables the destructive call only once the operator has typed the component name exactly. Directories stay on disk, and the dialog says so.

The preview parser and the exact-name gate are pure functions in `api/componentDelete.ts` with Vitest coverage. A rendered-modal test needs a jsdom harness the SPA does not have yet; noted in the change's tasks.

Closes #211

## Verification
`npm run typecheck`, `make admin-ui-test` (9 tests), `make build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
