### PR TITLE
fix(auth): refuse write methods on subscriber paths with 405

### DIFF
--- a/auth/internal/handler/forward_auth.go
+++ b/auth/internal/handler/forward_auth.go
@@ -20,7 +20,8 @@ import (
 )
 
 // ForwardAuthHandler validates subscriber credentials for Traefik forwardAuth.
-// GET /auth — returns 200 (allow), 401 (deny), or 503 (error/fail-closed).
+// GET /auth — returns 200 (allow), 401 (deny), 405 (write method on a
+// subscriber path), or 503 (error/fail-closed).
 // Component visibility is resolved via a live DB lookup on every request so that
 // visibility changes take effect immediately without a service restart.
 //
@@ -57,6 +58,24 @@ func (h *ForwardAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		metrics.RequestDuration.Observe(time.Since(start).Seconds())
 	}()
+
+	// Subscribers only read. The Traefik routers already refuse write methods,
+	// but forward-auth is the second line: a new route or an edited rule must
+	// not silently re-open writes into the serving containers, none of which
+	// authenticate on their own. Traefik puts the original method in
+	// X-Forwarded-Method; when the header is absent, the request method is the
+	// only thing to go on.
+	method := r.Header.Get("X-Forwarded-Method")
+	if method == "" {
+		method = r.Method
+	}
+	if method != http.MethodGet && method != http.MethodHead {
+		h.Logger.Warn("write method refused on a subscriber path", logsafe.Attr("method", method))
+		metrics.RequestsTotal.WithLabelValues("denied-method").Inc()
+		w.Header().Set("Allow", "GET, HEAD")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
 
 	requestedComponent, ok := extractComponent(r.Header.Get("X-Forwarded-Uri"))
 	if !ok {

--- a/auth/internal/handler/forward_auth_test.go
+++ b/auth/internal/handler/forward_auth_test.go
@@ -581,3 +581,70 @@ func TestForwardAuth_PublicComponentCache_SurvivesOutage(t *testing.T) {
 		run(t, 0, http.StatusServiceUnavailable)
 	})
 }
+
+// A subscriber path is read-only. Traefik refuses write methods at the router,
+// and forward-auth refuses them again so a router change cannot re-open writes
+// into the serving containers, which have no authentication of their own.
+func TestForwardAuth_WriteMethodRefused(t *testing.T) {
+	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		t.Run(method, func(t *testing.T) {
+			h := newTestHandler(&mockStore{
+				getByValueFn: func(_ context.Context, value string) (*store.Key, error) {
+					return &store.Key{ID: value, Component: "core", Active: true}, nil
+				},
+			})
+			req := httptest.NewRequest("GET", "/auth", nil)
+			req.Header.Set("Authorization", basicAuthHeader(validKey))
+			req.Header.Set("X-Forwarded-Uri", "/oci/v2/lts-core/blobs/uploads/")
+			req.Header.Set("X-Forwarded-Method", method)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Errorf("expected 405, got %d", w.Code)
+			}
+			if got := w.Header().Get("Allow"); got != "GET, HEAD" {
+				t.Errorf("expected Allow: GET, HEAD; got %q", got)
+			}
+			if w.Body.Len() != 0 {
+				t.Errorf("expected empty body, got %q", w.Body.String())
+			}
+		})
+	}
+}
+
+// A public component is allowed without credentials, but not for a write.
+func TestForwardAuth_WriteMethodRefusedOnPublicComponent(t *testing.T) {
+	cs := newStubComponentStore()
+	cs.comps["core"] = &store.Component{Name: "core", Visibility: "public"}
+	h := newTestHandler(&mockStore{})
+	h.ComponentStore = cs
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.Header.Set("X-Forwarded-Uri", "/oci/v2/lts-core/manifests/2025")
+	req.Header.Set("X-Forwarded-Method", "PUT")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+// HEAD is how docker and apt probe; it must stay allowed.
+func TestForwardAuth_HeadAllowed(t *testing.T) {
+	h := newTestHandler(&mockStore{
+		getByValueFn: func(_ context.Context, value string) (*store.Key, error) {
+			return &store.Key{ID: value, Component: "core", Active: true}, nil
+		},
+	})
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.Header.Set("Authorization", basicAuthHeader(validKey))
+	req.Header.Set("X-Forwarded-Uri", "/rpm/core/2025/el9-x86_64/")
+	req.Header.Set("X-Forwarded-Method", "HEAD")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}

--- a/auth/internal/metrics/metrics.go
+++ b/auth/internal/metrics/metrics.go
@@ -10,7 +10,7 @@ import "github.com/prometheus/client_golang/prometheus"
 
 var (
 	// RequestsTotal counts forwardAuth requests by outcome status.
-	// Labels: status = allowed | denied | error
+	// Labels: status = allowed | allowed-public | denied | denied-method | error
 	RequestsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "packyard_auth_requests_total",

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -6,7 +6,7 @@ Metrics are exposed by the auth service at `http://auth:9090/metrics` (Docker-in
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `packyard_auth_requests_total{status="allowed\|denied\|error"}` | Counter | forwardAuth request outcomes |
+| `packyard_auth_requests_total{status="allowed\|allowed-public\|denied\|denied-method\|error"}` | Counter | forwardAuth request outcomes |
 | `packyard_auth_duration_seconds` | Histogram | forwardAuth latency |
 | `packyard_auth_component_cache_requests_total` | Counter | Component lookups through the public-component cache (forward-auth and admin reads) |
 | `packyard_auth_component_cache_hits_total` | Counter | Lookups answered from the cache without a store call; hit ratio is hits / requests |


### PR DESCRIPTION
## Summary
The `GET`/`HEAD` restriction on the subscriber routers was the hotfix for GHSA-mh97-rrf3-66wc, and until now it was the only thing standing between an anonymous client and a write into Zot, aptly or the RPM tree. None of those containers authenticate on their own, and forward-auth answered `200` for a public component whatever the method.

Forward-auth now refuses anything but `GET` and `HEAD` on subscriber paths with `405 Method Not Allowed` and an `Allow: GET, HEAD` header. It reads the original method from `X-Forwarded-Method` and falls back to the request method when that header is absent. The outcome is counted as `denied-method` on `packyard_auth_requests_total`.

This is task 0.3 of the `e2e-subscriber-coverage` change, the last item that was deferred out of #230.

## Verification
- New unit tests: `POST`, `PUT`, `PATCH` and `DELETE` get `405` with the `Allow` header, a write to a public component gets `405` as well, and `HEAD` stays allowed.
- `gofmt`, `go vet` and `go test ./...` pass in `auth/`.
- The end-to-end AC6 assertion in `tests/e2e/oci-subscriber.sh` still expects `404` or `405`, so the edge-level refusal keeps working either way.

Closes #232