### PR TITLE
fix(traefik): trust forwarded headers sanitised by the entryPoint

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -108,6 +108,9 @@ VALID_KEY=your-subscription-key \
 bash tests/e2e/rpm-subscriber.sh
 ```
 
+AC4 repeats the 401 check with `X-Forwarded-Uri`, `X-Forwarded-Prefix` and `X-Forwarded-For` set by the client, pointing at the public component.
+The entryPoint trusts no client, so forward-auth still sees the real path and the private component still answers 401.
+
 ### DEB subscriber test (Story 5.2)
 
 **Prerequisites:** `apt-get`, `dpkg`, `python3`, `curl`, `gpg` installed (requires Debian/Ubuntu host or container).

--- a/tests/e2e/rpm-subscriber.sh
+++ b/tests/e2e/rpm-subscriber.sh
@@ -143,6 +143,26 @@ else
   fail "AC3 — expected HTTP 401 for invalid key; got HTTP ${HTTP_STATUS}"
 fi
 
+# ─── AC4: Forwarded headers from the client cannot move the scope ────────────
+# forward-auth scopes on X-Forwarded-Uri. The entryPoint trusts no client, so a
+# client-supplied X-Forwarded-* never reaches the auth service and the private
+# component still answers 401. Regression test for the trustForwardHeader
+# migration and, in shape, for GHSA-6384-m2mw-rf54.
+
+echo ""
+echo "=== AC4: Spoofed forwarded headers do not change the scope decision ==="
+SPOOF_URL="$(echo "${BASE_URL}" | sed 's|://|://subscriber:invalidkey9999@|')/rpm/${PRIVATE_COMPONENT}/${SERIES}/${OS_ARCH}/repodata/repomd.xml"
+HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H "X-Forwarded-Uri: /rpm/${COMPONENT}/${SERIES}/${OS_ARCH}/repodata/repomd.xml" \
+  -H "X-Forwarded-Prefix: /rpm/${COMPONENT}" \
+  -H "X-Forwarded-For: 127.0.0.1" \
+  "${SPOOF_URL}" || true)
+if [ "${HTTP_STATUS}" = "401" ]; then
+  pass "AC4 — spoofed X-Forwarded-* headers still return 401 on '${PRIVATE_COMPONENT}'"
+else
+  fail "AC4 — spoofed X-Forwarded-* headers returned ${HTTP_STATUS}; the client must not reach '${COMPONENT}' scope"
+fi
+
 # ─── Summary ─────────────────────────────────────────────────────────────────
 
 echo ""

--- a/traefik/dynamic-ci/middlewares.yml
+++ b/traefik/dynamic-ci/middlewares.yml
@@ -5,7 +5,14 @@ http:
         address: "http://auth:8080/auth"
         authRequestHeaders:
           - "Authorization"
-        trustForwardHeader: false
+        # The entryPoint sanitises X-Forwarded-* from every client not listed in
+        # forwardedHeaders.trustedIPs, and no entryPoint here lists any, so
+        # nothing a client sends survives to this middleware. What reaches the
+        # auth service is Traefik's own header set, which is what `true` trusts.
+        # `false` is deprecated since 3.6.14, the release that patched
+        # GHSA-6384-m2mw-rf54: it forwarded a client's X-Forwarded-Prefix
+        # untouched. Leaving the option unset logs a warning on every start.
+        trustForwardHeader: true
         # authResponseHeaders omitted — auth service returns no headers to pass downstream
         # fail-closed: Traefik returns 503 if auth service is unreachable (NFR11)
 

--- a/traefik/dynamic-dev/middlewares.yml
+++ b/traefik/dynamic-dev/middlewares.yml
@@ -5,7 +5,14 @@ http:
         address: "http://auth:8080/auth"
         authRequestHeaders:
           - "Authorization"
-        trustForwardHeader: false
+        # The entryPoint sanitises X-Forwarded-* from every client not listed in
+        # forwardedHeaders.trustedIPs, and no entryPoint here lists any, so
+        # nothing a client sends survives to this middleware. What reaches the
+        # auth service is Traefik's own header set, which is what `true` trusts.
+        # `false` is deprecated since 3.6.14, the release that patched
+        # GHSA-6384-m2mw-rf54: it forwarded a client's X-Forwarded-Prefix
+        # untouched. Leaving the option unset logs a warning on every start.
+        trustForwardHeader: true
         # authResponseHeaders omitted — auth service returns no headers to pass downstream
         # fail-closed: Traefik returns 503 if auth service is unreachable (NFR11)
 

--- a/traefik/dynamic/middlewares.yml
+++ b/traefik/dynamic/middlewares.yml
@@ -5,7 +5,14 @@ http:
         address: "http://auth:8080/auth"
         authRequestHeaders:
           - "Authorization"
-        trustForwardHeader: false
+        # The entryPoint sanitises X-Forwarded-* from every client not listed in
+        # forwardedHeaders.trustedIPs, and no entryPoint here lists any, so
+        # nothing a client sends survives to this middleware. What reaches the
+        # auth service is Traefik's own header set, which is what `true` trusts.
+        # `false` is deprecated since 3.6.14, the release that patched
+        # GHSA-6384-m2mw-rf54: it forwarded a client's X-Forwarded-Prefix
+        # untouched. Leaving the option unset logs a warning on every start.
+        trustForwardHeader: true
         # authResponseHeaders omitted — auth service returns no headers to pass downstream
         # fail-closed: Traefik returns 503 if auth service is unreachable (NFR11)
 


### PR DESCRIPTION
## Summary
`trustForwardHeader: false` is deprecated since Traefik 3.6.14, the release that patched [GHSA-6384-m2mw-rf54](https://github.com/traefik/traefik/security/advisories/GHSA-6384-m2mw-rf54), where that exact setting left a client's `X-Forwarded-Prefix` intact for the auth service to read. Since #239 put us on 3.7.13, Traefik logs on every start that the option "creates an inconsistent security behavior where some X-Forwarded headers are removed but others are forwarded as is".

The replacement model sanitises at the entryPoint: `X-Forwarded-*` from any client not listed in `forwardedHeaders.trustedIPs` is stripped, and no entryPoint here lists any, so nothing a client sends survives to the middleware. `trustForwardHeader: true` then trusts only Traefik's own header set. All three variants (`dynamic`, `dynamic-ci`, `dynamic-dev`) change together.

## Verification
Measured on a Traefik 3.7.13 lab running this middleware chain, with a request carrying `X-Forwarded-Uri: /deb/SPOOFED/x`, `X-Forwarded-Prefix: /SPOOF` and `X-Forwarded-For: 9.9.9.9`:

| `trustForwardHeader` | what the auth service received |
|---|---|
| `false` (3.6.12, what production runs) | `X-Forwarded-Uri: /deb/minion/2025/dists/bookworm/InRelease` |
| `false` (3.7.13) | same, plus the start-up warning |
| absent (3.7.13) | same, plus the start-up warning |
| `true` (3.7.13) | same, no warning |

The spoofed values never reach the auth service in any configuration, so this is a deprecation fix rather than a behaviour change.

`tests/e2e/rpm-subscriber.sh` gains AC4, which repeats the invalid-key 401 check with those three headers set by the client and pointing at the public component. It must stay 401, which is the property the advisory was about.

## Not affected
Our chain was never exposed: `packyard-auth` runs before both strip middlewares, the auth service scopes on `X-Forwarded-Uri` rather than `X-Forwarded-Prefix`, and this Traefik is the edge with no trusted upstream proxy. The deployment host still runs 3.6.12, below the patched 3.6.14, and picks up 3.7.13 at the next deployment.

## Follow-ups seen in the same 3.7 start-up warnings, not addressed here
- `maxResponseBodySize` is unset on forwardAuth, so a compromised or hung auth service can return an unbounded body.
- `aliasHeadersStrategy` is unset, so headers like `X_Forwarded_Uri` are forwarded as-is. Our Go handler does not read them and nginx maps them to a distinct variable, so nothing acts on them today.

Closes #242