### PR TITLE
chore: correct README/CONTRIBUTING drift and declare the SPA license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Run `make help` to list every target.
 2. Branch from `main`. Use `<type>/<short-description>`, for example `fix/forward-auth-401`.
 3. Keep one logical change per pull request.
 4. Pull requests are squash-merged. The PR title becomes the commit subject on `main`, so give it a Conventional Commit title.
-5. CI must be green before merge. The required checks are the auth unit tests, the Docker image build and the docs build.
+5. CI must be green before merge. The `main` ruleset requires five checks: `Auth lint`, `Auth unit tests`, `Build Docker images`, `Build docs` and `Workflow lint`. The first four are path-filtered and skip when nothing they watch changed; `Workflow lint` runs on every pull request.
 
 ## Commit messages
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,25 @@ Promotion pipeline (GitHub Actions):
 
 **Services:**
 
+Every image is pinned by tag and digest in `compose.yml`, which Dependabot keeps current.
+Versions are deliberately left out of this table so it cannot drift from those pins.
+
 | Service | Image | Role |
 |---------|-------|------|
-| `traefik` | `traefik:3.6.12` | TLS, routing, forwardAuth middleware |
-| `auth` | built from `./auth` | Subscription key validation, admin API, Prometheus metrics |
-| `rpm` | built from `./rpm` | nginx serving signed RPM repos |
-| `deb` | `nginx:alpine` | nginx serving Aptly-published DEB repos |
-| `zot` | `ghcr.io/project-zot/zot-linux-amd64:v2.1.2` | OCI registry with keyless cosign signatures |
-| `aptly` | `ghcr.io/no42-org/packyard-aptly:1.6.2` | DEB repo management and signing (multi-arch) |
-| `rustfs` | `rustfs/rustfs:latest` | S3-compatible staging storage for promotion pipeline |
-| `static` | `nginx:alpine` | Public GPG key hosting |
-| `backup` | `keinos/sqlite3:latest` | Daily SQLite backup of the key store |
+| `traefik` | upstream `traefik` | TLS, routing, forwardAuth middleware |
+| `auth` | `ghcr.io/no42-org/packyard-auth`, built from `./auth` | Subscription key validation, admin API, Prometheus metrics |
+| `rpm` | `ghcr.io/no42-org/packyard-rpm`, built from `./rpm` | nginx serving signed RPM repos |
+| `deb` | upstream `nginx` | nginx serving Aptly-published DEB repos |
+| `zot` | upstream `ghcr.io/project-zot/zot-linux-amd64` | OCI registry with keyless cosign signatures |
+| `aptly` | `ghcr.io/no42-org/packyard-aptly`, built from `./aptly` | DEB repo management and signing (multi-arch) |
+| `rustfs` | upstream `rustfs/rustfs` | S3-compatible staging storage for promotion pipeline |
+| `rustfs-init` | upstream `amazon/aws-cli` | One-shot bucket provisioning for RustFS |
+| `static` | `ghcr.io/no42-org/packyard-static`, built from `./static` | Public GPG key hosting |
+| `backup` | `ghcr.io/no42-org/packyard-backup`, built from `./backup` | Daily SQLite backup of the key store |
+
+The five `packyard-*` images are published by this project.
+`auth`, `rpm` and `static` are released by tag alongside Packyard itself; `aptly` and `backup` carry the version of the upstream tool they wrap.
+See [RELEASING.md](RELEASING.md).
 
 ## Documentation
 
@@ -56,9 +64,12 @@ Full documentation: https://no42-org.github.io/packyard/
 
 Requires Docker Compose v2, `curl`, `jq`.
 
+`main` tracks the next `-rc` preview, so bring up a release tag rather than the branch tip.
+
 ```bash
 git clone https://github.com/no42-org/packyard.git
 cd packyard
+git checkout "$(git describe --tags --abbrev=0)"   # latest release; omit to run the preview
 cp .env.example .env        # set ACME_EMAIL, PKG_DOMAIN, ADMIN_DOMAIN and the OAuth provider
 docker compose up -d
 bash verify.sh

--- a/auth/internal/admin-ui/package-lock.json
+++ b/auth/internal/admin-ui/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "packyard-admin-ui",
       "version": "0.0.0",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tanstack/react-query": "^5.102.8",
         "react": "^19.2.8",

--- a/auth/internal/admin-ui/package.json
+++ b/auth/internal/admin-ui/package.json
@@ -2,6 +2,7 @@
   "name": "packyard-admin-ui",
   "version": "0.0.0",
   "private": true,
+  "license": "GPL-3.0-or-later",
   "description": "Admin SPA for Packyard auth service (D12). Built with Vite, embedded into the auth Go binary at compile time.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

A repository audit found the README describing images the tree stopped using, a Quick Start that hands new users an unreleased preview, and an SPA manifest with no license. This corrects all three, plus a stale line in CONTRIBUTING.

Closes #250

## What changed

**README service table.** Eight of nine rows were wrong. The table repeated version numbers Dependabot bumps weekly, so it was guaranteed to drift again — the versions are now dropped entirely and the table points at the `compose.yml` pins, which are the single source of truth. Rows now also mark which images this project publishes; `static` and `backup` were listed as third-party (`nginx:alpine`, `keinos/sqlite3:latest`) when both are first-party released images. Added the missing `rustfs-init` service.

**Quick Start.** `main` tracks the next `-rc` per RELEASING.md section 4, so `git clone && docker compose up -d` brought up `packyard-auth:0.7.1-rc` rather than v0.7.0. Now checks out the latest release tag, with the preview called out as the opt-out.

**CONTRIBUTING.** Named three required checks; the `main` ruleset requires five, adding `Auth lint` and `Workflow lint`.

**SPA manifest.** `auth/internal/admin-ui/package.json` declared no `license` while being compiled into the GPL auth binary. Now `GPL-3.0-or-later`, matching `LICENSE`, the root `package.json` and every source header. The lockfile picks up the same field.

## Verification

- `make admin-ui-test` — 2 files, 9 tests passed
- `git describe --tags --abbrev=0 origin/main` returns `v0.7.0`, so the new Quick Start command resolves to the latest release
- Service table cross-checked row by row against `compose.yml`
- Lockfile diff is exactly the one added `license` line

## Checklist

- [x] Linked issue exists and is referenced above with a closing keyword
- [x] `cd auth && go test ./...` passes for auth changes (no Go changes; admin UI tests run instead)
- [x] `make docs-build` passes for docs changes (no `docs/` changes; README and CONTRIBUTING are outside the Docusaurus site)
- [x] Commits are signed off (DCO) and follow Conventional Commits
- [x] Docs updated where behaviour changed