### PR TITLE
feat: add a make target for running a single test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Always go through `make`. CI runs the same targets, so they must stay in sync.
 |------|---------|
 | Build the auth binary with the embedded admin UI | `make build` |
 | Run the auth unit tests | `make test` |
-| Run one test | `cd auth && go test ./internal/handler -run TestName` |
+| Run one test | `make test-one RUN=TestName [PKG=./internal/handler]` |
 | gofmt check and go vet | `make lint` |
 | Lint workflow files | `make lint-workflows` |
 | Build the docs site (fails on broken links) | `make docs-build` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Requirements: Docker Compose v2, Go (version in `auth/go.mod`), Node 20 (version
 | Build the auth binary with the embedded SPA | `make build` |
 | Run the auth unit tests | `make test` |
 | Run the admin SPA unit tests | `make admin-ui-test` |
+| Run a single auth test | `make test-one RUN=TestName [PKG=./internal/handler]` |
 | Bring up the full stack and smoke-test it | `docker compose up -d && bash verify.sh` |
 
 Run `make help` to list every target.

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ UNAME_S := $(shell uname -s)
 
 .PHONY: help docs-install docs-serve docs-build docs-clean check-node test-rpm-publish test-publish-scripts \
         admin-ui admin-ui-install admin-ui-test admin-ui-dev admin-ui-clean \
-        build build-clean test lint lint-workflows lint-image-pins build-image-auth build-image-rpm build-images \
+        build build-clean test test-one lint lint-workflows lint-image-pins build-image-auth build-image-rpm build-images \
         ci-guard ci-signing-key ci-stack-up ci-stack-down ci-stack-logs ci-seed ci-verify-env ci-publish-fixtures e2e-observability e2e-rpm e2e-deb e2e-oci
 
 ## help: Show this help
@@ -95,6 +95,24 @@ build-clean:
 ## test: Run the auth service unit tests
 test:
 	cd auth && $(GO) test ./...
+
+# Both need a default: --warn-undefined-variables (top of this file) fires on
+# a bare $(RUN) when the caller omits it.
+# PKG narrows the search when a test name is ambiguous or ./... is too slow.
+RUN ?=
+PKG ?= ./...
+
+## test-one: Run a single auth test, e.g. make test-one RUN=TestName [PKG=./internal/handler]
+test-one:
+	@test -n "$(RUN)" || { echo "test-one: set RUN to a test name or regexp, e.g. make test-one RUN=TestName"; exit 1; }
+	@# `go test -run` exits 0 when the pattern matches nothing, so a typo'd
+	@# name reports success and hides that no test ran. -list is the cheap
+	@# pre-flight: it reports what would match without running it.
+	@cd auth && test "$$($(GO) test $(PKG) -list '$(RUN)' 2>/dev/null | grep -c '^Test')" -gt 0 \
+	  || { echo "test-one: no test matches RUN='$(RUN)' in PKG=$(PKG)"; exit 1; }
+	# -count=1 defeats the test cache: this target is for an edit-run-edit
+	# loop, where a "(cached)" ok would hide the change under test.
+	cd auth && $(GO) test $(PKG) -run '$(RUN)' -count=1 -v
 
 ## test-rpm-publish: Build the rpm image and publish a fixture RPM into two OS targets (needs Docker)
 test-rpm-publish:


### PR DESCRIPTION
## Summary

AGENTS.md told agents that everything goes through `make`, then listed one command that did not:

```
| Run one test | `cd auth && go test ./internal/handler -run TestName` |
```

It was the only row bypassing `make`, and it did so because no target existed. #255 closed the same drift in README, CONTRIBUTING and the pull request template; this is the case that needed code rather than an edit.

Closes #258

## Usage

```bash
make test-one RUN=TestForwardAuthIntegration_PrivateToPublic
make test-one RUN=TestForwardAuth PKG=./internal/handler   # narrow when the name is ambiguous or ./... is slow
```

`RUN` is the test name or regexp, `PKG` narrows the search and defaults to `./...`.

## Three deliberate choices

**Both variables carry a `?=` default.** The Makefile sets `MAKEFLAGS += --warn-undefined-variables`, so a bare `$(RUN)` would warn when the caller omits it.

**`-count=1` defeats the test cache.** The target exists for an edit-run-edit loop, where a `(cached)` ok would hide the very change under test.

**A `-list` pre-flight rejects a pattern that matches nothing.** This is the one worth reviewing. Plain `go test -run TestTypo` prints `[no tests to run]` and **exits 0**, so a mistyped test name reports success without running anything — the likeliest error for this target, and a silent false green. `go test -list` reports what would match without running it, which catches this without parsing test output or masking the real run's exit code.

I measured the cost before adding it: roughly 1s warm for a narrowed `PKG`, ~3s for `./...`, against a run that already takes several seconds. I considered detecting the case from the output stream instead and rejected it — preserving `go test`'s exit code through a pipe needs `pipefail`, which is not available in `dash`, the `/bin/sh` on the CI runners.

## Verification

| Case | Before | After |
|------|--------|-------|
| `RUN=TestThisDoesNotExist` | exit **0**, silent false green | exit 2, `no test matches RUN=... in PKG=...` |
| Real test that passes | — | exit 0 |
| Real test that fails | — | exit 2 (verified with a temporary failing test, since removed) |
| `RUN` omitted | — | exit 2 with usage hint |

Also checked: `make help` lists and aligns the new target, `make lint` and `make test` still pass, and the target emits no undefined-variable warnings.

## Checklist

- [x] Linked issue exists and is referenced above with a closing keyword
- [x] `make test` passes for auth changes
- [x] `make docs-build` passes for docs changes (no `docs/` changes)
- [x] Commits are signed off (DCO) and follow Conventional Commits
- [x] Docs updated where behaviour changed (AGENTS.md and CONTRIBUTING.md rows now point at `make test-one`)

Assisted-by: ClaudeCode:claude-opus-5