### PR TITLE
chore(compose): pin every third-party image by digest and let Dependabot maintain them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,9 +24,27 @@ updates:
       - dependencies
       - github-actions
 
-  # Docker base images — service Dockerfiles only (auth, rpm, backup, aptly, static).
-  # Images declared in compose.yml are not scanned by Dependabot's docker ecosystem,
-  # and the repository root has no Dockerfile.
+  # Container images declared in compose.yml. `docker-compose` is a separate
+  # ecosystem from `docker`, generally available since February 2025. Its file
+  # matcher is /(docker-)?compose(-\w+)?(\.[\w-]+)?\.ya?ml/, which covers
+  # compose.yml but not compose.override.<name>.yml; scripts/lint-image-pins.sh
+  # keeps the arm64 override's Zot pin in step and rejects any unpinned image.
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    labels:
+      - dependencies
+      - docker
+    ignore:
+      # First-party images. Their tag is written by the release process
+      # (RELEASING.md § 1), never by a bot.
+      - dependency-name: "ghcr.io/no42-org/packyard-*"
+
+  # Docker base images — service Dockerfiles (auth, rpm, backup, aptly, static).
+  # The repository root has no Dockerfile, so each service gets its own entry.
   - package-ecosystem: docker
     directory: /auth
     schedule:

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -148,3 +148,6 @@ jobs:
       # paths-filter takes its filters as a YAML string; neither linter above
       # parses it, and a bad indent there skips every gate at run time.
       - run: make lint-workflows
+      # Compose images must be pinned by digest; Dependabot maintains the pins
+      # in compose.yml and cannot see the override files.
+      - run: make lint-image-pins

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,21 @@ Every new source file starts with an SPDX header matching the repository license
 
 Use the comment syntax of the language. Leave existing headers as they are.
 
+## Container image pins
+
+Every third-party image, in a `Dockerfile` or a compose file, is pinned by tag and digest:
+
+```yaml
+image: traefik:3.6.12@sha256:171c9c3565b29f6c133f1c1b43c5d4e5853415198e9e1078c001f8702ff66aec
+```
+
+A tag alone is mutable, and the deployment host runs watchtower, which re-pulls a tag that moved.
+`make lint-image-pins` fails the build on an unpinned image and on a Zot version that differs between `compose.yml` and `compose.override.arm64.yml`.
+The `ghcr.io/no42-org/packyard-*` images are the exception: the release process writes their tag, so they carry no digest.
+
+Dependabot maintains the pins weekly: the `docker-compose` ecosystem for `compose.yml` and the `docker` ecosystem for each service `Dockerfile`.
+Its compose matcher does not see `compose.override.<name>.yml`, so a bump there is manual and the lint check is what catches a forgotten one.
+
 ## Releases
 
 Maintainers cut releases from `main` by tag. The procedure is in [RELEASING.md](RELEASING.md).

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ UNAME_S := $(shell uname -s)
 
 .PHONY: help docs-install docs-serve docs-build docs-clean check-node test-rpm-publish test-publish-scripts \
         admin-ui admin-ui-install admin-ui-test admin-ui-dev admin-ui-clean \
-        build build-clean test lint lint-workflows build-image-auth build-image-rpm build-images \
+        build build-clean test lint lint-workflows lint-image-pins build-image-auth build-image-rpm build-images \
         ci-guard ci-signing-key ci-stack-up ci-stack-down ci-stack-logs ci-seed ci-verify-env ci-publish-fixtures e2e-observability e2e-rpm e2e-deb e2e-oci
 
 ## help: Show this help
@@ -112,6 +112,10 @@ lint:
 ## lint-workflows: Validate YAML embedded in workflow action inputs (paths-filter)
 lint-workflows:
 	python3 scripts/lint-workflow-filters.py
+
+## lint-image-pins: Assert every third-party compose image is pinned by digest
+lint-image-pins:
+	bash scripts/lint-image-pins.sh
 
 ## build-image-auth: Build the auth container image locally (no push)
 build-image-auth:

--- a/compose.override.arm64.yml
+++ b/compose.override.arm64.yml
@@ -11,4 +11,4 @@
 
 services:
   zot:
-    image: ghcr.io/project-zot/zot-linux-arm64:v2.1.2
+    image: ghcr.io/project-zot/zot-linux-arm64:v2.1.2@sha256:c3fc47782d98b731d5928a24182b495e28cc92f9dcf1d5317f7dbd632e10bf30

--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 services:
 
   traefik:
-    image: traefik:3.6.12
+    image: traefik:3.6.12@sha256:171c9c3565b29f6c133f1c1b43c5d4e5853415198e9e1078c001f8702ff66aec
     restart: unless-stopped
     cap_drop: [ALL]
     cap_add:
@@ -108,7 +108,7 @@ services:
       - backend  # promotion-only; not Traefik-proxied for subscribers
 
   deb:
-    image: nginx:alpine
+    image: nginx:1.31-alpine@sha256:72ba65eb42c10344912a84ff42408db7d34f2feb642204570ab8fc5ffd29f1d3
     restart: unless-stopped
     user: "101:101"             # run directly as nginx user — no privilege drop, no cap_add needed
     cap_drop: [ALL]
@@ -144,7 +144,7 @@ services:
       - proxy
 
   zot:
-    image: ghcr.io/project-zot/zot-linux-amd64:v2.1.2
+    image: ghcr.io/project-zot/zot-linux-amd64:v2.1.2@sha256:073f30d99fbdbcd8869334231c9ca45c75e535e4bdc6e28cc8a1541abe7a3f71
     restart: unless-stopped
     cap_drop: [ALL]
     security_opt:
@@ -162,7 +162,7 @@ services:
       - proxy
 
   rustfs:
-    image: rustfs/rustfs:latest
+    image: rustfs/rustfs:v1.0.0-rc.5@sha256:b7014e0ce2bc703c1316b3ef760e29dfae61fe4a50d1a66fa89638e0f8ea211f
     restart: unless-stopped
     cap_drop: [ALL]
     security_opt:
@@ -189,7 +189,7 @@ services:
       - backend  # promotion-only; not Traefik-proxied for subscribers
 
   rustfs-init:
-    image: amazon/aws-cli:latest
+    image: amazon/aws-cli:2.36.40@sha256:b6aeb95d19d7f5a8cae4eb814cb16739b6b2a4f2f46f427ada6a8c9a20d9881d
     depends_on:
       rustfs:
         condition: service_healthy

--- a/scripts/lint-image-pins.sh
+++ b/scripts/lint-image-pins.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# lint-image-pins.sh — every third-party container image in a compose file
+# must be pinned `tag@sha256:<digest>`, the way the Dockerfiles pin their
+# bases. A tag alone is mutable: the deployment host runs watchtower, which
+# re-pulls a moved tag and once broke the auth service that way.
+#
+# Two exemptions:
+#   - `ghcr.io/no42-org/packyard-*` — first-party images. Their tag is written
+#     by the release process (RELEASING.md § 1), not by a bot, and pinning a
+#     digest there would mean a compose change for every rebuild.
+#   - `*:local` — images built by a test stack, never pulled.
+#
+# It also asserts the Zot version matches between compose.yml and the arm64
+# override. Dependabot's docker-compose matcher only sees `compose.yml`, so
+# without this the override silently keeps an older Zot.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+FAILED=0
+note() { echo "lint-image-pins: $*" >&2; FAILED=1; }
+
+for f in compose.yml compose.override.*.yml tests/publish/compose.yml; do
+  [ -f "$f" ] || continue
+  while IFS= read -r entry; do
+    lineno="${entry%%:*}"                  # `grep -n` prefix
+    ref="${entry#*image:}"
+    ref="${ref#"${ref%%[![:space:]]*}"}"   # strip leading whitespace
+    case "${ref}" in
+      ghcr.io/no42-org/packyard-*) continue ;;
+      *:local) continue ;;
+    esac
+    case "${ref}" in
+      *@sha256:*) ;;
+      *) note "${f}:${lineno}: '${ref}' is not pinned by digest (expected <image>:<tag>@sha256:<digest>)" ;;
+    esac
+  done < <(grep -n '^[[:space:]]*image:' "$f")
+done
+
+zot_version() { sed -n "s|.*zot-linux-$1:\([^@]*\)@.*|\1|p" "$2" | head -1; }
+amd64=$(zot_version amd64 compose.yml)
+arm64=$(zot_version arm64 compose.override.arm64.yml)
+if [ -z "${amd64}" ] || [ -z "${arm64}" ]; then
+  note "could not read the Zot version from compose.yml (${amd64:-unset}) or compose.override.arm64.yml (${arm64:-unset})"
+elif [ "${amd64}" != "${arm64}" ]; then
+  note "Zot version differs: compose.yml has ${amd64}, compose.override.arm64.yml has ${arm64}"
+fi
+
+if [ "${FAILED}" -ne 0 ]; then
+  exit 1
+fi
+echo "image pins OK"


### PR DESCRIPTION
## Summary
`compose.yml` mixed pin styles while every `Dockerfile` in the tree is pinned `tag@sha256`. `rustfs/rustfs:latest`, `amazon/aws-cli:latest` and `nginx:alpine` floated; `traefik:3.6.12` and the Zot images had a tag but no digest. A mutable tag is also what the deployment host's watchtower follows, and that is how the auth service broke once.

- Every third-party image in `compose.yml` and `compose.override.arm64.yml` is now `tag@sha256:<digest>`. `latest` was resolved to the version tag with the identical digest: `rustfs/rustfs:v1.0.0-rc.5`, `amazon/aws-cli:2.36.40`, and `nginx:alpine` to `nginx:1.31-alpine`, the same pin `static/Dockerfile` already uses.
- `.github/dependabot.yml` gains the `docker-compose` ecosystem (generally available since February 2025), weekly, with the same cooldown and labels as the other entries. `ghcr.io/no42-org/packyard-*` is ignored: the release process writes those tags.
- `scripts/lint-image-pins.sh`, wired into the quality gates as `make lint-image-pins`, rejects any third-party compose image without a digest and any Zot version drift between `compose.yml` and the arm64 override. Dependabot's compose matcher is `/(docker-)?compose(-\w+)?(\.[\w-]+)?\.ya?ml/`, which never sees `compose.override.<name>.yml`, so that check is what catches a forgotten bump there.
- `CONTRIBUTING.md` documents the policy and the exception.

## Verification
- `make lint-image-pins` passes; it fails as expected when Traefik's digest is removed (`compose.yml:4: 'traefik:3.6.12' is not pinned by digest`) and when the arm64 override is moved to `v2.1.1` (`Zot version differs`).
- `docker compose config` validates for `compose.yml` alone and with the arm64, CI and dev overrides.
- `shellcheck` clean; `.github/dependabot.yml` parses.
- Every digest matches what `pkg.onms.eu` already runs, so no running image changes on the next deployment.

Closes #236