### PR TITLE
fix(traefik): bound the forwardAuth response and drop alias headers

### DIFF
--- a/traefik/dynamic-ci/middlewares.yml
+++ b/traefik/dynamic-ci/middlewares.yml
@@ -5,6 +5,10 @@ http:
         address: "http://auth:8080/auth"
         authRequestHeaders:
           - "Authorization"
+        # The auth service answers with an empty body on every path, so 1 KiB is
+        # generous. Unset means unlimited, which lets a hung or compromised auth
+        # service exhaust Traefik's memory. Over the limit the request gets 401.
+        maxResponseBodySize: 1024
         # The entryPoint sanitises X-Forwarded-* from every client not listed in
         # forwardedHeaders.trustedIPs, and no entryPoint here lists any, so
         # nothing a client sends survives to this middleware. What reaches the

--- a/traefik/dynamic-dev/middlewares.yml
+++ b/traefik/dynamic-dev/middlewares.yml
@@ -5,6 +5,10 @@ http:
         address: "http://auth:8080/auth"
         authRequestHeaders:
           - "Authorization"
+        # The auth service answers with an empty body on every path, so 1 KiB is
+        # generous. Unset means unlimited, which lets a hung or compromised auth
+        # service exhaust Traefik's memory. Over the limit the request gets 401.
+        maxResponseBodySize: 1024
         # The entryPoint sanitises X-Forwarded-* from every client not listed in
         # forwardedHeaders.trustedIPs, and no entryPoint here lists any, so
         # nothing a client sends survives to this middleware. What reaches the

--- a/traefik/dynamic/middlewares.yml
+++ b/traefik/dynamic/middlewares.yml
@@ -5,6 +5,10 @@ http:
         address: "http://auth:8080/auth"
         authRequestHeaders:
           - "Authorization"
+        # The auth service answers with an empty body on every path, so 1 KiB is
+        # generous. Unset means unlimited, which lets a hung or compromised auth
+        # service exhaust Traefik's memory. Over the limit the request gets 401.
+        maxResponseBodySize: 1024
         # The entryPoint sanitises X-Forwarded-* from every client not listed in
         # forwardedHeaders.trustedIPs, and no entryPoint here lists any, so
         # nothing a client sends survives to this middleware. What reaches the

--- a/traefik/traefik.ci.yml
+++ b/traefik/traefik.ci.yml
@@ -16,6 +16,13 @@ accessLog:
 entryPoints:
   web:
     address: "0.0.0.0:80"
+    http:
+      # Go splits header names on dashes only, so X_Forwarded_Uri and
+      # X.Forwarded.Uri are distinct headers to it while a backend deriving
+      # variable names (nginx, CGI) reads them as the same one. `delete` drops
+      # any header whose name carries a character other than a letter, a digit
+      # or a dash, before routing.
+      aliasHeadersStrategy: delete
   metrics:
     address: "127.0.0.1:8082"  # Traefik's own /metrics; loopback-only inside the container, internal only in CI
 

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -16,6 +16,13 @@ accessLog:
 entryPoints:
   websecure:
     address: "0.0.0.0:443"
+    http:
+      # Go splits header names on dashes only, so X_Forwarded_Uri and
+      # X.Forwarded.Uri are distinct headers to it while a backend deriving
+      # variable names (nginx, CGI) reads them as the same one. `delete` drops
+      # any header whose name carries a character other than a letter, a digit
+      # or a dash, before routing.
+      aliasHeadersStrategy: delete
   metrics:
     address: "127.0.0.1:8082"  # Traefik's own /metrics for Prometheus. Bound to loopback inside the container so only sidecars sharing the network namespace (or `docker exec`) can scrape — other containers on the proxy network cannot reach it.
 


### PR DESCRIPTION
## Summary
The two hardening follow-ups from #243, both warnings Traefik 3.7 logs on every start.

- `maxResponseBodySize: 1024` on `packyard-auth` in all three variants. Unset means Traefik reads whatever the auth service returns into memory; our handler writes an empty body on every path, so 1 KiB is generous. Over the limit Traefik refuses the request with 401.
- `aliasHeadersStrategy: delete` on the public entryPoint in `traefik.yml` and `traefik.ci.yml`. A header named `X_Forwarded_Uri` or `X.Forwarded.Uri` is distinct from `X-Forwarded-Uri` to Go, so the auth service never reads it, but nginx sits behind three routers and backends that derive variable names from header names read them as one. Traefik recommends `delete` or `reject` when such backends are exposed; `delete` is silent, `reject` would answer 400 to a client sending something like `X_Request_Id`.

## Verification
Measured on a Traefik 3.7.13 lab running the real `packyard-auth` and `packyard-strip-deb` middlewares:

- Start-up is clean. Both warnings are gone; the only line left is the unrelated RFC 3986 encoded-characters note.
- `GET /deb/minion/2025/dists/bookworm/InRelease` returns 200 as before.
- The same request with `X_Forwarded_Uri: /deb/SPOOFED/x` also returns 200, and neither the auth service nor the backend receives that header. `X-Legit-Header` passes through untouched, so the strategy drops only aliasing names.

## Note for the deployment host
`aliasHeadersStrategy` is entryPoint-level and this Traefik is the shared ingress on `pkg.onms.eu`, so the `delete` strategy applies to `blittermib.eu` and `bawue.spieli.eu` as well. It only drops headers whose names carry a character other than a letter, a digit or a dash, which no browser or ordinary client sends.

Closes #244