### PR TITLE
test: prove the DEB subscriber suite fails without the /deb strip (do not merge)

### DIFF
--- a/traefik/dynamic-ci/routers-public.yml
+++ b/traefik/dynamic-ci/routers-public.yml
@@ -25,7 +25,6 @@ http:
       rule: "PathPrefix(`/deb/`)"
       middlewares:
         - packyard-auth       # MUST be first — forwardAuth sees the full /deb/<component>/... path
-        - packyard-strip-deb
       service: packyard-deb-svc
       # No tls: — CI uses plaintext HTTP
 


### PR DESCRIPTION
Not for merge. Verification task 5.1 of the `e2e-subscriber-coverage` change.

The DEB router in the CI Traefik config loses `packyard-strip-deb`, so nginx sees `/deb/<component>/...` instead of `<component>/...`. `make e2e-deb` has to fail on that. If it passes, the suite is vacuous.

Closed and deleted once the run has reported.