### PR TITLE
docs: route contributor commands through make and document trailer survival

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Closes #<issue>
 ## Checklist
 
 - [ ] Linked issue exists and is referenced above with a closing keyword
-- [ ] `cd auth && go test ./...` passes for auth changes
+- [ ] `make test` passes for auth changes (and `make admin-ui-test` for admin SPA changes)
 - [ ] `make docs-build` passes for docs changes
 - [ ] Commits are signed off (DCO) and follow Conventional Commits
 - [ ] Docs updated where behaviour changed (README, docs/, RELEASING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ Requirements: Docker Compose v2, Go (version in `auth/go.mod`), Node 20 (version
 | Preview the docs with live reload | `make docs-serve` |
 | Build the admin SPA into the Go embed directory | `make admin-ui` |
 | Build the auth binary with the embedded SPA | `make build` |
-| Run the auth unit tests | `cd auth && go test ./...` |
+| Run the auth unit tests | `make test` |
+| Run the admin SPA unit tests | `make admin-ui-test` |
 | Bring up the full stack and smoke-test it | `docker compose up -d && bash verify.sh` |
 
 Run `make help` to list every target.
@@ -56,6 +57,21 @@ Signed-off-by: Jane Doe <jane@example.org>
 ```
 
 The human signer reviews all AI-generated code and remains responsible for its correctness and license compliance.
+
+### Keeping the trailer through the merge
+
+Repeat both trailers at the end of the pull request description, not only on the branch commit.
+
+Pull requests here are squash-merged, and GitHub builds the squash commit message from the pull request description rather than from the branch commits.
+A trailer that lives only on a branch commit is dropped when the pull request merges, so `Assisted-by` disappears from `main` even though the branch carried it correctly.
+
+GitHub appends its own `Signed-off-by` after the description, separated by a blank line.
+That blank line splits the two into separate trailer blocks, so `git log --format='%(trailers)'` reports only the sign-off.
+Search the message body instead:
+
+```bash
+git log --format='%H %s' --grep='^Assisted-by:' main
+```
 
 ## Source file headers
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ See [Getting Started](https://no42-org.github.io/packyard/getting-started/quick-
 
 | Task | Command |
 |------|---------|
-| Auth unit tests | `cd auth && go test ./...` |
+| Auth unit tests | `make test` |
 | Auth binary with embedded admin UI | `make build` |
 | Docs site with live reload | `make docs-serve` |
 


### PR DESCRIPTION
## Summary

Two contributor-facing inaccuracies. Commands told people to bypass `make`, and CONTRIBUTING required a trailer without saying how to keep it through a squash merge.

Closes #254

## Commands go through `make`

CLAUDE.md states everything goes through `make` so local and CI commands stay in sync, and CI invokes `make test`. Three places said otherwise:

| File | Was | Now |
|------|-----|-----|
| `README.md`, Local Development | `cd auth && go test ./...` | `make test` |
| `CONTRIBUTING.md`, Setup | `cd auth && go test ./...` | `make test`, plus a `make admin-ui-test` row |
| `.github/pull_request_template.md` | `cd auth && go test ./...` | `make test` (and `make admin-ui-test` for SPA changes) |

`make test` is exactly `cd auth && $(GO) test ./...` today. That equivalence is why this is worth closing now rather than after the target grows a step and the docs quietly become wrong.

## Trailers surviving the merge

CONTRIBUTING requires `Assisted-by` before `Signed-off-by`, but pull requests here are squash-merged and GitHub builds the squash message from the **pull request description**, not the branch commits. A trailer that lives only on a branch commit is dropped.

Observable on `main`:

- 52e653f (#251) carried both trailers on its branch commit. The merged commit has only `Signed-off-by`.
- 0e6dcd8 (#253) repeated `Assisted-by` at the end of the body. It survived.

There is a second-order wrinkle worth writing down: GitHub appends its sign-off after a blank line, which splits the trailers into two blocks, so `git log --format='%(trailers)'` reports only the sign-off even when `Assisted-by` is present. The new section gives the grep that actually works.

## Verification

- `git grep -n 'go test \./\.\.\.'` over `README.md`, `CONTRIBUTING.md`, `.github/` and `CLAUDE.md` returns nothing
- `make -n test` and `make -n admin-ui-test` both resolve, so the documented targets exist
- The documented audit command returns 0e6dcd8 (#253) and not 52e653f (#251), which is exactly the distinction the new section explains

## Checklist

- [x] Linked issue exists and is referenced above with a closing keyword
- [x] `make test` passes for auth changes (documentation only, no code changes)
- [x] `make docs-build` passes for docs changes (no `docs/` changes)
- [x] Commits are signed off (DCO) and follow Conventional Commits
- [x] Docs updated where behaviour changed

Assisted-by: ClaudeCode:claude-opus-5