### PR TITLE
feat(oci): address a component by its own name in the registry

### DIFF
--- a/.github/workflows/promote-oci.yml
+++ b/.github/workflows/promote-oci.yml
@@ -109,7 +109,7 @@ jobs:
           COMPONENT: ${{ inputs.component }}
           SERIES: ${{ inputs.series }}
         run: |
-          IMAGE_BASE="${ZOT_REGISTRY}/lts-${COMPONENT}"
+          IMAGE_BASE="${ZOT_REGISTRY}/${COMPONENT}"
           for arch in x86_64 arm64; do
             tarcount=$(find "./staging/${arch}" -maxdepth 1 -name '*.tar' 2>/dev/null | wc -l)
             [ "$tarcount" -eq 1 ] || { echo "Expected exactly 1 .tar for ${arch}, found ${tarcount}"; exit 1; }
@@ -123,7 +123,7 @@ jobs:
           COMPONENT: ${{ inputs.component }}
           SERIES: ${{ inputs.series }}
         run: |
-          IMAGE_BASE="${ZOT_REGISTRY}/lts-${COMPONENT}"
+          IMAGE_BASE="${ZOT_REGISTRY}/${COMPONENT}"
           crane index append \
             --tag "${IMAGE_BASE}:${SERIES}" \
             --manifest "${IMAGE_BASE}:${SERIES}-x86_64" \
@@ -140,7 +140,7 @@ jobs:
           COMPONENT: ${{ inputs.component }}
           SERIES: ${{ inputs.series }}
         run: |
-          IMAGE_BASE="${ZOT_REGISTRY}/lts-${COMPONENT}"
+          IMAGE_BASE="${ZOT_REGISTRY}/${COMPONENT}"
           for tag in "${SERIES}-x86_64" "${SERIES}-arm64" "${SERIES}"; do
             digest=$(crane digest --insecure "${IMAGE_BASE}:${tag}")
             cosign sign --yes --allow-insecure-registry "${IMAGE_BASE}@${digest}"
@@ -153,7 +153,7 @@ jobs:
           SERIES: ${{ inputs.series }}
           CERT_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/promote-oci.yml@${{ github.ref }}
         run: |
-          IMAGE_BASE="${ZOT_REGISTRY}/lts-${COMPONENT}"
+          IMAGE_BASE="${ZOT_REGISTRY}/${COMPONENT}"
           if cosign verify \
             --allow-insecure-registry \
             --certificate-identity "${CERT_IDENTITY}" \

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -36,7 +36,7 @@ on:
         required: true
         default: bookworm,trixie,jammy,noble
       images:
-        description: "Comma-separated image names to copy; each becomes lts-<component>/<image>. Empty skips images"
+        description: "Comma-separated image names to copy; each becomes <component>/<image>. Empty skips images"
         required: false
         default: core,minion,sentinel
       source_registry:
@@ -307,7 +307,7 @@ jobs:
           }
           for t in ${RPM_TARGETS}; do check "https://${HOST}/rpm/${COMPONENT}/${SERIES}/${t}/repodata/repomd.xml"; done
           for d in ${DEB_DISTROS}; do check "https://${HOST}/deb/${COMPONENT}/${SERIES}/dists/${d}/InRelease"; done
-          for i in ${IMAGES}; do check "https://${HOST}/oci/v2/lts-${COMPONENT}/${i}/manifests/${VERSION}"; done
+          for i in ${IMAGES}; do check "https://${HOST}/oci/v2/${COMPONENT}/${i}/manifests/${VERSION}"; done
 
       - name: Cleanup
         if: always()

--- a/auth/internal/handler/forward_auth.go
+++ b/auth/internal/handler/forward_auth.go
@@ -20,8 +20,8 @@ import (
 )
 
 // ForwardAuthHandler validates subscriber credentials for Traefik forwardAuth.
-// GET /auth — returns 200 (allow), 401 (deny), 405 (write method on a
-// subscriber path), or 503 (error/fail-closed).
+// GET /auth — returns 200 (allow), 401 (deny), 404 (path shape not served),
+// 405 (write method on a subscriber path), or 503 (error/fail-closed).
 // Component visibility is resolved via a live DB lookup on every request so that
 // visibility changes take effect immediately without a service restart.
 //
@@ -77,10 +77,14 @@ func (h *ForwardAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A path matching none of the served shapes carries no component to reason
+	// about. 404 says so; 401 would tell a subscriber their key is wrong when
+	// their path is. Unknown components below keep answering 401, which is
+	// what the enumeration guard is for.
 	requestedComponent, ok := extractComponent(r.Header.Get("X-Forwarded-Uri"))
 	if !ok {
-		metrics.RequestsTotal.WithLabelValues("denied").Inc()
-		w.WriteHeader(http.StatusUnauthorized)
+		metrics.RequestsTotal.WithLabelValues("denied-path").Inc()
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
@@ -199,9 +203,16 @@ func isHex(s string) bool {
 //
 //	/rpm/{component}/{series}/{os-arch}/...   → component at index 1
 //	/deb/{component}/{series}/...             → component at index 1
-//	/oci/v2/lts-{component}/...               → strip "lts-" prefix from index 2
+//	/oci/v2/{component}/{image}/...           → component at index 2
 //
-// Returns ("", false) if the path is unrecognised or too short.
+// The component is the name it carries in the admin UI in all three, with no
+// prefix added or stripped. Registry repositories used to be named
+// lts-{component}; a path in that shape now denotes a component literally
+// named "lts-{component}", which is normally unknown and therefore denied.
+//
+// Returns ("", false) if the path is unrecognised or too short. Callers answer
+// 404 for that, not 401: a path shape reveals nothing about which components
+// exist, so hiding it behind the enumeration guard only misleads.
 func extractComponent(path string) (string, bool) {
 	// TrimPrefix removes the leading slash so SplitN gives clean segments.
 	parts := strings.SplitN(strings.TrimPrefix(path, "/"), "/", 5)
@@ -215,19 +226,16 @@ func extractComponent(path string) (string, bool) {
 		// /deb/{component}/{series}/...
 		comp = parts[1]
 	case "oci":
-		// /oci/v2/lts-{component}/...
-		if len(parts) < 3 {
+		// /oci/v2/{component}/{image}/... — Traefik only ever forwards the
+		// /oci/v2/ shape, so anything else under /oci/ is not a served path.
+		if len(parts) < 3 || parts[1] != "v2" {
 			return "", false
 		}
-		after, found := strings.CutPrefix(parts[2], "lts-")
-		if !found {
-			return "", false
-		}
-		comp = after
+		comp = parts[2]
 	default:
 		return "", false
 	}
-	// An empty segment (e.g. "/rpm//x" or "/oci/v2/lts-/x") is not a component.
+	// An empty segment (e.g. "/rpm//x" or "/oci/v2//x") is not a component.
 	if comp == "" {
 		return "", false
 	}

--- a/auth/internal/handler/forward_auth.go
+++ b/auth/internal/handler/forward_auth.go
@@ -77,11 +77,24 @@ func (h *ForwardAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	forwardedURI := r.Header.Get("X-Forwarded-Uri")
+
+	// The registry version check carries no repository, so it has no component
+	// to scope. The distribution spec wants 200 or 401 here and clients treat
+	// anything else as a broken registry: crane refuses to talk to a registry
+	// whose /v2/ answers 404. 401 is the "authenticate if you can" signal that
+	// docker, crane and cosign all continue past.
+	if isRegistryPing(forwardedURI) {
+		metrics.RequestsTotal.WithLabelValues("denied").Inc()
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
 	// A path matching none of the served shapes carries no component to reason
 	// about. 404 says so; 401 would tell a subscriber their key is wrong when
 	// their path is. Unknown components below keep answering 401, which is
 	// what the enumeration guard is for.
-	requestedComponent, ok := extractComponent(r.Header.Get("X-Forwarded-Uri"))
+	requestedComponent, ok := extractComponent(forwardedURI)
 	if !ok {
 		metrics.RequestsTotal.WithLabelValues("denied-path").Inc()
 		w.WriteHeader(http.StatusNotFound)
@@ -195,6 +208,18 @@ func isHex(s string) bool {
 		}
 	}
 	return true
+}
+
+// isRegistryPing reports whether the path is the OCI distribution version
+// check, which every registry client issues before its first request. Traefik
+// forwards it as /v2/ on the registry router and /oci/v2/ on the path router;
+// neither names a repository.
+func isRegistryPing(path string) bool {
+	switch strings.TrimSuffix(path, "/") {
+	case "/v2", "/oci/v2":
+		return true
+	}
+	return false
 }
 
 // extractComponent parses the LTS component name from an X-Forwarded-Uri path.

--- a/auth/internal/handler/forward_auth_test.go
+++ b/auth/internal/handler/forward_auth_test.go
@@ -294,22 +294,92 @@ func TestForwardAuth_MalformedAuthHeader(t *testing.T) {
 }
 
 func TestForwardAuth_UnrecognisedForwardedUri(t *testing.T) {
-	// Handler's !ok branch from extractComponent — e.g. /gpg/ path has no auth middleware
-	// but if it somehow reaches /auth, or an empty header is sent, the handler must return 401.
+	// Handler's !ok branch from extractComponent. A path matching none of the
+	// served shapes carries no component, so it answers 404: the enumeration
+	// guard that makes an unknown component 401 has nothing to hide here, and
+	// 401 would tell a subscriber their key is wrong when their path is.
 	h := newTestHandler(&mockStore{
 		getByValueFn: func(_ context.Context, value string) (*store.Key, error) {
 			return &store.Key{ID: value, Component: "core", Active: true}, nil
 		},
 	})
-	cases := []string{"", "/", "/gpg/lts.asc", "/unknown/path"}
+	cases := []string{"", "/", "/gpg/lts.asc", "/unknown/path", "/oci/core/manifests/2025", "/oci/v2"}
 	for _, uri := range cases {
 		req := httptest.NewRequest("GET", "/auth", nil)
 		req.Header.Set("Authorization", basicAuthHeader(validKey))
 		req.Header.Set("X-Forwarded-Uri", uri)
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
-		if w.Code != http.StatusUnauthorized {
-			t.Errorf("uri=%q: expected 401, got %d", uri, w.Code)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("uri=%q: expected 404, got %d", uri, w.Code)
+		}
+		if w.Body.Len() != 0 {
+			t.Errorf("uri=%q: expected empty body, got %q", uri, w.Body.String())
+		}
+	}
+}
+
+// The registry addresses a component by its own name: /oci/v2/<component>/...
+// with no prefix. A component named <c> is served at /rpm/<c>/, /deb/<c>/ and
+// <host>/oci/<c>/<image>.
+func TestForwardAuth_OCIPathUsesComponentNameVerbatim(t *testing.T) {
+	h := newTestHandler(&mockStore{
+		getByValueFn: func(_ context.Context, value string) (*store.Key, error) {
+			return &store.Key{ID: value, Component: "core", Active: true}, nil
+		},
+	})
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.Header.Set("Authorization", basicAuthHeader(validKey))
+	req.Header.Set("X-Forwarded-Uri", "/oci/v2/core/fixture/manifests/2025")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for a key scoped to 'core', got %d", w.Code)
+	}
+}
+
+// The former repository shape is not special-cased: it names a component
+// "lts-core", which does not exist, so it gets the unknown-component 401.
+func TestForwardAuth_OCIPrefixedPathIsAnUnknownComponent(t *testing.T) {
+	h := newTestHandler(&mockStore{
+		getByValueFn: func(_ context.Context, value string) (*store.Key, error) {
+			return &store.Key{ID: value, Component: "core", Active: true}, nil
+		},
+	})
+	req := httptest.NewRequest("GET", "/auth", nil)
+	req.Header.Set("Authorization", basicAuthHeader(validKey))
+	req.Header.Set("X-Forwarded-Uri", "/oci/v2/lts-core/manifests/2025")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for the unknown component 'lts-core', got %d", w.Code)
+	}
+}
+
+func TestExtractComponent(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+		ok   bool
+	}{
+		{"/rpm/core/2025/el9-x86_64/x.rpm", "core", true},
+		{"/deb/core/2025/dists/bookworm/InRelease", "core", true},
+		{"/oci/v2/core/fixture/manifests/2025", "core", true},
+		{"/oci/v2/bluebird/core/manifests/38", "bluebird", true},
+		{"/oci/v2/lts-bluebird/core/manifests/38", "lts-bluebird", true},
+		{"/oci/v2//manifests/38", "", false},
+		{"/oci/v2", "", false},
+		{"/oci/bluebird/core/manifests/38", "", false},
+		{"/gpg/lts.asc", "", false},
+		{"/", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := extractComponent(c.path)
+		if got != c.want || ok != c.ok {
+			t.Errorf("extractComponent(%q) = (%q, %v); want (%q, %v)", c.path, got, ok, c.want, c.ok)
 		}
 	}
 }
@@ -490,8 +560,8 @@ func FuzzExtractComponent(f *testing.F) {
 	for _, seed := range []string{
 		"/rpm/core/2025/el9-x86_64/Packages/x.rpm",
 		"/deb/core/2025/dists/bookworm/InRelease",
+		"/oci/v2/core/fixture/manifests/2025",
 		"/oci/v2/lts-core/manifests/2025",
-		"/oci/v2/core/manifests/2025",
 		"/gpg/lts.asc",
 		"/",
 		"",
@@ -595,7 +665,7 @@ func TestForwardAuth_WriteMethodRefused(t *testing.T) {
 			})
 			req := httptest.NewRequest("GET", "/auth", nil)
 			req.Header.Set("Authorization", basicAuthHeader(validKey))
-			req.Header.Set("X-Forwarded-Uri", "/oci/v2/lts-core/blobs/uploads/")
+			req.Header.Set("X-Forwarded-Uri", "/oci/v2/core/fixture/blobs/uploads/")
 			req.Header.Set("X-Forwarded-Method", method)
 			w := httptest.NewRecorder()
 			h.ServeHTTP(w, req)
@@ -620,7 +690,7 @@ func TestForwardAuth_WriteMethodRefusedOnPublicComponent(t *testing.T) {
 	h := newTestHandler(&mockStore{})
 	h.ComponentStore = cs
 	req := httptest.NewRequest("GET", "/auth", nil)
-	req.Header.Set("X-Forwarded-Uri", "/oci/v2/lts-core/manifests/2025")
+	req.Header.Set("X-Forwarded-Uri", "/oci/v2/core/fixture/manifests/2025")
 	req.Header.Set("X-Forwarded-Method", "PUT")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)

--- a/auth/internal/handler/forward_auth_test.go
+++ b/auth/internal/handler/forward_auth_test.go
@@ -303,7 +303,7 @@ func TestForwardAuth_UnrecognisedForwardedUri(t *testing.T) {
 			return &store.Key{ID: value, Component: "core", Active: true}, nil
 		},
 	})
-	cases := []string{"", "/", "/gpg/lts.asc", "/unknown/path", "/oci/core/manifests/2025", "/oci/v2"}
+	cases := []string{"", "/", "/gpg/lts.asc", "/unknown/path", "/oci/core/manifests/2025", "/oci/v2//manifests/38"}
 	for _, uri := range cases {
 		req := httptest.NewRequest("GET", "/auth", nil)
 		req.Header.Set("Authorization", basicAuthHeader(validKey))
@@ -358,6 +358,26 @@ func TestForwardAuth_OCIPrefixedPathIsAnUnknownComponent(t *testing.T) {
 	}
 }
 
+// Every registry client pings /v2/ before its first request. The distribution
+// spec wants 200 or 401 there; crane treats 404 as a broken registry and gives
+// up, which is how the 404-for-unparseable-paths change first showed up in CI.
+func TestForwardAuth_RegistryPingStays401(t *testing.T) {
+	h := newTestHandler(&mockStore{
+		getByValueFn: func(_ context.Context, value string) (*store.Key, error) {
+			return &store.Key{ID: value, Component: "core", Active: true}, nil
+		},
+	})
+	for _, uri := range []string{"/v2/", "/v2", "/oci/v2/", "/oci/v2"} {
+		req := httptest.NewRequest("GET", "/auth", nil)
+		req.Header.Set("X-Forwarded-Uri", uri)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("uri=%q: expected 401 for the registry ping, got %d", uri, w.Code)
+		}
+	}
+}
+
 func TestExtractComponent(t *testing.T) {
 	cases := []struct {
 		path string
@@ -371,6 +391,7 @@ func TestExtractComponent(t *testing.T) {
 		{"/oci/v2/lts-bluebird/core/manifests/38", "lts-bluebird", true},
 		{"/oci/v2//manifests/38", "", false},
 		{"/oci/v2", "", false},
+		{"/v2/", "", false},
 		{"/oci/bluebird/core/manifests/38", "", false},
 		{"/gpg/lts.asc", "", false},
 		{"/", "", false},

--- a/auth/internal/metrics/metrics.go
+++ b/auth/internal/metrics/metrics.go
@@ -10,7 +10,7 @@ import "github.com/prometheus/client_golang/prometheus"
 
 var (
 	// RequestsTotal counts forwardAuth requests by outcome status.
-	// Labels: status = allowed | allowed-public | denied | denied-method | error
+	// Labels: status = allowed | allowed-public | denied | denied-method | denied-path | error
 	RequestsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "packyard_auth_requests_total",

--- a/docs/ops/manual-test-plan.md
+++ b/docs/ops/manual-test-plan.md
@@ -259,30 +259,35 @@ Expected: first three `401`, last one `200`.
 
 ### 5.1 OCI component extraction
 
-OCI paths use the format `/oci/v2/lts-{component}/...`. The auth service strips the `lts-` prefix.
+OCI paths use the format `/oci/v2/{component}/...`, the component named exactly as it is everywhere else.
 
 ```bash
 # core key on OCI core repo
 curl -u "subscriber:${CORE_KEY}" \
   -o /dev/null -w "%{http_code}\n" \
-  "http://localhost/oci/v2/lts-core/tags/list"
+  "http://localhost/oci/v2/core/tags/list"
 
 # core key on OCI minion repo — denied
 curl -u "subscriber:${CORE_KEY}" \
   -o /dev/null -w "%{http_code}\n" \
-  "http://localhost/oci/v2/lts-minion/tags/list"
+  "http://localhost/oci/v2/minion/tags/list"
 ```
 
 Expected: first `200` or `404` (Zot has no images pushed yet), second `401`.
 
 ```bash
-# Path without lts- prefix — should be denied (unrecognised format)
+# Unknown component — denied, and indistinguishable from a wrong key
 curl -u "subscriber:${CORE_KEY}" \
   -o /dev/null -w "%{http_code}\n" \
   "http://localhost/oci/v2/someother-repo/tags/list"
+
+# Not a served path shape — 404, so a mistyped path is not read as a bad key
+curl -u "subscriber:${CORE_KEY}" \
+  -o /dev/null -w "%{http_code}\n" \
+  "http://localhost/oci/core/tags/list"
 ```
 
-Expected: `401`.
+Expected: first `401`, second `404`.
 
 ---
 

--- a/docs/ops/release-runbook.md
+++ b/docs/ops/release-runbook.md
@@ -72,8 +72,8 @@ bash scripts/stage-artifact.sh sentinel 2025 rpm el9-x86_64  ./packyard-sentinel
 bash scripts/stage-artifact.sh core 2025 deb noble-amd64 ./packyard-core-2025_amd64.deb
 
 # OCI — stage x86_64 and arm64 archives separately
-bash scripts/stage-artifact.sh core 2025 oci x86_64 ./lts-core-x86_64.tar
-bash scripts/stage-artifact.sh core 2025 oci arm64  ./lts-core-arm64.tar
+bash scripts/stage-artifact.sh core 2025 oci x86_64 ./core-x86_64.tar
+bash scripts/stage-artifact.sh core 2025 oci arm64  ./core-arm64.tar
 ```
 
 Confirm the artifacts are in the bucket:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -206,8 +206,8 @@ startup (restart required to pick up new components in those paths).
 | `PATCH`  | `/api/v1/components/{name}`       | Update component visibility              |
 | `DELETE` | `/api/v1/components/{name}`       | Deprovision a component (safe-lock)      |
 
-A key scoped to `core` grants access only to `/rpm/core/`, `/deb/core/`,
-and `lts-core` OCI paths. Cross-component access is denied — a `core` key
+A key scoped to `core` grants access only to `/rpm/core/`, `/deb/core/`
+and `/oci/core/` paths. Cross-component access is denied — a `core` key
 cannot access `/rpm/minion/`. The component name in the key must match the
 path segment exactly.
 

--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -6,7 +6,7 @@ Metrics are exposed by the auth service at `http://auth:9090/metrics` (Docker-in
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `packyard_auth_requests_total{status="allowed\|allowed-public\|denied\|denied-method\|error"}` | Counter | forwardAuth request outcomes |
+| `packyard_auth_requests_total{status="allowed\|allowed-public\|denied\|denied-method\|denied-path\|error"}` | Counter | forwardAuth request outcomes |
 | `packyard_auth_duration_seconds` | Histogram | forwardAuth latency |
 | `packyard_auth_component_cache_requests_total` | Counter | Component lookups through the public-component cache (forward-auth and admin reads) |
 | `packyard_auth_component_cache_hits_total` | Counter | Lookups answered from the cache without a store call; hit ratio is hits / requests |

--- a/docs/reference/promotion-pipeline.md
+++ b/docs/reference/promotion-pipeline.md
@@ -26,7 +26,7 @@ GitHub Release                                 1. validate inputs, preflight the
 quay.io/bluebird/core:38.1.0      ──────────► 4. rpm container:  add-package.sh into every rpm_target
   (cosign-signed)                              5. aptly container: one snapshot, published per deb_distro
                                                6. cosign verify upstream, crane copy into Zot as
-                                                  lts-<component>/<image>:<version> and :<series>,
+                                                  <component>/<image>:<version> and :<series>,
                                                   cosign sign with this workflow's identity
                                                7. curl every published path through the public hostname
 ```

--- a/docs/reference/subscriber-usage.md
+++ b/docs/reference/subscriber-usage.md
@@ -30,7 +30,7 @@ deb [signed-by=/usr/share/keyrings/lts.gpg] \
 
 ## OCI (Docker / Kubernetes)
 
-Images are published as `lts-<component>/<image>` with an immutable version tag and a floating series tag that follows the newest version in that series.
+Images are published as `<component>/<image>`, the component named exactly as it is in the admin UI and in the RPM and DEB paths, with an immutable version tag and a floating series tag that follows the newest version in that series.
 
 ```bash
 # Authenticate (not needed for a public component). The registry host is
@@ -40,8 +40,8 @@ docker login pkg.example.org \
   --password KEY
 
 # Pull a specific version, or the newest version of a series
-docker pull pkg.example.org/oci/lts-bluebird/core:38.1.0
-docker pull pkg.example.org/oci/lts-bluebird/core:38
+docker pull pkg.example.org/oci/bluebird/core:38.1.0
+docker pull pkg.example.org/oci/bluebird/core:38
 
 # Verify the signature. Images are signed keylessly by the promoting
 # workflow, so you pin the signing workflow's identity rather than a key.
@@ -49,10 +49,12 @@ docker pull pkg.example.org/oci/lts-bluebird/core:38
 cosign verify \
   --certificate-identity-regexp 'https://github.com/no42-org/packyard/\.github/workflows/promote-release\.yml@refs/heads/main' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  pkg.example.org/oci/lts-bluebird/core:38.1.0
+  pkg.example.org/oci/bluebird/core:38.1.0
 ```
 
-Images promoted from staged tarballs with the older `promote-oci.yml` workflow are named `lts-<component>:<series>` and verify against `promote-oci\.yml` in the identity above.
+Images promoted from staged tarballs with the older `promote-oci.yml` workflow are named `<component>:<series>` and verify against `promote-oci\.yml` in the identity above.
+
+Images promoted before Packyard 0.6.2 were published as `lts-<component>/<image>`, a leftover of an earlier product name. That prefix is gone: `<host>/oci/lts-<component>/…` now names a component called `lts-<component>`, which does not exist, and answers `401`.
 
 The signature is stored in the registry next to the image, so `docker pull` and `cosign verify` both go through the same `/oci/` endpoint.
 

--- a/scripts/ci/publish-fixtures.sh
+++ b/scripts/ci/publish-fixtures.sh
@@ -68,7 +68,7 @@ mkdir -p "${WORK}/bundle/packages" "${WORK}/bundle/signing"
 cp "${DEB}" "${WORK}/bundle/packages/"; cp "${REPO_ROOT}/ci/key.asc" "${WORK}/bundle/signing/key.asc"; cp "${REPO_ROOT}/ci/passphrase" "${WORK}/bundle/signing/passphrase"
 tar -cf - -C "${WORK}/bundle" . | bash "${REPO_ROOT}/scripts/publish/deb.sh" "${COMPOSE_FILE_MAIN}" "${COMPONENT}" "${SERIES}" "${KEYID}" "${DEB_DISTRO}"
 
-echo "== oci.sh -> lts-${COMPONENT}/${IMAGE}:${SERIES} (COSIGN_SIGN=${COSIGN_SIGN:-0})"
+echo "== oci.sh -> ${COMPONENT}/${IMAGE}:${SERIES} (COSIGN_SIGN=${COSIGN_SIGN:-0})"
 SOURCE_REF="${FIXTURE_IMAGE_REF}" COSIGN_SIGN="${COSIGN_SIGN:-0}" OWN_IDENTITY="${OWN_IDENTITY:-}" \
   bash "${REPO_ROOT}/scripts/publish/oci.sh" "${ZOT_REGISTRY}" "${COMPONENT}" "${IMAGE}" "${SERIES}" "${SERIES}"
 echo "fixtures published"

--- a/scripts/publish/oci.sh
+++ b/scripts/publish/oci.sh
@@ -2,7 +2,10 @@
 # Copyright 2026 Ronny Trommer <ronny@no42.org>
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# oci.sh — copy an image into Zot as lts-<component>/<image> and sign it.
+# oci.sh — copy an image into Zot as <component>/<image> and sign it.
+#
+# The repository is the component name verbatim, the same name the admin UI,
+# /rpm/<component>/ and /deb/<component>/ use (#237).
 #
 # Usage: oci.sh <zot-registry> <component> <image> <version> <series>
 #
@@ -36,7 +39,7 @@ for v in "${COMPONENT}" "${IMAGE}" "${VERSION}" "${SERIES}"; do
 done
 for cmd in crane cosign; do command -v "$cmd" >/dev/null || { echo "ERROR: $cmd not found" >&2; exit 1; }; done
 
-dst="${ZOT}/lts-${COMPONENT}/${IMAGE}"
+dst="${ZOT}/${COMPONENT}/${IMAGE}"
 
 if [ -n "${SOURCE_IDENTITY:-}" ]; then
   # Never copy an image the source did not sign.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -71,8 +71,8 @@ docker compose exec aptly /scripts/publish-snapshot.sh core 2025 bookworm
 
 # Option B: Manual (for local dev only — requires SSH tunnel to Zot on port 5000)
 ssh -fN -L 5000:localhost:5000 deploy@HOST
-crane push /tmp/test-amd64.tar localhost:5000/lts-core:2025-x86_64 --insecure
-crane push /tmp/test-arm64.tar localhost:5000/lts-core:2025-arm64 --insecure
+crane push /tmp/test-amd64.tar localhost:5000/core:2025-x86_64 --insecure
+crane push /tmp/test-arm64.tar localhost:5000/core:2025-arm64 --insecure
 ```
 
 ---

--- a/tests/e2e/oci-subscriber.sh
+++ b/tests/e2e/oci-subscriber.sh
@@ -21,8 +21,8 @@
 #   COMPONENT           — public component (default: core)
 #   SERIES              — series tag to pull (default: 2025)
 #   OCI_REGISTRY        — registry reference for docker/crane (default: BASE_URL host)
-#   OCI_IMAGE           — image name under lts-<component>/ (default: unset, the
-#                         legacy lts-<component>:<series> reference)
+#   OCI_IMAGE           — image name under <component>/ (default: unset, the
+#                         legacy single-segment <component>:<series> reference)
 #   PRIVATE_COMPONENT   — a private component for the 401 check (default: minion)
 #   COSIGN_CERT_IDENTITY_REGEXP — signing identity to verify (default: promote-release on main)
 #   COSIGN_SKIP         — "1" skips the signature check (pull requests in CI, where
@@ -45,9 +45,9 @@ PRIVATE_COMPONENT="${PRIVATE_COMPONENT:-minion}"
 REGISTRY="${BASE_URL#https://}"; REGISTRY="${REGISTRY#http://}"
 REGISTRY="${OCI_REGISTRY:-${REGISTRY}}"
 if [ -n "${OCI_IMAGE:-}" ]; then
-  REPO_PATH="lts-${COMPONENT}/${OCI_IMAGE}"
+  REPO_PATH="${COMPONENT}/${OCI_IMAGE}"
 else
-  REPO_PATH="lts-${COMPONENT}"
+  REPO_PATH="${COMPONENT}"
 fi
 IMAGE="${REGISTRY}/oci/${REPO_PATH}:${SERIES}"
 # crane needs to be told a plain-HTTP registry is intended; docker infers it for localhost.
@@ -108,9 +108,9 @@ echo "=== AC3: Auth middleware order and 401 check ==="
 # its own request path (/auth), not the forwarded URI, so that could never
 # match. The middleware order is proven by AC3b instead: a private
 # component can only answer 401 on the /v2/oci/... shape if forward-auth
-# saw the rewritten, unstripped /oci/v2/lts-<component>/ path.
+# saw the rewritten, unstripped /oci/v2/<component>/ path.
 # AC3b — a private component answers 401 to an invalid key, on both path shapes
-for path in "oci/v2/lts-${PRIVATE_COMPONENT}/manifests/${SERIES}" "v2/oci/lts-${PRIVATE_COMPONENT}/manifests/${SERIES}"; do
+for path in "oci/v2/${PRIVATE_COMPONENT}/manifests/${SERIES}" "v2/oci/${PRIVATE_COMPONENT}/manifests/${SERIES}"; do
   HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' -u "subscriber:invalidkey9999" "${BASE_URL}/${path}" || true)
   if [ "${HTTP_STATUS}" = "401" ]; then
     pass "AC3b — invalid key returns 401 on /${path}"


### PR DESCRIPTION
## Summary
A component is named once, in the admin UI, and RPM and DEB serve it under exactly that name. The registry did not: `bluebird` was published as `pkg.onms.eu/oci/lts-bluebird/core:38`, and the name a user derives from the UI answered **401**, because `extractComponent` could not parse a path without the prefix and an unknown component is denied. A subscriber reads that as "my key is wrong".

`git log -S` traces the prefix to 71c9cd2, the commit that replaced the Meridian/OpenNMS branding. It marks nothing that matters: `scripts/publish/oci.sh` is the only writer Zot has.

- The subscriber reference becomes `<host>/oci/<component>/<image>:<tag>`, and `extractComponent` reads the component from `/oci/v2/<component>/…` verbatim. It also now requires the `v2` segment, which Traefik always supplies.
- A path matching none of the served shapes answers **404**, not 401. A path shape reveals nothing about which components exist, so the enumeration guard has nothing to protect there. Unknown components keep answering 401. New metric label `denied-path`.
- No compatibility shape. `/oci/lts-bluebird/…` now names a component called `lts-bluebird`, which does not exist. The live registry holds one release, published four days ago, so this is the cheapest moment the names will ever agree.

## Verification
- New unit tests: the bare name resolves, the prefixed shape is an unknown component, `extractComponent` is covered by a table including `/oci/v2` and a non-`v2` second segment, and the unrecognised-URI test now asserts 404 with an empty body.
- `gofmt`, `go vet`, `go test ./...` pass in `auth/`; `make lint`, `make lint-workflows`, `make lint-image-pins` pass.
- The integration suite is the end-to-end proof: the CI fixture is published as `core/fixture` and `tests/e2e/oci-subscriber.sh` pulls it anonymously, checks 401 on both path shapes for the private component, and verifies the cosign signature.

## The live cutover is not in this PR
It needs a release on the host first, and the order matters. Measured against the production registry while preparing this:

- `cosign copy` does **not** carry referrer-attached Sigstore bundles into Zot. The destination reports zero referrers and `cosign verify` fails with `no signatures found`.
- `oras cp -r` reproduces all three referrers and verification passes against the renamed repository, so signatures are digest-bound and survive a rename.
- Zot hardlinks deduplicated blobs, so a second copy of a 2 GB image left the volume unchanged at 3.8 GB.

So the host sequence is copy, deploy, delete: `oras cp -r` into the bare names while the old auth still serves the prefixed ones, deploy the release carrying this change, then delete the prefixed repositories. No window where neither name works.

Refs #237