### PR TITLE
fix(traefik): only route GET and HEAD to the registry on the subscriber path

### DIFF
--- a/traefik/dynamic-ci/routers-public.yml
+++ b/traefik/dynamic-ci/routers-public.yml
@@ -29,10 +29,14 @@ http:
       service: packyard-deb-svc
       # No tls: — CI uses plaintext HTTP
 
+    # Subscribers only read. Forward-auth allows every method on a public
+    # component and Zot enforces nothing itself, so write methods must not
+    # reach the registry: they match no router here and get 404. Promotions
+    # push to Zot on its loopback port and never traverse these routers.
     oci-authenticated:
       entryPoints:
         - web
-      rule: "PathPrefix(`/oci/`)"
+      rule: "PathPrefix(`/oci/`) && (Method(`GET`) || Method(`HEAD`))"
       middlewares:
         - packyard-auth       # MUST be first — forwardAuth sees full /oci/v2/... for scope check
         - packyard-strip-oci  # MUST be second — strips /oci before Zot receives request
@@ -48,7 +52,7 @@ http:
     oci-v2-authenticated:
       entryPoints:
         - websecure
-      rule: 'PathPrefix(`/v2/`)'
+      rule: 'PathPrefix(`/v2/`) && (Method(`GET`) || Method(`HEAD`))'
       middlewares:
         - packyard-v2-to-oci  # MUST be first — turns /v2/oci/... into /oci/v2/...
         - packyard-auth       # sees the rewritten /oci/v2/lts-<component>/... path

--- a/traefik/dynamic-dev/routers-public.yml
+++ b/traefik/dynamic-dev/routers-public.yml
@@ -33,10 +33,14 @@ http:
       service: packyard-deb-svc
       tls: {}
 
+    # Subscribers only read. Forward-auth allows every method on a public
+    # component and Zot enforces nothing itself, so write methods must not
+    # reach the registry: they match no router here and get 404. Promotions
+    # push to Zot on its loopback port and never traverse these routers.
     oci-authenticated:
       entryPoints:
         - websecure
-      rule: "PathPrefix(`/oci/`)"
+      rule: "PathPrefix(`/oci/`) && (Method(`GET`) || Method(`HEAD`))"
       middlewares:
         - packyard-auth       # MUST be first — forwardAuth sees full /oci/v2/... for scope check
         - packyard-strip-oci  # MUST be second — strips /oci before Zot receives request
@@ -52,7 +56,7 @@ http:
     oci-v2-authenticated:
       entryPoints:
         - websecure
-      rule: "PathPrefix(`/v2/`)"
+      rule: "PathPrefix(`/v2/`) && (Method(`GET`) || Method(`HEAD`))"
       middlewares:
         - packyard-v2-to-oci  # MUST be first — turns /v2/oci/... into /oci/v2/...
         - packyard-auth       # sees the rewritten /oci/v2/lts-<component>/... path

--- a/traefik/dynamic/routers-public.yml
+++ b/traefik/dynamic/routers-public.yml
@@ -33,10 +33,14 @@ http:
       tls:
         certResolver: letsencrypt
 
+    # Subscribers only read. Forward-auth allows every method on a public
+    # component and Zot enforces nothing itself, so write methods must not
+    # reach the registry: they match no router here and get 404. Promotions
+    # push to Zot on its loopback port and never traverse these routers.
     oci-authenticated:
       entryPoints:
         - websecure
-      rule: 'Host(`{{ env "PKG_DOMAIN" }}`) && PathPrefix(`/oci/`)'
+      rule: 'Host(`{{ env "PKG_DOMAIN" }}`) && PathPrefix(`/oci/`) && (Method(`GET`) || Method(`HEAD`))'
       middlewares:
         - packyard-auth       # MUST be first — forwardAuth sees full /oci/v2/... for scope check
         - packyard-strip-oci  # MUST be second — strips /oci before Zot receives request
@@ -53,7 +57,7 @@ http:
     oci-v2-authenticated:
       entryPoints:
         - websecure
-      rule: 'Host(`{{ env "PKG_DOMAIN" }}`) && PathPrefix(`/v2/`)'
+      rule: 'Host(`{{ env "PKG_DOMAIN" }}`) && PathPrefix(`/v2/`) && (Method(`GET`) || Method(`HEAD`))'
       middlewares:
         - packyard-v2-to-oci  # MUST be first — turns /v2/oci/... into /oci/v2/...
         - packyard-auth       # sees the rewritten /oci/v2/lts-<component>/... path


### PR DESCRIPTION
## Summary
Forward-auth allows every HTTP method on a public component and Zot has neither authentication nor a read-only policy of its own. Anonymous clients could therefore open blob uploads and push manifests through `/oci/` and `/v2/` on a public component, overwriting the tags subscribers pull. On pkg.onms.eu an anonymous `POST /oci/v2/lts-bluebird/core/blobs/uploads/` answered 202.

The two OCI routers in `dynamic`, `dynamic-ci` and `dynamic-dev` now match `GET` and `HEAD` only. Write methods match no router and get 404 at the edge. Promotions push to Zot over the SSH tunnel on its loopback port and never traverse these routers.

Applied on pkg.onms.eu as a hotfix before this PR. Verified there: `POST` and `PUT` on both path shapes answer 404, `GET` and `HEAD` answer 200, `docker pull` through the public hostname works.

The durable half, forward-auth answering 405 for write methods regardless of visibility, follows in the `e2e-subscriber-coverage` change together with an e2e assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
