### PR TITLE
docs: replace OpenSpec decision IDs with the reasoning they point at

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,6 +1,7 @@
-# Stage 1: SPA build — Vite + TypeScript + React per D12. Output is copied
-# into auth/internal/adminui/dist where the Go build's //go:embed picks it
-# up.
+# Stage 1: SPA build — Vite + TypeScript + React. Output is copied into
+# auth/internal/adminui/dist where the Go build's //go:embed picks it up,
+# so the runtime artefact stays a single Go binary: one container, one
+# port, one TLS cert. Node and npm are build-time only.
 #
 # TODO(release-hardening): pin base images to immutable digests (node@sha256:…,
 # golang@sha256:…, distroless@sha256:…) before tagging a production release.

--- a/auth/internal/admin-ui/package.json
+++ b/auth/internal/admin-ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "license": "GPL-3.0-or-later",
-  "description": "Admin SPA for Packyard auth service (D12). Built with Vite, embedded into the auth Go binary at compile time.",
+  "description": "Admin SPA for the Packyard auth service. Built with Vite, embedded into the auth Go binary at compile time.",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/auth/internal/admin-ui/vite.config.ts
+++ b/auth/internal/admin-ui/vite.config.ts
@@ -6,15 +6,16 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// Vite config tuned for embedding into the auth Go binary per D12 + D22.
+// Vite config tuned for embedding the bundle into the auth Go binary and
+// for serving it under the admin UI's strict CSP.
 //
 // - `base: "/admin/"` makes all bundled asset URLs absolute under /admin/,
 //   matching how the Go handler serves them via go:embed.
 // - `build.assetsDir: "assets"` so bundled JS/CSS end up at
 //   /admin/assets/*.js | *.css (referenced by `<script src>` / `<link href>`).
-// - CSS is extracted into a side-file, not inlined — required for the CSP
-//   policy in D22 (`style-src 'self' 'nonce-{nonce}'`) to authorise bundled
-//   styles via 'self' instead of needing 'unsafe-inline'.
+// - CSS is extracted into a side-file, not inlined — the CSP served with
+//   /admin/* is `style-src 'self' 'nonce-{nonce}'`, so bundled styles are
+//   authorised via 'self' instead of needing 'unsafe-inline'.
 // - No `legacy()` plugin: it injects an inline polyfill script that would
 //   need an 'unsafe-inline' hatch. Admin UI ships modern-browser-only.
 export default defineConfig({

--- a/auth/internal/adminui/adminui.go
+++ b/auth/internal/adminui/adminui.go
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-// Package adminui serves the embedded React + TypeScript SPA at /admin/*
-// per D12 of change 2026-05-21-admin-ui-account-lifecycle. Static assets
-// (the Vite-built bundle) are served straight from the embedded FS;
-// the SPA shell at /admin/ returns the index.html with the per-request
-// CSP nonce already set on the response header by middleware.AdminCSP.
+// Package adminui serves the embedded React + TypeScript SPA at /admin/*,
+// so the auth service ships as a single binary rather than a second Node
+// service. Static assets (the Vite-built bundle) are served straight from
+// the embedded FS; the SPA shell at /admin/ returns the index.html with
+// the per-request CSP nonce already set on the response header by
+// middleware.AdminCSP.
 //
 // CSP authorisation: the policy is `script-src 'self'` + `style-src
-// 'self'` (D22), which already authorises every bundled asset since
+// 'self'`, which already authorises every bundled asset since
 // they're all served same-origin from /admin/assets/. The per-request
 // nonce header is set unconditionally so a future inline runtime-config
 // `<script nonce="…">` block can be added without policy churn.


### PR DESCRIPTION
## Summary

Four tracked files cited `D12` and `D22`, decision IDs from an OpenSpec design document that `.gitignore` excludes from the repository. Anyone who clones packyard hits a reference that reads like a spec identifier they should be able to look up, with nothing to look up. Each decision is one line, so this states it instead of naming it.

Closes #252

## What changed

| File | Before | After |
|------|--------|-------|
| `auth/Dockerfile` | "Vite + TypeScript + React per D12" | says the runtime artefact stays a single Go binary — one container, one port, one TLS cert — and that Node/npm are build-time only |
| `auth/internal/admin-ui/package.json` | "Admin SPA for Packyard auth service (D12)." | drops the ID; a package description should not carry a spec label |
| `auth/internal/admin-ui/vite.config.ts` | "per D12 + D22", "the CSP policy in D22" | names the actual policy, `style-src 'self' 'nonce-{nonce}'` |
| `auth/internal/adminui/adminui.go` | "per D12 of change 2026-05-21-admin-ui-account-lifecycle", "(D22)" | says the SPA is embedded so the service ships as one binary rather than a second Node service |

Comments only. No behaviour change.

## Why not just commit `openspec/`

It is in the AI tools block of `.gitignore` by repository policy, so the references cannot be fixed by making the target available.

The IDs were also not unique. `openspec/changes/archive/2026-05-12-migrate-docs-to-docusaurus/design.md:126` defines its own `D12` about imprint and privacy stubs, so a bare `D12` was ambiguous even for someone holding the directory.

`vite.config.ts` and `adminui.go` already spelled out the CSP policy `D22` refers to in the surrounding comment, so the label was redundant there rather than load-bearing.

## Verification

- `make lint` — gofmt clean, `go vet ./...` passes
- `make test` — all 8 auth packages pass
- `make admin-ui-test` — 2 files, 9 tests passed
- `git grep -nE '\bD[0-9]{1,2}\b'` over tracked files returns nothing
- `package-lock.json` unchanged; npm does not record `description`

## Checklist

- [x] Linked issue exists and is referenced above with a closing keyword
- [x] `cd auth && go test ./...` passes for auth changes
- [x] `make docs-build` passes for docs changes (no `docs/` changes)
- [x] Commits are signed off (DCO) and follow Conventional Commits
- [x] Docs updated where behaviour changed (comments only, no behaviour change)

Assisted-by: ClaudeCode:claude-opus-5